### PR TITLE
feat(parsing): freeze the parsed-clause schema and add the reproducib…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration check extract-text
+.PHONY: install lint format format-check typecheck test test-integration check extract-text remove-boilerplate build-clause-tree parse
 
 help:
 	@echo "Available targets:"
@@ -13,6 +13,9 @@ help:
 	@echo "  test-integration  - Run integration tests"
 	@echo "  check             - Run all checks (lint, format-check, typecheck, test)"
 	@echo "  extract-text      - Extract and cache text from the policy corpus"
+	@echo "  remove-boilerplate - Remove boilerplate from the cached extraction"
+	@echo "  build-clause-tree - Recover the clause tree from the cleaned corpus"
+	@echo "  parse             - Rebuild the parsed-clause corpus under build/"
 
 install:
 	uv sync
@@ -39,3 +42,12 @@ check: lint format-check typecheck test
 
 extract-text:
 	PYTHONPATH=app/src uv run python scripts/extract_text.py
+
+remove-boilerplate:
+	PYTHONPATH=app/src uv run python scripts/remove_boilerplate.py
+
+build-clause-tree:
+	PYTHONPATH=app/src uv run python scripts/build_clause_tree.py
+
+parse: extract-text remove-boilerplate build-clause-tree
+	PYTHONPATH=app/src uv run python scripts/build_corpus.py

--- a/app/src/application/use_cases/clause_segmentation.py
+++ b/app/src/application/use_cases/clause_segmentation.py
@@ -46,6 +46,7 @@ detection rule here changes, so stale cached output is invalidated.
 
 import re
 import statistics
+import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 
@@ -58,7 +59,7 @@ from domain.clause_tree import (
 )
 from domain.extracted_text import ExtractedDocument, ExtractedPage, ExtractedSpan
 
-CLAUSE_SEGMENTATION_VERSION = "v1"
+CLAUSE_SEGMENTATION_VERSION = "v2"
 
 NUMBERED_BOLD_THRESHOLD = 0.5
 PART_BOLD_THRESHOLD = 0.9
@@ -384,6 +385,21 @@ def _detect_heading(
     )
 
 
+def _slugify(text: str) -> str:
+    """Turn a heading title into a stable, human-readable path segment.
+
+    Used only for [HeadingConvention.UNNUMBERED_PART], which carries no
+    ``numbering_label``. Anchoring the segment to the title's own text
+    (not to scan position) keeps the segment -- and therefore the
+    [Clause.clause_id] built from it -- stable when an unrelated part is
+    inserted or removed elsewhere in the document.
+    """
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_text.lower()).strip("-")
+    return slug or "part"
+
+
 class _ClauseBuilder:
     """Mutable accumulator for one clause while the document is being walked."""
 
@@ -392,6 +408,7 @@ class _ClauseBuilder:
         *,
         document_id: str,
         clause_id: str,
+        path: str,
         numbering_label: str,
         title: str,
         convention: HeadingConvention,
@@ -401,6 +418,7 @@ class _ClauseBuilder:
     ) -> None:
         self.document_id = document_id
         self.clause_id = clause_id
+        self.path = path
         self.numbering_label = numbering_label
         self.title = title
         self.convention = convention
