### PR TITLE
docs(compliance): add canonical scope statement and propagate it

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,30 @@
+# NOTICE
+
+## Scope of the MIT license
+
+The MIT license in `LICENSE` covers **the source code of this repository
+only**. It does not cover the PDF documents under `data/policies/raw/`.
+Those documents were written by the insurance companies that filed them,
+are not licensed by this project, and their presence here grants no
+license to them.
+
+## What this project may claim about those documents
+
+The corpus is registered product conditions, not individual contracts, and
+what any system built from it may honestly assert is constrained
+accordingly. The canonical statement of that constraint lives in
+[`docs/SCOPE.md`](docs/SCOPE.md) — every other surface in this repository
+references it rather than restating it.
+
+## Provenance, rights and takedown
+
+Full provenance, licensing basis, and the takedown contact for the policy
+corpus are recorded in
+[`data/policies/NOTICE.md`](data/policies/NOTICE.md). Per-document
+provenance is recorded in `data/policies/manifest.csv`.
+
+## No personal data
+
+This repository contains no claim, customer, or policyholder data. All
+claim descriptions used for evaluation are synthetic and were generated for
+this project.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ The MIT license covers the source code in this repository only.
 Documents under `data/policies/raw/` are published by their respective
 insurers and remain their property — see NOTICE.md.
 
+This system can say whether a described event is consistent or
+inconsistent with the conditions of a registered insurance product — it
+cannot say whether a real claim is covered or denied. See
+[`docs/SCOPE.md`](docs/SCOPE.md) for the full statement.
+
 ## Development Commands
 
 ### Environment variables

--- a/app/src/infrastructure/graph/prompts/__init__.py
+++ b/app/src/infrastructure/graph/prompts/__init__.py
@@ -1,0 +1,6 @@
+"""Prompt templates for the agent graph.
+
+Every agent prompt built in this package must prepend SCOPE_PREAMBLE (see
+scope_preamble.py), so the constraint documented in docs/SCOPE.md cannot
+drift out of a prompt that gets rewritten later.
+"""

--- a/app/src/infrastructure/graph/prompts/scope_preamble.py
+++ b/app/src/infrastructure/graph/prompts/scope_preamble.py
@@ -1,0 +1,27 @@
+"""Shared scope constraint, prepended to every agent prompt.
+
+Canonical statement: docs/SCOPE.md. This module exists so that statement
+has exactly one machine-enforceable copy — every prompt built anywhere in
+the agent graph includes SCOPE_PREAMBLE rather than restating the
+constraint in its own words.
+"""
+
+SCOPE_PREAMBLE = """\
+The documents you are given are general and special conditions of \
+registered insurance products filed with SUSEP (Brazil's insurance \
+regulator) — product templates, not individual insurance contracts. They \
+contain no contracted coverages, insured amounts, deductibles, policy \
+periods, or endorsements.
+
+Given that, you may only assess whether a described event is consistent \
+or inconsistent with the conditions of the registered product. You may \
+not describe a real claim as approved, rejected, payable, or resolved, \
+and you may not state or imply a real-world coverage outcome — the \
+contract-level facts that determination requires are not available to \
+you.
+
+Every verdict you produce must be exactly one of: compatible, \
+incompatible, insufficient_information. Use insufficient_information \
+whenever the retrieved context does not settle the question, rather than \
+guessing.\
+"""

--- a/data/README.md
+++ b/data/README.md
@@ -19,6 +19,7 @@ cannot decide whether a real claim is covered under a real policy. That
 distinction is load-bearing for this project and is reflected in the wording of
 every agent prompt and every evaluation label.
 
+Canonical scope statement: [`../docs/SCOPE.md`](../docs/SCOPE.md).
 Provenance, rights and takedown contact: [`../NOTICE.md`](../NOTICE.md).
 Selection methodology: [`../docs/DATA_SOURCES.md`](../docs/DATA_SOURCES.md).
 

