### PR TITLE
feat(ci): add CI workflow, PR template and branching docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+<!-- e.g. [M1-03] -->
+
+## Checklist
+
+- [ ] Tests added/updated for the change (or explained why not needed)
+- [ ] Docs updated (`README.md`, `docs/`, or other affected doc)
+- [ ] Evaluation impact considered — does this change affect parsing,
+      retrieval, or evaluation numbers? If so, note it here
+- [ ] `make check` passes locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# paths-ignore below is an M0 placeholder: skip CI when a change only touches
+# Markdown docs. Once M1 adds heavy PDF-parsing jobs, revisit this filter so
+# it also skips those specific jobs (not the whole pipeline) on non-parsing
+# changes.
+on:
+  push:
+    branches: [main, staging]
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  quality:
+    name: Lint, format, type-check, unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Mypy
+        run: uv run mypy --strict app/src
+
+      - name: Unit tests
+        run: PYTHONPATH=app/src uv run pytest -m unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Branching model
+
+Work happens on topic branches named `<area>/<subject>`, for example
+`data/add-susep-corpus` or `feature/7-m0-07-ci-and-doc`. `<area>` is a short
+label for what the change touches (`feature`, `data`, `docs`, `fix`, ...);
+`<subject>` is a brief, hyphenated description, optionally prefixed with the
+issue number.
+
+- Topic branches are created from `staging` and merged back into `staging`
+  via pull request.
+- `staging` is periodically promoted to `main` via pull request, once the
+  changes on it are verified.
+- `main` reflects the current released/reviewable state of the project.
+
+## Commit messages
+
+Commits follow `type(scope): subject`, e.g. `feat(ci): add CI workflow` or
+`docs(compliance): add canonical scope statement`. Common types: `feat`,
+`fix`, `docs`, `refactor`, `test`, `chore`.
+
+## Before opening a pull request
+
+Run the full quality gate locally:
+
+```bash
+make check
+```
+
+This runs lint, format check, type check and the unit test suite — the same
+checks enforced by CI on every push and pull request (see
+`.github/workflows/ci.yml`). Optionally, install the pre-commit hooks so
+these checks run automatically before each commit (see `README.md` for
+setup instructions).
+
+Every pull request must use the template in
+`.github/pull_request_template.md`, which checks that tests, docs and
+evaluation impact were considered.
+
+## Branch protection
+
+Branch protection rules (requiring the CI check to pass and requiring PR
+review before merging into `staging` and `main`) are configured manually in
+the repository's GitHub settings (**Settings → Branches**). They are not
+enforced by any file in this repository.


### PR DESCRIPTION
## Summary

Adds the CI quality gate and formalizes the branching workflow already in use, closing out [M0-07]. This is infrastructure, not business logic: the goal is to make "it passes" an automatic, visible statement instead of something verified manually before a push.

## What's included

**CI workflow**
- GitHub Actions job running `ruff check`, `ruff format --check`, `mypy --strict` and `pytest -m unit` on every push to `main`/`staging` and on pull requests.
- `uv` dependency caching via `setup-uv`, so runs don't reinstall the toolchain from scratch each time.

**Branching & contribution docs**
- `CONTRIBUTING.md` documents the branching model already in practice: topic branches named `<area>/<subject>` (e.g. `data/add-susep-corpus`), merged into `staging`, then promoted to `main`.
- Commit message convention documented alongside it.

**Pull request template**
- Checklist covering tests, documentation, and evaluation impact — the last one specifically to catch changes that silently affect a previously published metric (retrieval scores, parsing accuracy, etc.).

## Design decision: Markdown-only path filter

A `paths-ignore` filter skips the pipeline on documentation-only changes. This is a deliberate placeholder, not the final rule: at this stage (M0) there's no source code and no PDF-parsing pipeline yet, so there's nothing "heavy" to filter around. The filter exists so the eventual heavy jobs introduced in M1 (parsing, OCR, corpus rebuilds) have a mechanism to skip on docs-only PRs — it will be revisited and tightened once those jobs actually exist, rather than guessed at now.

## Out of scope

- Branch protection rules are **not** enforced in this PR. They're a GitHub repository setting configured manually outside of code, and are noted as such in `CONTRIBUTING.md` rather than left undocumented.
- Integration tests and the heavier evaluation suite are intentionally excluded from this workflow — they belong to later milestones once the corresponding code exists.