@@ -423,6 +441,7 @@ class _ClauseBuilder:
         return Clause(
             document_id=self.document_id,
             clause_id=self.clause_id,
+            path=self.path,
             numbering_label=self.numbering_label,
             title=self.title,
             convention=self.convention,
@@ -485,12 +504,18 @@ def segment_document(document: ExtractedDocument) -> ClauseTree:
     stack: list[_ClauseBuilder] = []
     orphan_char_count = 0
     total_char_count = 0
-    clause_counter = 0
+    # Segment collisions are counted per parent bucket (keyed by parent_id,
+    # None for document roots), so a duplicate segment under one parent
+    # never affects sibling counts under a different parent -- the id
+    # scheme's whole point is that an edit in one branch of the tree must
+    # not shift the clause_id of a node in an unrelated branch.
+    sibling_segment_counts: dict[str | None, dict[str, int]] = {}
 
-    def next_id() -> str:
-        nonlocal clause_counter
-        clause_counter += 1
-        return f"{document.document_id}:{clause_counter}"
+    def next_segment(parent_id: str | None, base: str) -> str:
+        counts = sibling_segment_counts.setdefault(parent_id, {})
+        counts[base] = counts.get(base, 0) + 1
+        occurrence = counts[base]
+        return base if occurrence == 1 else f"{base}-{occurrence}"
 
     def open_clause(match: _HeadingMatch, page_number: int, depth: int) -> None:
         if match.convention == HeadingConvention.UNNUMBERED_PART:
@@ -498,11 +523,21 @@ def segment_document(document: ExtractedDocument) -> ClauseTree:
         else:
             while stack and stack[-1].depth >= depth:
                 stack.pop()
-        parent_id = stack[-1].clause_id if stack else None
-        clause_id = next_id()
+        parent = stack[-1] if stack else None
+        parent_id = parent.clause_id if parent else None
+        parent_path = parent.path if parent else None
+
+        # numbering_label is empty only for UNNUMBERED_PART, whose segment
+        # is anchored to the title's own text instead -- see [_slugify].
+        base_segment = match.numbering_label or _slugify(match.title)
+        segment = next_segment(parent_id, base_segment)
+        path = f"{parent_path}/{segment}" if parent_path else segment
+        clause_id = f"{document.document_id}:{path}"
+
         builder = _ClauseBuilder(
             document_id=document.document_id,
             clause_id=clause_id,
+            path=path,
             numbering_label=match.numbering_label,
             title=match.title,
             convention=match.convention,

--- a/app/src/domain/clause_tree.py
+++ b/app/src/domain/clause_tree.py
@@ -32,6 +32,7 @@ class Clause:
 
     document_id: str
     clause_id: str
+    path: str
     numbering_label: str
     title: str
     convention: HeadingConvention

--- a/app/src/infrastructure/parsing/clause_schema.py
+++ b/app/src/infrastructure/parsing/clause_schema.py
@@ -1,0 +1,86 @@
+"""Frozen serialization contract between parsing and everything downstream.
+
+Not the domain model -- [domain.clause_tree.Clause] and
+[domain.clause_classification.TypedClause] stay stdlib-only frozen
+dataclasses per that layer's constraint (pydantic/pyarrow are forbidden
+imports in domain/application, see tests/architecture/test_layer_boundaries
+.py). [ParsedClauseRecord] is the flat, validated row [M1-07]'s
+``scripts/build_corpus.py`` persists to ``build/`` -- the wire schema a
+re-parse must keep honest, so it fails loudly on any clause missing
+required provenance rather than writing it silently.
+
+``SCHEMA_VERSION`` feeds ``build/manifest.json`` (see
+[infrastructure.parsing.corpus_artifact]), so a consumer reading the
+artefact in isolation still knows which contract produced it.
+"""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from domain.clause_classification import ClauseType, TypedClause, TypeSource
+
+SCHEMA_VERSION = "v1"
+
+_NonEmptyStr = Annotated[str, Field(min_length=1)]
+
+
+class ParsedClauseRecord(BaseModel):
+    """One flattened, validated clause row in the parsed corpus."""
+
+    schema_version: str
+    clause_id: _NonEmptyStr
+    document_id: _NonEmptyStr
+    parent_id: str | None
+    path: _NonEmptyStr
+    title: _NonEmptyStr
+    text: str
+    clause_type: ClauseType
+    type_source: TypeSource
+    confidence: float | None
+    bundle_section: str | None
+    page_start: Annotated[int, Field(ge=1)]
+    page_end: Annotated[int, Field(ge=1)]
+    source: Literal["text", "ocr"]
+    susep_process: _NonEmptyStr
+    insurer: _NonEmptyStr
+    cnpj: _NonEmptyStr
+    product_line: _NonEmptyStr
+    indemnity_regime: _NonEmptyStr
+    filing_year: _NonEmptyStr
+
+
+def flatten_typed_clause(
+    typed: TypedClause, *, source: Literal["text", "ocr"]
+) -> ParsedClauseRecord:
+    """Flatten a [TypedClause] plus its manifest provenance into one record.
+
+    ``source`` is supplied by the caller (derived from the manifest's
+    ``extraction_mode`` -- see ``scripts/build_corpus.py``) because no
+    per-clause extraction mode exists on [Clause]/[ExtractedDocument]: a
+    document is routed through exactly one extraction path end to end.
+    """
+    clause = typed.clause
+    provenance = typed.provenance
+    return ParsedClauseRecord(
+        schema_version=SCHEMA_VERSION,
+        clause_id=clause.clause_id,
+        document_id=clause.document_id,
+        parent_id=clause.parent_id,
+        path=clause.path,
+        title=clause.title,
+        text="\n".join(clause.content_lines),
+        clause_type=typed.clause_type,
+        type_source=typed.type_source,
+        confidence=typed.confidence,
+        bundle_section=clause.bundle_section,
+        page_start=clause.page_start,
+        page_end=clause.page_end,
+        source=source,
+        susep_process=provenance.susep_process,
+        insurer=provenance.insurer,
+        cnpj=provenance.cnpj,
+        product_line=provenance.product_line,
+        indemnity_regime=provenance.indemnity_regime,
+        filing_year=provenance.process_year,
+    )

--- a/app/src/infrastructure/parsing/clause_tree_caching.py
+++ b/app/src/infrastructure/parsing/clause_tree_caching.py
@@ -30,6 +30,7 @@ CLAUSE_TREE_CACHE_DIR = Path("data/cache/clause_trees")
 _ROW_SCHEMA = pa.schema(
     [
         ("clause_id", pa.string()),
+        ("path", pa.string()),
         ("numbering_label", pa.string()),
         ("title", pa.string()),
         ("convention", pa.string()),
@@ -39,6 +40,8 @@ _ROW_SCHEMA = pa.schema(
         ("content_lines", pa.string()),
         ("page_start", pa.int64()),
         ("page_end", pa.int64()),
+        ("bundle_section", pa.string()),
+        ("bundle_confidence", pa.string()),
         ("is_depth_anomaly", pa.bool_()),
     ]
 )
@@ -60,6 +63,7 @@ def write_clause_tree_cache(tree: ClauseTree, path: Path) -> None:
     rows = [
         {
             "clause_id": clause.clause_id,
+            "path": clause.path,
             "numbering_label": clause.numbering_label,
             "title": clause.title,
             "convention": clause.convention.value,
@@ -69,6 +73,8 @@ def write_clause_tree_cache(tree: ClauseTree, path: Path) -> None:
             "content_lines": "\n".join(clause.content_lines),
             "page_start": clause.page_start,
             "page_end": clause.page_end,
+            "bundle_section": clause.bundle_section or "",
+            "bundle_confidence": clause.bundle_confidence or "",
             "is_depth_anomaly": clause.is_depth_anomaly,
         }
         for clause in tree.all_clauses
@@ -122,6 +128,7 @@ def read_clause_tree_cache(path: Path) -> ClauseTree:
         Clause(
             document_id=document_id,
             clause_id=row["clause_id"],
+            path=row["path"],
             numbering_label=row["numbering_label"],
             title=row["title"],
             convention=HeadingConvention(row["convention"]),
@@ -133,6 +140,8 @@ def read_clause_tree_cache(path: Path) -> ClauseTree:
             ),
             page_start=row["page_start"],
             page_end=row["page_end"],
+            bundle_section=row["bundle_section"] or None,
+            bundle_confidence=row["bundle_confidence"] or None,
             is_depth_anomaly=row["is_depth_anomaly"],
         )
         for row in table.to_pylist()

--- a/app/src/infrastructure/parsing/corpus_artifact.py
+++ b/app/src/infrastructure/parsing/corpus_artifact.py
@@ -1,0 +1,86 @@
+"""The final, versioned corpus artifact -- ``build/`` (gitignored).
+
+Unlike the per-document caches in ``data/cache/`` (one Parquet file per
+document, keyed by a stage-version hash -- see [infrastructure.parsing.
+clause_tree_caching] and friends), this is the single combined output of
+the whole pipeline: everything downstream of parsing (retrieval indexing,
+evaluation, a future golden-set validation step) reads from here, never
+from the per-stage caches directly. Rebuilt end to end by ``make parse`` ->
+``scripts/build_corpus.py``, never hand-edited.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pydantic import BaseModel
+
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+
+BUILD_DIR = Path("build")
+PARQUET_PATH = BUILD_DIR / "parsed_clauses.parquet"
+JSONL_PATH = BUILD_DIR / "parsed_clauses.jsonl"
+BUILD_MANIFEST_PATH = BUILD_DIR / "manifest.json"
+
+
+class BuildManifest(BaseModel):
+    """Reproducibility record for one ``make parse`` run.
+
+    ``llm_classification_enabled`` is always ``False`` today -- see
+    [infrastructure.parsing.null_classifier] for why ``scripts/
+    build_corpus.py`` runs a deterministic stub instead of a real LLM.
+    """
+
+    schema_version: str
+    clause_segmentation_version: str
+    boilerplate_removal_version: str
+    llm_classification_enabled: bool
+    built_at_utc: datetime
+    clause_counts_by_document: dict[str, int]
+    total_clause_count: int
+
+
+def utc_now() -> datetime:
+    """Return the current time in UTC, for [BuildManifest.built_at_utc]."""
+    return datetime.now(UTC)
+
+
+def write_parsed_clauses_parquet(records: list[ParsedClauseRecord], path: Path) -> None:
+    """Write the flattened corpus to Parquet, one row per clause."""
+    rows = [record.model_dump(mode="json") for record in records]
+    table = pa.Table.from_pylist(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, path)
+
+
+def read_parsed_clauses_parquet(path: Path) -> list[ParsedClauseRecord]:
+    """Read the flattened corpus back from Parquet."""
+    rows = pq.read_table(path).to_pylist()
+    return [ParsedClauseRecord.model_validate(row) for row in rows]
+
+
+def write_parsed_clauses_jsonl(records: list[ParsedClauseRecord], path: Path) -> None:
+    """Write the flattened corpus to JSONL, one row per line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(record.model_dump_json())
+            handle.write("\n")
+
+
+def read_parsed_clauses_jsonl(path: Path) -> list[ParsedClauseRecord]:
+    """Read the flattened corpus back from JSONL."""
+    with path.open("r", encoding="utf-8") as handle:
+        return [
+            ParsedClauseRecord.model_validate(json.loads(line))
+            for line in handle
+            if line.strip()
+        ]
+
+
+def write_build_manifest(manifest: BuildManifest, path: Path) -> None:
+    """Write the build manifest as pretty-printed JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")

--- a/app/src/infrastructure/parsing/null_classifier.py
+++ b/app/src/infrastructure/parsing/null_classifier.py
@@ -1,0 +1,27 @@
+"""Deterministic stand-in for the LLM classification pass.
+
+``scripts/build_corpus.py`` runs with this classifier by default: no
+[langchain_core.language_models.chat_models.BaseChatModel] factory exists
+in this repo yet (see [infrastructure.parsing.llm_classifier
+.LangchainClauseClassifier], which requires one already built), and
+calling a real LLM would make ``make parse`` depend on an API key and
+network access, and its output non-deterministic run to run -- directly at
+odds with [M1-07]'s "reproducible build" goal. Every clause the rule pass
+in [application.use_cases.clause_classification.classify_and_enrich_clauses]
+leaves unmatched falls through to this classifier, which always raises;
+that function's existing ``except Exception`` fallback then assigns
+``ClauseType.OTHER``/``TypeSource.LLM``/``confidence=0.0`` deterministically.
+Wiring a real LLM here is left to a future issue.
+"""
+
+from domain.clause_classification import ClauseType
+
+
+class NullClauseClassifier:
+    """A [application.ports.clause_classifier.ClauseClassifierPort] stub."""
+
+    def classify(self, clause_title: str, clause_text: str) -> tuple[ClauseType, float]:
+        """Always raise; the caller's OTHER/0.0 fallback then applies."""
+        raise NotImplementedError(
+            "No LLM classifier is wired up yet -- see this module's docstring."
+        )

--- a/notebooks/scratch/parsed_clause_schema.ipynb
+++ b/notebooks/scratch/parsed_clause_schema.ipynb
@@ -1,0 +1,409 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "Setting the python path to import code from app/src.\n",
+    "\n",
+    "The extrapath is configured at .vscode/settings.json to avoid IDE errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def find_project_root(marker=\"pyproject.toml\") -> Path:\n",
+    "    p = Path.cwd().resolve()\n",
+    "    for parent in [p, *p.parents]:\n",
+    "        if (parent / marker).exists():\n",
+    "            return parent\n",
+    "    raise FileNotFoundError(f\"{marker} not found starting from {p}\")\n",
+    "\n",
+    "\n",
+    "root_dir = find_project_root()\n",
+    "sys.path.append(str(root_dir / \"app\" / \"src\"))\n",
+    "root_dir\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from application.use_cases.boilerplate_removal import BOILERPLATE_REMOVAL_VERSION\n",
+    "from application.use_cases.clause_classification import classify_and_enrich_clauses\n",
+    "from application.use_cases.clause_segmentation import (\n",
+    "    CLAUSE_SEGMENTATION_VERSION,\n",
+    "    segment_document,\n",
+    ")\n",
+    "from domain.clause_tree import Clause, ClauseTree\n",
+    "from infrastructure.parsing.boilerplate_caching import (\n",
+    "    boilerplate_cache_path,\n",
+    "    compute_boilerplate_cache_key,\n",
+    ")\n",
+    "from infrastructure.parsing.caching import read_cache\n",
+    "from infrastructure.parsing.clause_schema import (\n",
+    "    SCHEMA_VERSION,\n",
+    "    ParsedClauseRecord,\n",
+    "    flatten_typed_clause,\n",
+    ")\n",
+    "from infrastructure.parsing.clause_tree_caching import (\n",
+    "    clause_tree_cache_path,\n",
+    "    compute_clause_tree_cache_key,\n",
+    "    read_clause_tree_cache,\n",
+    ")\n",
+    "from infrastructure.parsing.corpus_artifact import (\n",
+    "    BuildManifest,\n",
+    "    read_parsed_clauses_jsonl,\n",
+    "    read_parsed_clauses_parquet,\n",
+    "    utc_now,\n",
+    "    write_build_manifest,\n",
+    "    write_parsed_clauses_jsonl,\n",
+    "    write_parsed_clauses_parquet,\n",
+    ")\n",
+    "from infrastructure.parsing.manifest import read_manifest\n",
+    "from infrastructure.parsing.null_classifier import NullClauseClassifier\n",
+    "from infrastructure.parsing.rules_loader import load_classification_rules\n",
+    "\n",
+    "MANIFEST_PATH = root_dir / \"data\" / \"policies\" / \"manifest.csv\"\n",
+    "RULES_PATH = root_dir / \"data\" / \"parsing\" / \"clause_type_mapping.csv\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "path and clause_id deterministic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from domain.extracted_text import ExtractedDocument, ExtractedPage, ExtractedSpan\n",
+    "\n",
+    "\n",
+    "def _span(page_number, line_id, text, *, bold):\n",
+    "    return ExtractedSpan(\n",
+    "        document_id=\"scratch\",\n",
+    "        page_number=page_number,\n",
+    "        line_id=line_id,\n",
+    "        order=line_id,\n",
+    "        bbox=(50.0, 100.0 + line_id * 15.0, 50.0 + len(text) * 6.0, 110.0 + line_id * 15.0),\n",
+    "        font_size=11.0,\n",
+    "        font_name=\"Test-BoldMT\" if bold else \"TestMT\",\n",
+    "        text=text,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def _document(lines: list[tuple[str, bool]]) -> ExtractedDocument:\n",
+    "    spans = [_span(1, i, text, bold=bold) for i, (text, bold) in enumerate(lines)]\n",
+    "    page = ExtractedPage(page_number=1, spans=tuple(spans), char_count=sum(len(t) for t, _ in lines))\n",
+    "    return ExtractedDocument(document_id=\"scratch\", filename=\"scratch.pdf\", pages=(page,), extractor_version=\"v1\")\n",
+    "\n",
+    "\n",
+    "baseline_doc = _document([\n",
+    "    (\"1. OBJETO DO SEGURO\", True),\n",
+    "    (\"Corpo do objeto.\", False),\n",
+    "    (\"2. COBERTURAS\", True),\n",
+    "    (\"2.1 Cobertura Basica\", True),\n",
+    "    (\"Texto da cobertura basica.\", False),\n",
+    "])\n",
+    "\n",
+    "with_insertion_doc = _document([\n",
+    "    (\"1. OBJETO DO SEGURO\", True),\n",
+    "    (\"Corpo do objeto.\", False),\n",
+    "    (\"1.1 Definicoes Extras\", True),\n",
+    "    (\"Texto das definicoes extras.\", False),\n",
+    "    (\"2. COBERTURAS\", True),\n",
+    "    (\"2.1 Cobertura Basica\", True),\n",
+    "    (\"Texto da cobertura basica.\", False),\n",
+    "])\n",
+    "\n",
+    "tree_a = segment_document(baseline_doc)\n",
+    "tree_b = segment_document(with_insertion_doc)\n",
+    "\n",
+    "for clause in tree_a.all_clauses:\n",
+    "    print(clause.numbering_label, \"-\", clause.path, \"-\", clause.clause_id)\n",
+    "\n",
+    "print()\n",
+    "print(\"clause_count A/B:\", tree_a.report.clause_count, tree_b.report.clause_count)\n",
+    "\n",
+    "\n",
+    "def find(tree: ClauseTree, numbering_label: str) -> Clause:\n",
+    "    return next(c for c in tree.all_clauses if c.numbering_label == numbering_label)\n",
+    "\n",
+    "\n",
+    "assert find(tree_a, \"2\").clause_id == find(tree_b, \"2\").clause_id\n",
+    "assert find(tree_a, \"2.1\").clause_id == find(tree_b, \"2.1\").clause_id\n",
+    "print(\"clause_id de '2' e '2.1' inalterado apesar da cláusula extra inserida em '1'.\")\n",
+    "\n",
+    "tree_a_rerun = segment_document(baseline_doc)\n",
+    "assert [c.clause_id for c in tree_a.all_clauses] == [c.clause_id for c in tree_a_rerun.all_clauses]\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "Using a real doc from corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest_records = read_manifest(MANIFEST_PATH)\n",
+    "document_id = \"10\"\n",
+    "entry = next(r for r in manifest_records if r[\"id\"] == document_id)\n",
+    "print(entry[\"filename\"], entry[\"product_line\"], entry[\"insurer\"])\n",
+    "\n",
+    "boilerplate_key = compute_boilerplate_cache_key(BOILERPLATE_REMOVAL_VERSION)\n",
+    "boilerplate_path = boilerplate_cache_path(document_id, boilerplate_key)\n",
+    "document = read_cache(\"../../\" + str(boilerplate_path))\n",
+    "\n",
+    "tree = segment_document(document)\n",
+    "print(\"clauses:\", tree.report.clause_count, \"max_depth:\", tree.report.max_depth)\n",
+    "print(\"orphan_ratio:\", round(tree.report.orphan_ratio, 4))\n",
+    "\n",
+    "for clause in tree.all_clauses[:15]:\n",
+    "    print(f\"{clause.path:20s} depth={clause.depth} bundle={clause.bundle_section!r} title={clause.title[:60]!r}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Reading from cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clause_tree_key = compute_clause_tree_cache_key(CLAUSE_SEGMENTATION_VERSION)\n",
+    "clause_tree_path = clause_tree_cache_path(document_id, clause_tree_key)\n",
+    "cached_tree = read_clause_tree_cache(\"../../\" + str(clause_tree_path))\n",
+    "\n",
+    "with_bundle = [c for c in cached_tree.all_clauses if c.bundle_section]\n",
+    "print(f\"{len(with_bundle)}/{len(cached_tree.all_clauses)} cláusulas com bundle_section definido\")\n",
+    "with_bundle[0].bundle_section, with_bundle[0].bundle_confidence\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "Classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rules = load_classification_rules(RULES_PATH)\n",
+    "classifier = NullClauseClassifier()\n",
+    "\n",
+    "typed_clauses = classify_and_enrich_clauses(cached_tree, manifest_records, rules, classifier)\n",
+    "\n",
+    "source = \"ocr\" if entry[\"extraction_mode\"] == \"ocr_required\" else \"text\"\n",
+    "records = [flatten_typed_clause(typed, source=source) for typed in typed_clauses]\n",
+    "\n",
+    "print(f\"{len(records)} generated, schema_version={records[0].schema_version}\")\n",
+    "records[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import collections\n",
+    "\n",
+    "print(\"clause_type:\", collections.Counter(r.clause_type for r in records))\n",
+    "print(\"type_source:\", collections.Counter(r.type_source for r in records))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "Let's see the provenance validation failing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import replace\n",
+    "\n",
+    "from pydantic import ValidationError\n",
+    "\n",
+    "typed_sample = typed_clauses[0]\n",
+    "broken_provenance = replace(typed_sample.provenance, insurer=\"\")\n",
+    "broken_typed = replace(typed_sample, provenance=broken_provenance)\n",
+    "\n",
+    "try:\n",
+    "    flatten_typed_clause(broken_typed, source=source)\n",
+    "except ValidationError as exc:\n",
+    "    print(\"Failed:\")\n",
+    "    print(exc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "round-trip parquet/JSONL and build manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scratch_dir = root_dir / \"notebooks\" / \"scratch\" / \"_m1_07_scratch_output\"\n",
+    "scratch_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "parquet_path = scratch_dir / \"parsed_clauses.parquet\"\n",
+    "jsonl_path = scratch_dir / \"parsed_clauses.jsonl\"\n",
+    "\n",
+    "write_parsed_clauses_parquet(records, parquet_path)\n",
+    "write_parsed_clauses_jsonl(records, jsonl_path)\n",
+    "\n",
+    "restored_parquet = read_parsed_clauses_parquet(parquet_path)\n",
+    "restored_jsonl = read_parsed_clauses_jsonl(jsonl_path)\n",
+    "\n",
+    "assert restored_parquet == records\n",
+    "assert restored_jsonl == records\n",
+    "print(\"Round-trip OK:\", len(records), \"registers\")\n",
+    "\n",
+    "manifest = BuildManifest(\n",
+    "    schema_version=SCHEMA_VERSION,\n",
+    "    clause_segmentation_version=CLAUSE_SEGMENTATION_VERSION,\n",
+    "    boilerplate_removal_version=BOILERPLATE_REMOVAL_VERSION,\n",
+    "    llm_classification_enabled=False,\n",
+    "    built_at_utc=utc_now(),\n",
+    "    clause_counts_by_document={document_id: len(records)},\n",
+    "    total_clause_count=len(records),\n",
+    ")\n",
+    "write_build_manifest(manifest, scratch_dir / \"manifest.json\")\n",
+    "manifest\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "Now I'm going to check the real artifact built by make parse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "real_parquet = root_dir / \"build\" / \"parsed_clauses.parquet\"\n",
+    "\n",
+    "if real_parquet.exists():\n",
+    "    all_records = read_parsed_clauses_parquet(real_parquet)\n",
+    "    print(f\"{len(all_records)} clauses in {len(set(r.document_id for r in all_records))} docs\")\n",
+    "    print(collections.Counter(r.source for r in all_records))\n",
+    "    print(collections.Counter(r.clause_type for r in all_records))\n",
+    "else:\n",
+    "    print(\"build/parsed_clauses.parquet does not exist yet. Run `make parse`.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "Let's clean up things"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "\n",
+    "shutil.rmtree(scratch_dir, ignore_errors=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Insurance Claims (uv)",
+   "language": "python",
+   "name": "insurance-claims-multiagent-rag"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/build_corpus.py
+++ b/scripts/build_corpus.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Build the final, versioned parsed-clause corpus -- ``build/`` (gitignored).
+
+The last stage of the parsing pipeline [M1-07]: reads every document's
+clause tree from ``data/cache/clause_trees/`` (this script never
+re-segments -- a missing cache means ``scripts/build_clause_tree.py`` has
+not been run yet, and silently re-deriving it here would hide that instead
+of failing loudly), classifies each clause ([M1-05]'s deterministic rules,
+with a stub LLM fallback -- see [infrastructure.parsing.null_classifier]
+for why), flattens the result against [infrastructure.parsing.
+clause_schema.ParsedClauseRecord], and writes the combined corpus plus a
+build manifest recording exactly what produced it.
+
+Run via ``make parse``, which chains this after ``extract-text``,
+``remove-boilerplate`` and ``build-clause-tree`` -- the whole pipeline,
+from ``data/policies/raw/`` to ``build/``, in one command.
+"""
+
+from pathlib import Path
+from typing import Literal
+
+from application.use_cases.boilerplate_removal import BOILERPLATE_REMOVAL_VERSION
+from application.use_cases.clause_classification import classify_and_enrich_clauses
+from application.use_cases.clause_segmentation import CLAUSE_SEGMENTATION_VERSION
+from domain.clause_tree import ClauseTree
+from infrastructure.parsing.clause_schema import (
+    SCHEMA_VERSION,
+    ParsedClauseRecord,
+    flatten_typed_clause,
+)
+from infrastructure.parsing.clause_tree_caching import (
+    clause_tree_cache_path,
+    compute_clause_tree_cache_key,
+    read_clause_tree_cache,
+)
+from infrastructure.parsing.corpus_artifact import (
+    BUILD_MANIFEST_PATH,
+    JSONL_PATH,
+    PARQUET_PATH,
+    BuildManifest,
+    utc_now,
+    write_build_manifest,
+    write_parsed_clauses_jsonl,
+    write_parsed_clauses_parquet,
+)
+from infrastructure.parsing.manifest import read_manifest
+from infrastructure.parsing.null_classifier import NullClauseClassifier
+from infrastructure.parsing.rules_loader import load_classification_rules
+
+MANIFEST_PATH = Path("data/policies/manifest.csv")
+RULES_PATH = Path("data/parsing/clause_type_mapping.csv")
+
+
+def load_clause_tree(document_id: str, filename: str) -> ClauseTree:
+    """Load a document's clause tree from its upstream [M1-04] cache.
+
+    Raises ``FileNotFoundError`` if that cache is missing -- run
+    ``scripts/build_clause_tree.py`` first.
+    """
+    cache_key = compute_clause_tree_cache_key(CLAUSE_SEGMENTATION_VERSION)
+    path = clause_tree_cache_path(document_id, cache_key)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No clause-tree cache for {filename} (document {document_id}) "
+            f"at {path}. Run `scripts/build_clause_tree.py` first."
+        )
+    return read_clause_tree_cache(path)
+
+
+def resolve_source(extraction_mode: str) -> Literal["text", "ocr"]:
+    """Map the manifest's ``extraction_mode`` to the flat schema's ``source``.
+
+    A whole document is routed through exactly one extraction path (see
+    ``scripts/extract_text.py``), so this is decided once per document,
+    never per clause.
+    """
+    return "ocr" if extraction_mode == "ocr_required" else "text"
+
+
+def run_build_corpus() -> tuple[list[ParsedClauseRecord], dict[str, int]]:
+    """Classify and flatten every document's clause tree. Returns (records, counts)."""
+    manifest_records = read_manifest(MANIFEST_PATH)
+    rules = load_classification_rules(RULES_PATH)
+    classifier = NullClauseClassifier()
+
+    records: list[ParsedClauseRecord] = []
+    counts: dict[str, int] = {}
+    for entry in manifest_records:
+        document_id = entry["id"]
+        filename = entry["filename"]
+        tree = load_clause_tree(document_id, filename)
+        typed_clauses = classify_and_enrich_clauses(
+            tree, manifest_records, rules, classifier
+        )
+        source = resolve_source(entry["extraction_mode"])
+        document_records = [
+            flatten_typed_clause(typed, source=source) for typed in typed_clauses
+        ]
+        records.extend(document_records)
+        counts[document_id] = len(document_records)
+        print(f"{filename}: clauses={len(document_records)}")
+
+    return records, counts
+
+
+def main() -> None:
+    """Build the corpus and write it, plus a build manifest, under ``build/``."""
+    records, counts = run_build_corpus()
+
+    write_parsed_clauses_parquet(records, PARQUET_PATH)
+    write_parsed_clauses_jsonl(records, JSONL_PATH)
+    manifest = BuildManifest(
+        schema_version=SCHEMA_VERSION,
+        clause_segmentation_version=CLAUSE_SEGMENTATION_VERSION,
+        boilerplate_removal_version=BOILERPLATE_REMOVAL_VERSION,
+        llm_classification_enabled=False,
+        built_at_utc=utc_now(),
+        clause_counts_by_document=counts,
+        total_clause_count=len(records),
+    )
+    write_build_manifest(manifest, BUILD_MANIFEST_PATH)
+    print(
+        f"Wrote {len(records)} clauses across {len(counts)} documents to "
+        f"{PARQUET_PATH}, {JSONL_PATH}, {BUILD_MANIFEST_PATH}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/application/use_cases/test_clause_classification.py
+++ b/tests/unit/application/use_cases/test_clause_classification.py
@@ -47,6 +47,7 @@ def build_dummy_tree(title: str, text: str = "body") -> ClauseTree:
     clause = Clause(
         document_id="1",
         clause_id="c1",
+        path="1",
         numbering_label="1.",
         title=title,
         # Assuming enum is not strictly checked here if mock

--- a/tests/unit/application/use_cases/test_clause_segmentation.py
+++ b/tests/unit/application/use_cases/test_clause_segmentation.py
@@ -795,3 +795,71 @@ def test_ocr_page_detects_headings_by_pattern_only() -> None:
     assert tree.report.extraction_mode == "ocr_required"
     assert any(w.kind == "ocr_relaxed_mode" for w in tree.report.warnings)
     assert tree.report.clause_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# clause_id/path determinism [M1-07]: same input produces the same id, and a
+# structural edit confined to one branch never shifts the id of a clause in
+# an unrelated branch -- see [application.use_cases.clause_segmentation.
+# _slugify] and the sibling-segment-counting scheme in [segment_document].
+# ---------------------------------------------------------------------------
+
+
+def _coverages_document() -> ExtractedDocument:
+    return _document(
+        [
+            _page(
+                1,
+                [
+                    _heading_line(1, 1, "1. OBJETO DO SEGURO"),
+                    _body_line(1, 2, "Corpo do objeto."),
+                    _heading_line(1, 3, "2. COBERTURAS"),
+                    _heading_line(1, 4, "2.1 Cobertura Basica"),
+                    _body_line(1, 5, "Texto da cobertura basica."),
+                ],
+            )
+        ]
+    )
+
+
+@pytest.mark.unit
+def test_clause_id_deterministic_across_two_runs() -> None:
+    document = _coverages_document()
+
+    first = segment_document(document)
+    second = segment_document(document)
+
+    assert [c.clause_id for c in first.all_clauses] == [
+        c.clause_id for c in second.all_clauses
+    ]
+    assert [c.path for c in first.all_clauses] == [c.path for c in second.all_clauses]
+
+
+@pytest.mark.unit
+def test_clause_id_stable_when_unrelated_clause_inserted() -> None:
+    """Inserting a clause under "1" must not shift the id of "2"/"2.1"."""
+    baseline = segment_document(_coverages_document())
+
+    with_insertion = segment_document(
+        _document(
+            [
+                _page(
+                    1,
+                    [
+                        _heading_line(1, 1, "1. OBJETO DO SEGURO"),
+                        _body_line(1, 2, "Corpo do objeto."),
+                        _heading_line(1, 3, "1.1 Definicoes Extras"),
+                        _body_line(1, 4, "Texto das definicoes extras."),
+                        _heading_line(1, 5, "2. COBERTURAS"),
+                        _heading_line(1, 6, "2.1 Cobertura Basica"),
+                        _body_line(1, 7, "Texto da cobertura basica."),
+                    ],
+                )
+            ]
+        )
+    )
+
+    assert with_insertion.report.clause_count == baseline.report.clause_count + 1
+    assert _find(with_insertion, "2").clause_id == _find(baseline, "2").clause_id
+    assert _find(with_insertion, "2.1").clause_id == _find(baseline, "2.1").clause_id
+    assert _find(with_insertion, "2").path == _find(baseline, "2").path

--- a/tests/unit/infrastructure/parsing/test_clause_schema.py
+++ b/tests/unit/infrastructure/parsing/test_clause_schema.py
@@ -1,0 +1,104 @@
+"""Tests for the flattened clause schema and required-provenance validation."""
+
+from dataclasses import replace
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from domain.clause_classification import (
+    ClauseProvenance,
+    ClauseType,
+    TypedClause,
+    TypeSource,
+)
+from domain.clause_tree import Clause, HeadingConvention
+from infrastructure.parsing.clause_schema import SCHEMA_VERSION, flatten_typed_clause
+
+
+def _clause() -> Clause:
+    return Clause(
+        document_id="1",
+        clause_id="1:2",
+        path="2",
+        numbering_label="2",
+        title="2. COBERTURAS",
+        convention=HeadingConvention.NUMBERED_DECIMAL,
+        depth=1,
+        parent_id=None,
+        child_ids=(),
+        content_lines=("Texto da cobertura.",),
+        page_start=3,
+        page_end=4,
+        bundle_section=None,
+        bundle_confidence=None,
+        is_depth_anomaly=False,
+    )
+
+
+def _provenance() -> ClauseProvenance:
+    return ClauseProvenance(
+        document_id="1",
+        susep_process="15414900666201489",
+        insurer="Bradesco Seguros",
+        cnpj="12345678000199",
+        product_line="CASCO",
+        indemnity_regime="VD",
+        process_year="2019",
+    )
+
+
+def _typed_clause(**provenance_overrides: str) -> TypedClause:
+    provenance = replace(_provenance(), **provenance_overrides)
+    return TypedClause(
+        clause=_clause(),
+        clause_type=ClauseType.COVERAGE,
+        type_source=TypeSource.RULE,
+        confidence=1.0,
+        provenance=provenance,
+    )
+
+
+@pytest.mark.unit
+def test_flatten_typed_clause_produces_valid_record() -> None:
+    typed = _typed_clause()
+
+    record = flatten_typed_clause(typed, source="text")
+
+    assert record.schema_version == SCHEMA_VERSION
+    assert record.clause_id == "1:2"
+    assert record.path == "2"
+    assert record.text == "Texto da cobertura."
+    assert record.filing_year == "2019"
+    assert record.source == "text"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field",
+    [
+        "susep_process",
+        "insurer",
+        "cnpj",
+        "product_line",
+        "indemnity_regime",
+        "process_year",
+    ],
+)
+def test_flatten_missing_provenance_field_raises(field: str) -> None:
+    typed = _typed_clause(**{field: ""})
+
+    with pytest.raises(ValidationError):
+        flatten_typed_clause(typed, source="text")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["clause_id", "path", "title"])
+def test_flatten_empty_identity_field_raises(field: str) -> None:
+    typed = _typed_clause()
+    overrides: dict[str, Any] = {field: ""}
+    clause = replace(typed.clause, **overrides)
+    typed = replace(typed, clause=clause)
+
+    with pytest.raises(ValidationError):
+        flatten_typed_clause(typed, source="text")

--- a/tests/unit/infrastructure/parsing/test_clause_tree_caching.py
+++ b/tests/unit/infrastructure/parsing/test_clause_tree_caching.py
@@ -38,6 +38,7 @@ def _tree() -> ClauseTree:
     root = Clause(
         document_id="17",
         clause_id="17:1",
+        path="1",
         numbering_label="1",
         title="1. OBJETO DO SEGURO",
         convention=HeadingConvention.NUMBERED_DECIMAL,
@@ -47,11 +48,14 @@ def _tree() -> ClauseTree:
         content_lines=("Corpo do objeto.",),
         page_start=1,
         page_end=2,
+        bundle_section=None,
+        bundle_confidence=None,
         is_depth_anomaly=False,
     )
     child = Clause(
         document_id="17",
         clause_id="17:2",
+        path="1/1.1",
         numbering_label="1.1",
         title="1.1 Âmbito Geográfico",
         convention=HeadingConvention.NUMBERED_DECIMAL,
@@ -61,6 +65,8 @@ def _tree() -> ClauseTree:
         content_lines=(),
         page_start=2,
         page_end=2,
+        bundle_section="1. OBJETO DO SEGURO",
+        bundle_confidence="high",
         is_depth_anomaly=True,
     )
     warning = ClauseTreeWarning(

--- a/tests/unit/infrastructure/parsing/test_corpus_artifact.py
+++ b/tests/unit/infrastructure/parsing/test_corpus_artifact.py
@@ -1,0 +1,88 @@
+"""Round-trip tests for the final corpus artifact (Parquet/JSONL/build manifest)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from infrastructure.parsing.clause_schema import SCHEMA_VERSION, ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import (
+    BuildManifest,
+    read_parsed_clauses_jsonl,
+    read_parsed_clauses_parquet,
+    utc_now,
+    write_build_manifest,
+    write_parsed_clauses_jsonl,
+    write_parsed_clauses_parquet,
+)
+
+
+def _record(**overrides: object) -> ParsedClauseRecord:
+    base: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "clause_id": "1:2",
+        "document_id": "1",
+        "parent_id": None,
+        "path": "2",
+        "title": "2. COBERTURAS",
+        "text": "Texto da cobertura.",
+        "clause_type": "coverage",
+        "type_source": "rule",
+        "confidence": 1.0,
+        "bundle_section": None,
+        "page_start": 3,
+        "page_end": 4,
+        "source": "text",
+        "susep_process": "15414900666201489",
+        "insurer": "Bradesco Seguros",
+        "cnpj": "12345678000199",
+        "product_line": "CASCO",
+        "indemnity_regime": "VD",
+        "filing_year": "2019",
+    }
+    base.update(overrides)
+    return ParsedClauseRecord.model_validate(base)
+
+
+@pytest.mark.unit
+def test_write_then_read_parquet_round_trips(tmp_path: Path) -> None:
+    records = [_record(), _record(clause_id="1:3", path="3", parent_id="1:2")]
+    path = tmp_path / "parsed_clauses.parquet"
+
+    write_parsed_clauses_parquet(records, path)
+    restored = read_parsed_clauses_parquet(path)
+
+    assert restored == records
+
+
+@pytest.mark.unit
+def test_write_then_read_jsonl_round_trips(tmp_path: Path) -> None:
+    records = [_record(), _record(clause_id="1:3", path="3", parent_id="1:2")]
+    path = tmp_path / "parsed_clauses.jsonl"
+
+    write_parsed_clauses_jsonl(records, path)
+    restored = read_parsed_clauses_jsonl(path)
+
+    assert restored == records
+    assert len(path.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+@pytest.mark.unit
+def test_write_build_manifest_round_trips(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        schema_version=SCHEMA_VERSION,
+        clause_segmentation_version="v2",
+        boilerplate_removal_version="v1",
+        llm_classification_enabled=False,
+        built_at_utc=utc_now(),
+        clause_counts_by_document={"1": 2, "2": 5},
+        total_clause_count=7,
+    )
+    path = tmp_path / "manifest.json"
+
+    write_build_manifest(manifest, path)
+    restored = BuildManifest.model_validate(
+        json.loads(path.read_text(encoding="utf-8"))
+    )
+
+    assert restored == manifest


### PR DESCRIPTION
## Summary

- Defines `ParsedClauseRecord`, the frozen Pydantic schema that flattens a
  `TypedClause` + its manifest provenance into the wire contract everything
  downstream of parsing reads (`infrastructure/parsing/clause_schema.py`).
  Required provenance/identity fields reject empty strings, so a clause
  missing provenance fails loudly instead of writing silently.
- Replaces `clause_id`'s sequential-counter generation with a
  `document_id:path` scheme anchored to each clause's own heading numbering
  (or a title slug for unnumbered parts). A structural fix in one branch of
  a document's tree no longer shifts the `clause_id` of unrelated clauses
  elsewhere in the same document — the property the DoD asks for
  ("evaluation labels survive a re-parse"). `CLAUSE_SEGMENTATION_VERSION`
  bumped `v1` → `v2` accordingly.
- Fixes a latent bug found while wiring this up: `bundle_section`/
  `bundle_confidence` were never persisted through the `clause_trees`
  Parquet cache (missing columns), so every cache read silently lost
  [M1-06]'s bundle classification. Added to `_ROW_SCHEMA` and the
  read/write path.
- Adds `scripts/build_corpus.py`, the final pipeline stage: reads the
  cached clause trees, classifies with the existing rule pass (LLM
  fallback is a deterministic stub — `NullClauseClassifier` — since no
  `BaseChatModel` factory exists yet in the repo and a real LLM call would
  make the build non-reproducible; wiring it up is left to a follow-up
  issue), and writes the combined corpus to `build/parsed_clauses.parquet`
  + `.jsonl`, plus `build/manifest.json` (parser/schema versions,
  timestamp, per-document and total clause counts).
- Adds `make parse`, chaining `extract-text` → `remove-boilerplate` →
  `build-clause-tree` → the new build step, end to end from
  `data/policies/raw/`.
- Validated against the full corpus: 4,469 clauses across 30 documents,
  zero rows with empty provenance.

## Related issue

[M1-07]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
- [ ] Docs updated (`README.md`, `docs/`, or other affected doc) — no
      doc update needed for this issue; `docs/PARSING.md` is [M1-08] scope
- [x] Evaluation impact considered — does this change affect parsing,
      retrieval, or evaluation numbers? `clause_id` format changed
      (`doc:N` → `doc:path`); harmless today since `data/golden_set/` is
      still empty, but any future re-parse will change every `clause_id`
      again if the numbering-based path itself changes. Clause counts/
      boundaries are unchanged — only identifiers and the newly-fixed
      `bundle_section` persistence.
- [x] `make check` passes locally