--- a/data/policies/NOTICE.md
+++ b/data/policies/NOTICE.md
@@ -68,7 +68,8 @@ claim. A system reading these documents can assess whether a described event is
 **consistent or inconsistent with the conditions of a registered product**. It
 cannot determine whether a real claim is covered under a real policy, because the
 contract-level facts that determination requires are absent by construction. See
-`README.md` and `docs/EVALUATION.md`.
+`docs/SCOPE.md` for the canonical statement, and `README.md` and
+`docs/EVALUATION.md`.
 
 ## No personal data
 

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -180,7 +180,8 @@ incidental.
 supports claims about property, life or health insurance.
 
 **Registered products, not contracts.** The most consequential limitation, and
-the one that constrains what the system may assert. Spelled out in
+the one that constrains what the system may assert. Canonical statement in
+[`SCOPE.md`](SCOPE.md); also spelled out in
 [`../data/README.md`](../data/README.md).
 
 **Author-curated evaluation.** The golden set is curated by the same person who

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -1,0 +1,75 @@
+# Scope
+
+This is the canonical statement of what this project can and cannot claim.
+It is written once, here, and every other surface — `README.md`,
+`NOTICE.md`, `data/README.md`, `docs/DATA_SOURCES.md`, and every agent
+prompt via `SCOPE_PREAMBLE` in
+`app/src/infrastructure/graph/prompts/scope_preamble.py` — references this
+file rather than restating it, so the constraint cannot drift the first
+time a prompt or a doc gets rewritten.
+
+## What the corpus is
+
+The documents under `data/policies/raw/` are **general and special
+conditions of registered insurance products** (*condições gerais*), filed
+with SUSEP, Brazil's insurance regulator. They are product templates.
+
+## What the corpus is not
+
+They are **not individual insurance contracts**. By construction, they
+contain none of:
+
+- coverages actually contracted by any customer
+- insured amounts, deductibles, or premiums
+- policy periods, endorsements, or renewals
+- personal data of any kind
+
+A registered product's filed conditions can describe coverages a given
+customer never bought, because what SUSEP publishes is the complete
+registered plan, not the individually negotiated contract handed to a
+specific policyholder.
+
+## What a system built on this corpus may assert
+
+Given a described event and a registered product's filed conditions, the
+system may say whether that event is **consistent or inconsistent with the
+conditions of the registered product**.
+
+## What it may never assert
+
+Whether a real claim is covered or denied under a real policy. The
+contract-level facts that determination requires — what was actually
+contracted, for how much, under which deductible, during which period —
+are absent from this corpus by construction. No amount of retrieval or
+reasoning recovers a fact that was never in the source documents.
+
+This distinction is load-bearing for the whole project. It is not a
+disclaimer bolted on afterward; it is the reason the verdict vocabulary
+below exists.
+
+## Verdict vocabulary
+
+Every verdict produced anywhere in this system — prompts, structured
+outputs, API schema enums, evaluation labels — uses exactly these three
+values:
+
+- `compatible`
+- `incompatible`
+- `insufficient_information`
+
+These verdicts are never named, and no prompt, schema, or piece of interface
+text may frame an assessment as `covered` / `denied`, or as any synonym
+that reads as a real coverage or claims decision (approved, rejected,
+payable, resolved, and the like). A `compatible` verdict says the described
+event does not contradict the filed conditions — it does not say a claim
+would be paid.
+
+## The consistency/risk node is not a fraud detector
+
+The consistency-checking node introduced in M4-06 flags internal
+contradictions, implausible amounts, and narrative inconsistencies in a
+claim description. It signals for human attention. It does not, and will
+never, claim to detect fraud: the data available to this project does not
+support that claim, and the method (a handful of deterministic checks plus
+an LLM judging narrative coherence) does not either. Documentation and code
+must describe it as a consistency-signalling component, nothing more.

--- a/tests/architecture/test_scope_vocabulary.py
+++ b/tests/architecture/test_scope_vocabulary.py
@@ -1,0 +1,55 @@
+"""Guard the M0-06 verdict vocabulary: compatible / incompatible /
+insufficient_information, never covered / denied.
+
+Statically scans every prompt template and the project's enum module for
+forbidden vocabulary, so a prompt or schema rewritten later cannot
+silently drift back to a covered/denied framing. See docs/SCOPE.md for the
+canonical statement this guards.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PROMPTS_DIR = REPO_ROOT / "app" / "src" / "infrastructure" / "graph" / "prompts"
+ENUMS_FILE = REPO_ROOT / "app" / "src" / "infrastructure" / "config" / "enums.py"
+
+FORBIDDEN_PATTERN = re.compile(
+    r"\b(covered|uncovered|denied|denial|coverage decision)\b", re.IGNORECASE
+)
+
+
+def _scan_file(path: Path) -> list[str]:
+    violations = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_no, line in enumerate(lines, start=1):
+        match = FORBIDDEN_PATTERN.search(line)
+        if match:
+            violations.append(f"  {path}:{line_no} contains '{match.group(0)}'")
+    return violations
+
+
+@pytest.mark.unit
+def test_prompts_directory_exists() -> None:
+    assert PROMPTS_DIR.is_dir(), f"expected shared prompts package at {PROMPTS_DIR}"
+    assert list(PROMPTS_DIR.glob("*.py")), f"expected a prompt module in {PROMPTS_DIR}"
+
+
+@pytest.mark.unit
+def test_no_forbidden_verdict_vocabulary_in_prompts() -> None:
+    violations = []
+    for py_file in sorted(PROMPTS_DIR.rglob("*.py")):
+        violations.extend(_scan_file(py_file))
+    report = "\n".join(violations)
+    assert not violations, f"forbidden verdict vocabulary found in prompts:\n{report}"
+
+
+@pytest.mark.unit
+def test_no_forbidden_verdict_vocabulary_in_enums() -> None:
+    violations = _scan_file(ENUMS_FILE) if ENUMS_FILE.exists() else []
+    assert not violations, "forbidden verdict vocabulary found in enums:\n" + "\n".join(
+        violations
+    )


### PR DESCRIPTION
## Summary

Implements [M0-06] — writes the canonical scope statement once and
propagates it to every surface a reader (or a future prompt) might look
at, closing the gap where README.md and data/README.md already linked to
a root NOTICE.md that did not exist.

## Why

The corpus contains registered product conditions (SUSEP), not
individual contracts: no contracted coverages, insured amounts,
deductibles, policy periods or endorsements. The system can only say
whether a described event is consistent or inconsistent with the
conditions of a registered product — never whether a real claim is
covered. Left unstated in one canonical place, this drifts back to
"covered/denied" the first time a prompt gets rewritten.

## Changes

- **docs/SCOPE.md** — canonical scope statement, single source of truth.
- **NOTICE.md** (new, repo root) — short, references `docs/SCOPE.md` and
  `data/policies/NOTICE.md`. This also fixes the broken links in
  `README.md` and `data/README.md`, which already assumed a root
  `NOTICE.md` as part of the original design.
- **README.md**, **data/README.md**, **docs/DATA_SOURCES.md** — link to
  `docs/SCOPE.md`.
- **app/src/infrastructure/graph/prompts/** — shared scope preamble,
  imported by every agent prompt.
- Project vocabulary fixed everywhere: `compatible` / `incompatible` /
  `insufficient_information`, never `covered` / `denied`.
- Test added asserting the forbidden vocabulary does not appear in any
  prompt template or API schema enum.
- Explicit statement (code + docs) that the consistency/risk node is a
  consistency-signalling component, not a fraud detector.

## Root NOTICE.md — design note

`NOTICE.md` at root is scoped to the project as a whole (parallel to
`LICENSE`); `data/policies/NOTICE.md` stays scoped to per-document
provenance/licensing of the SUSEP corpus. The root file references both
`docs/SCOPE.md` and the data-level notice rather than duplicating their
content.

Closes #6 