### PR TITLE
feat(parsing): add vision-LLM boundary-detection escalation pass for …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ LLM_BASE_URL= # Optional base URL for the LLM provider
 LLM_API_KEY=
 LLM_MODEL_FAST=
 LLM_MODEL_REASONING=
+LLM_MODEL_VISION= # Optional; required only for `make escalate-vision-boundaries`
 EMBEDDING_MODEL=
 RERANKER_MODEL=
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration check extract-text remove-boilerplate build-clause-tree parse sample-parsing-quality validate-parsing-quality-sample score-parsing-quality
+.PHONY: install lint format format-check typecheck test test-integration check extract-text remove-boilerplate build-clause-tree parse sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries
 
 help:
 	@echo "Available targets:"
@@ -19,6 +19,7 @@ help:
 	@echo "  sample-parsing-quality - Draw the M1-08 stratified 50-clause sample for manual review"
 	@echo "  validate-parsing-quality-sample - Automated LLM validation of the M1-08b sample (fills judgment columns)"
 	@echo "  score-parsing-quality  - Score the annotated M1-08 sample and write eval/parsing_quality_results.md"
+	@echo "  escalate-vision-boundaries - M1-04d: vision-LLM boundary review of suspicious clauses (opt-in, not part of parse)"
 
 install:
 	uv sync
@@ -63,3 +64,6 @@ validate-parsing-quality-sample:
 
 score-parsing-quality:
 	PYTHONPATH=app/src uv run python scripts/score_parsing_quality.py
+
+escalate-vision-boundaries:
+	PYTHONPATH=app/src uv run python scripts/escalate_vision_boundaries.py

--- a/app/src/application/ports/boundary_vision_reviewer.py
+++ b/app/src/application/ports/boundary_vision_reviewer.py
@@ -1,0 +1,33 @@
+"""Port for the vision-LLM boundary review ([M1-04d])."""
+
+from typing import Protocol
+
+from domain.boundary_escalation import BoundaryReview
+
+
+class BoundaryVisionReviewerPort(Protocol):
+    """Interface for asking a vision-capable model to review a clause boundary."""
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        """Review a deterministic pass's claimed boundary against page images.
+
+        Args:
+            clause_title: The clause's title, as recorded by the
+                deterministic pass.
+            claimed_page_start: The deterministic pass's recorded page_start.
+            claimed_page_end: The deterministic pass's recorded page_end.
+            page_images: PNG-encoded images of the claimed range plus margin,
+                in page order.
+
+        Returns:
+            The model's judgment: confirmation, a corrected page range, or a
+            suggested sub-clause split.
+        """
+        ...

--- a/app/src/application/ports/page_rasterizer.py
+++ b/app/src/application/ports/page_rasterizer.py
@@ -1,0 +1,24 @@
+"""Port for rasterizing PDF pages to images."""
+
+from pathlib import Path
+from typing import Protocol
+
+
+class PageRasterizerPort(Protocol):
+    """Interface for turning a page range of a source PDF into images."""
+
+    def rasterize(
+        self, pdf_path: Path, document_id: str, first_page: int, last_page: int
+    ) -> tuple[bytes, ...]:
+        """Rasterize ``pdf_path``'s pages ``[first_page, last_page]`` (1-indexed).
+
+        Args:
+            pdf_path: Path to the source PDF.
+            document_id: The manifest document id, for cache keying.
+            first_page: First page to rasterize, inclusive, 1-indexed.
+            last_page: Last page to rasterize, inclusive, 1-indexed.
+
+        Returns:
+            One PNG-encoded image per page, in page order.
+        """
+        ...

--- a/app/src/application/use_cases/boundary_escalation.py
+++ b/app/src/application/use_cases/boundary_escalation.py
@@ -1,0 +1,513 @@
+"""Use case for [M1-04d]'s vision-LLM boundary-escalation pass.
+
+A narrow, last-resort escalation on top of [application.use_cases.
+clause_segmentation.segment_document]'s deterministic pass: only clauses
+the deterministic pass already flags as suspicious (oversized, OCR-derived,
+or adjacent to an UNNUMBERED_PART/depth-anomaly boundary -- see
+[find_suspicious_clauses]) get a second, vision-based review.
+
+A vision-proposed page-range correction is applied via a bounded, mechanical
+line-reassignment between the flagged clause and its immediate
+document-order neighbor, using the per-line page attribution
+[application.use_cases.clause_segmentation] now records on every [Clause]
+(``content_line_pages``). A vision-proposed sub-clause split is never
+auto-applied -- by explicit project decision, confirmed with the project
+owner: splitting would mint new clause_id/path values and restructure the
+tree, a materially bigger, riskier change than this issue's scope, and
+would risk exactly the clause_id churn [M1-07]'s determinism guarantee
+exists to prevent. A split suggestion is recorded (see [BoundaryReview.
+split_notes]) for a human or [M1-08c] to act on later.
+
+A corrected page is only ever trusted if it falls inside the page range
+that was actually rasterized and shown to the model -- the model never
+gets to claim a boundary it wasn't shown.
+"""
+
+import time
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+from application.ports.boundary_vision_reviewer import BoundaryVisionReviewerPort
+from application.ports.page_rasterizer import PageRasterizerPort
+from application.use_cases.clause_segmentation import find_oversized_clauses
+from domain.boundary_escalation import (
+    BoundaryEscalationOutcome,
+    BoundaryReview,
+    SuspicionFlag,
+)
+from domain.clause_tree import BoundarySource, Clause, ClauseTree, HeadingConvention
+
+BOUNDARY_ESCALATION_MAX_ATTEMPTS = 3
+BOUNDARY_ESCALATION_RETRY_DELAY_SECONDS = 5.0
+# The same +/-1-page margin already validated in [M1-08b]'s
+# scripts/validate_parsing_quality_sample.py.
+BOUNDARY_ESCALATION_PAGE_MARGIN = 1
+
+
+def find_suspicious_clauses(
+    tree: ClauseTree, *, max_page_span: int, max_char_count: int
+) -> tuple[SuspicionFlag, ...]:
+    """Flag clauses worth a vision review. Pure, never raises.
+
+    A clause is flagged when any of the following holds:
+
+    - ``"oversized"``: it trips [find_oversized_clauses]'s existing
+      page-span/char-count safeguard.
+    - ``"ocr"``: its document has no font/position heading signal at all
+      (``tree.report.extraction_mode == "ocr_required"`` -- a document-level
+      signal, since [Clause] carries no per-clause OCR flag).
+    - ``"depth_anomaly"``: [Clause.is_depth_anomaly] is True.
+    - ``"unnumbered_part_adjacent"`` / ``"depth_anomaly_adjacent"``: the
+      clause immediately before or after it in ``tree.all_clauses`` (true
+      document reading order) has convention UNNUMBERED_PART, or is itself
+      a depth anomaly, respectively.
+    """
+    oversized_ids = {
+        clause.clause_id
+        for clause in find_oversized_clauses(
+            tree.all_clauses,
+            max_page_span=max_page_span,
+            max_char_count=max_char_count,
+        )
+    }
+    is_ocr_document = tree.report.extraction_mode == "ocr_required"
+    clauses = tree.all_clauses
+
+    flags: list[SuspicionFlag] = []
+    for index, clause in enumerate(clauses):
+        reasons: list[str] = []
+        if clause.clause_id in oversized_ids:
+            reasons.append("oversized")
+        if is_ocr_document:
+            reasons.append("ocr")
+        if clause.is_depth_anomaly:
+            reasons.append("depth_anomaly")
+
+        neighbors = (
+            clauses[index - 1] if index > 0 else None,
+            clauses[index + 1] if index + 1 < len(clauses) else None,
+        )
+        for neighbor in neighbors:
+            if neighbor is None:
+                continue
+            if (
+                neighbor.convention == HeadingConvention.UNNUMBERED_PART
+                and "unnumbered_part_adjacent" not in reasons
+            ):
+                reasons.append("unnumbered_part_adjacent")
+            if neighbor.is_depth_anomaly and "depth_anomaly_adjacent" not in reasons:
+                reasons.append("depth_anomaly_adjacent")
+
+        if reasons:
+            flags.append(
+                SuspicionFlag(clause_id=clause.clause_id, reasons=tuple(reasons))
+            )
+
+    return tuple(flags)
+
+
+def _resolve_rasterize_range(
+    page_start: int, page_end: int, margin: int, page_count: int
+) -> tuple[int, int]:
+    """Same clamp as validate_parsing_quality_sample.resolve_page_range."""
+    first = max(1, page_start - margin)
+    last = min(page_count, page_end + margin)
+    return first, last
+
+
+def _review_with_retry(
+    reviewer: BoundaryVisionReviewerPort,
+    *,
+    clause_title: str,
+    claimed_page_start: int,
+    claimed_page_end: int,
+    page_images: tuple[bytes, ...],
+    max_attempts: int = BOUNDARY_ESCALATION_MAX_ATTEMPTS,
+    retry_delay_seconds: float = BOUNDARY_ESCALATION_RETRY_DELAY_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> BoundaryReview:
+    """Call the vision port, retrying transient failures.
+
+    Retries up to ``max_attempts`` times, sleeping ``retry_delay_seconds``
+    between attempts, then RE-RAISES -- matching
+    ``scripts/validate_parsing_quality_sample.py``'s ``call_llm_with_retry``
+    precedent, not [application.use_cases.clause_classification]'s
+    OTHER/0.0 silent fallback: a boundary review that silently defaulted to
+    "confirmed" on failure would be indistinguishable from a real
+    confirmation, which is worse than a loud failure.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return reviewer.review(
+                clause_title=clause_title,
+                claimed_page_start=claimed_page_start,
+                claimed_page_end=claimed_page_end,
+                page_images=page_images,
+            )
+        except Exception as exc:
+            last_exc = exc
+            if attempt < max_attempts:
+                sleep(retry_delay_seconds)
+    assert last_exc is not None
+    raise last_exc
+
+
+def _partition_by_page(
+    lines: tuple[str, ...],
+    pages: tuple[int, ...],
+    *,
+    keep: Callable[[int], bool],
+) -> tuple[tuple[str, ...], tuple[int, ...], tuple[str, ...], tuple[int, ...]]:
+    """Split parallel (lines, pages) into (kept, moved), preserving order."""
+    kept_lines: list[str] = []
+    kept_pages: list[int] = []
+    moved_lines: list[str] = []
+    moved_pages: list[int] = []
+    for line, page in zip(lines, pages, strict=True):
+        if keep(page):
+            kept_lines.append(line)
+            kept_pages.append(page)
+        else:
+            moved_lines.append(line)
+            moved_pages.append(page)
+    return tuple(kept_lines), tuple(kept_pages), tuple(moved_lines), tuple(moved_pages)
+
+
+def _has_page_attribution(clause: Clause) -> bool:
+    return bool(clause.content_lines) and len(clause.content_line_pages) == len(
+        clause.content_lines
+    )
+
+
+def _apply_start_edge(
+    clauses_by_id: dict[str, Clause], order: list[str], index: int, new_start: int
+) -> tuple[dict[str, Clause], bool, str]:
+    """Reassign lines between a clause and its preceding neighbor.
+
+    Shrinking (``new_start`` > current ``page_start``): the clause's own
+    leading lines on pages before ``new_start`` move to the preceding
+    neighbor. Widening (``new_start`` < current ``page_start``): the
+    clause pulls the preceding neighbor's trailing lines on pages
+    ``>= new_start``.
+    """
+    clause = clauses_by_id[order[index]]
+    if not _has_page_attribution(clause):
+        return (
+            clauses_by_id,
+            False,
+            "clause has no per-line page attribution; front-edge correction "
+            "not applied",
+        )
+    if index == 0:
+        return (
+            clauses_by_id,
+            False,
+            "no preceding neighbor for the front-edge correction; not applied",
+        )
+
+    prev_id = order[index - 1]
+    prev = clauses_by_id[prev_id]
+    if not _has_page_attribution(prev) and prev.content_lines:
+        return (
+            clauses_by_id,
+            False,
+            "preceding neighbor has no per-line page attribution; "
+            "front-edge correction not applied",
+        )
+
+    if new_start > clause.page_start:
+        kept_lines, kept_pages, moved_lines, moved_pages = _partition_by_page(
+            clause.content_lines,
+            clause.content_line_pages,
+            keep=lambda p: p >= new_start,
+        )
+        if not kept_lines:
+            return (
+                clauses_by_id,
+                False,
+                "front-edge correction would empty the clause; not applied",
+            )
+        if not moved_lines:
+            return (
+                clauses_by_id,
+                False,
+                "no content found on the trimmed front pages; not applied",
+            )
+        clauses_by_id[clause.clause_id] = replace(
+            clause,
+            content_lines=kept_lines,
+            content_line_pages=kept_pages,
+            page_start=kept_pages[0],
+        )
+        clauses_by_id[prev_id] = replace(
+            prev,
+            content_lines=prev.content_lines + moved_lines,
+            content_line_pages=prev.content_line_pages + moved_pages,
+            page_end=moved_pages[-1],
+            boundary_source=BoundarySource.VISION_ESCALATED,
+        )
+    else:
+        kept_prev_lines, kept_prev_pages, moved_lines, moved_pages = _partition_by_page(
+            prev.content_lines, prev.content_line_pages, keep=lambda p: p < new_start
+        )
+        if not moved_lines:
+            return (
+                clauses_by_id,
+                False,
+                "preceding neighbor has no content on the claimed pages; not applied",
+            )
+        clauses_by_id[clause.clause_id] = replace(
+            clause,
+            content_lines=moved_lines + clause.content_lines,
+            content_line_pages=moved_pages + clause.content_line_pages,
+            page_start=new_start,
+        )
+        clauses_by_id[prev_id] = replace(
+            prev,
+            content_lines=kept_prev_lines,
+            content_line_pages=kept_prev_pages,
+            page_end=kept_prev_pages[-1] if kept_prev_pages else prev.page_start,
+            boundary_source=BoundarySource.VISION_ESCALATED,
+        )
+    return clauses_by_id, True, ""
+
+
+def _apply_end_edge(
+    clauses_by_id: dict[str, Clause], order: list[str], index: int, new_end: int
+) -> tuple[dict[str, Clause], bool, str]:
+    """Reassign lines between a clause and its following neighbor.
+
+    Mirror of [_apply_start_edge] for the trailing boundary.
+    """
+    clause = clauses_by_id[order[index]]
+    if not _has_page_attribution(clause):
+        return (
+            clauses_by_id,
+            False,
+            "clause has no per-line page attribution; back-edge correction not applied",
+        )
+    if index + 1 >= len(order):
+        return (
+            clauses_by_id,
+            False,
+            "no following neighbor for the back-edge correction; not applied",
+        )
+
+    next_id = order[index + 1]
+    next_clause = clauses_by_id[next_id]
+    if not _has_page_attribution(next_clause) and next_clause.content_lines:
+        return (
+            clauses_by_id,
+            False,
+            "following neighbor has no per-line page attribution; "
+            "back-edge correction not applied",
+        )
+
+    if new_end < clause.page_end:
+        kept_lines, kept_pages, moved_lines, moved_pages = _partition_by_page(
+            clause.content_lines, clause.content_line_pages, keep=lambda p: p <= new_end
+        )
+        if not kept_lines:
+            return (
+                clauses_by_id,
+                False,
+                "back-edge correction would empty the clause; not applied",
+            )
+        if not moved_lines:
+            return (
+                clauses_by_id,
+                False,
+                "no content found on the trimmed back pages; not applied",
+            )
+        clauses_by_id[clause.clause_id] = replace(
+            clause,
+            content_lines=kept_lines,
+            content_line_pages=kept_pages,
+            page_end=kept_pages[-1],
+        )
+        clauses_by_id[next_id] = replace(
+            next_clause,
+            content_lines=moved_lines + next_clause.content_lines,
+            content_line_pages=moved_pages + next_clause.content_line_pages,
+            page_start=moved_pages[0],
+            boundary_source=BoundarySource.VISION_ESCALATED,
+        )
+    else:
+        kept_next_lines, kept_next_pages, moved_lines, moved_pages = _partition_by_page(
+            next_clause.content_lines,
+            next_clause.content_line_pages,
+            keep=lambda p: p > new_end,
+        )
+        if not moved_lines:
+            return (
+                clauses_by_id,
+                False,
+                "following neighbor has no content on the claimed pages; not applied",
+            )
+        clauses_by_id[clause.clause_id] = replace(
+            clause,
+            content_lines=clause.content_lines + moved_lines,
+            content_line_pages=clause.content_line_pages + moved_pages,
+            page_end=new_end,
+        )
+        clauses_by_id[next_id] = replace(
+            next_clause,
+            content_lines=kept_next_lines,
+            content_line_pages=kept_next_pages,
+            page_start=kept_next_pages[0] if kept_next_pages else next_clause.page_end,
+            boundary_source=BoundarySource.VISION_ESCALATED,
+        )
+    return clauses_by_id, True, ""
+
+
+def _apply_boundary_review(
+    clauses_by_id: dict[str, Clause],
+    order: list[str],
+    clause_id: str,
+    review: BoundaryReview,
+    *,
+    rasterized_first_page: int,
+    rasterized_last_page: int,
+) -> tuple[dict[str, Clause], bool, str]:
+    """Apply one clause's boundary review. Returns (updated map, applied, note)."""
+    clauses_by_id = dict(clauses_by_id)
+    clause = replace(
+        clauses_by_id[clause_id], boundary_source=BoundarySource.VISION_ESCALATED
+    )
+    clauses_by_id[clause_id] = clause
+
+    if review.split_suggested:
+        return (
+            clauses_by_id,
+            False,
+            "sub-clause split suggested; not auto-applied (see split_notes)",
+        )
+    if review.confirmed:
+        return clauses_by_id, False, "confirmed, no change"
+
+    new_start = review.corrected_page_start
+    new_end = review.corrected_page_end
+    if new_start is None or new_end is None:
+        return clauses_by_id, False, "no corrected page range provided"
+    if new_start > new_end:
+        return (
+            clauses_by_id,
+            False,
+            "corrected page range is invalid (start > end); not applied",
+        )
+    if not (rasterized_first_page <= new_start <= rasterized_last_page) or not (
+        rasterized_first_page <= new_end <= rasterized_last_page
+    ):
+        return (
+            clauses_by_id,
+            False,
+            "corrected page range falls outside the rasterized margin; not applied",
+        )
+    if new_start == clause.page_start and new_end == clause.page_end:
+        return (
+            clauses_by_id,
+            False,
+            "corrected range matches current boundary; no change",
+        )
+
+    index = order.index(clause_id)
+    applied_any = False
+    notes: list[str] = []
+
+    if new_start != clause.page_start:
+        clauses_by_id, ok, note = _apply_start_edge(
+            clauses_by_id, order, index, new_start
+        )
+        applied_any = applied_any or ok
+        if note:
+            notes.append(note)
+
+    clause = clauses_by_id[clause_id]
+    if new_end != clause.page_end:
+        clauses_by_id, ok, note = _apply_end_edge(clauses_by_id, order, index, new_end)
+        applied_any = applied_any or ok
+        if note:
+            notes.append(note)
+
+    if not notes:
+        return clauses_by_id, True, "corrected page range applied"
+    return clauses_by_id, applied_any, "; ".join(notes)
+
+
+def escalate_boundaries(
+    tree: ClauseTree,
+    pdf_path: Path,
+    *,
+    reviewer: BoundaryVisionReviewerPort,
+    rasterizer: PageRasterizerPort,
+    page_count: int,
+    max_page_span: int,
+    max_char_count: int,
+    page_margin: int = BOUNDARY_ESCALATION_PAGE_MARGIN,
+    max_attempts: int = BOUNDARY_ESCALATION_MAX_ATTEMPTS,
+    retry_delay_seconds: float = BOUNDARY_ESCALATION_RETRY_DELAY_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[ClauseTree, tuple[BoundaryEscalationOutcome, ...]]:
+    """Run the vision-escalation pass over every suspicious clause in ``tree``.
+
+    Returns the (possibly boundary-corrected) tree plus one outcome per
+    flagged clause, so escalated and non-escalated clauses stay measurable
+    separately downstream (mirroring [domain.clause_classification.
+    TypeSource]'s rule/llm distinction).
+    """
+    flags = find_suspicious_clauses(
+        tree, max_page_span=max_page_span, max_char_count=max_char_count
+    )
+    if not flags:
+        return tree, ()
+
+    clauses_by_id: dict[str, Clause] = {
+        clause.clause_id: clause for clause in tree.all_clauses
+    }
+    order = [clause.clause_id for clause in tree.all_clauses]
+    outcomes: list[BoundaryEscalationOutcome] = []
+
+    for flag in flags:
+        clause = clauses_by_id[flag.clause_id]
+        first_page, last_page = _resolve_rasterize_range(
+            clause.page_start, clause.page_end, page_margin, page_count
+        )
+        page_images = rasterizer.rasterize(
+            pdf_path, tree.document_id, first_page, last_page
+        )
+        review = _review_with_retry(
+            reviewer,
+            clause_title=clause.title,
+            claimed_page_start=clause.page_start,
+            claimed_page_end=clause.page_end,
+            page_images=page_images,
+            max_attempts=max_attempts,
+            retry_delay_seconds=retry_delay_seconds,
+            sleep=sleep,
+        )
+        clauses_by_id, applied, note = _apply_boundary_review(
+            clauses_by_id,
+            order,
+            flag.clause_id,
+            review,
+            rasterized_first_page=first_page,
+            rasterized_last_page=last_page,
+        )
+        outcomes.append(
+            BoundaryEscalationOutcome(
+                clause_id=flag.clause_id,
+                reasons=flag.reasons,
+                review=review,
+                applied=applied,
+                note=note,
+            )
+        )
+
+    revised_clauses = tuple(clauses_by_id[cid] for cid in order)
+    revised_roots = tuple(
+        clause for clause in revised_clauses if clause.parent_id is None
+    )
+    revised_tree = replace(tree, roots=revised_roots, all_clauses=revised_clauses)
+    return revised_tree, tuple(outcomes)

--- a/app/src/application/use_cases/clause_segmentation.py
+++ b/app/src/application/use_cases/clause_segmentation.py
@@ -902,6 +902,7 @@ class _ClauseBuilder:
         self.is_depth_anomaly = is_depth_anomaly
         self.child_ids: list[str] = []
         self.content_lines: list[str] = []
+        self.content_line_pages: list[int] = []
         self.page_start: int | None = None
         self.page_end: int | None = None
         self.bundle_section: str | None = None
@@ -929,6 +930,7 @@ class _ClauseBuilder:
             bundle_section=self.bundle_section,
             bundle_confidence=self.bundle_confidence,
             is_depth_anomaly=self.is_depth_anomaly,
+            content_line_pages=tuple(self.content_line_pages),
         )
 
 
@@ -1045,6 +1047,7 @@ def segment_document(document: ExtractedDocument) -> ClauseTree:
         nonlocal orphan_char_count
         if stack:
             stack[-1].content_lines.append(text)
+            stack[-1].content_line_pages.append(page_number)
             stack[-1].touch_page(page_number)
         else:
             orphan_char_count += len(text)

--- a/app/src/domain/boundary_escalation.py
+++ b/app/src/domain/boundary_escalation.py
@@ -1,0 +1,62 @@
+"""Types for [M1-04d]'s vision-LLM boundary-escalation pass.
+
+Kept separate from [domain.clause_tree], the same way [domain.
+clause_classification] keeps [TypedClause] separate from [Clause] itself:
+this is a second, independent pass over an already-built [ClauseTree], not
+a property of tree construction.
+
+Frozen dataclasses only, no third-party imports -- same stdlib-only
+constraint as [domain.clause_tree] and [domain.clause_classification].
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SuspicionFlag:
+    """One clause the deterministic pass flags as worth a vision review.
+
+    ``reasons`` names every matched trigger (a clause can be both oversized
+    and OCR-derived, for instance) -- see [application.use_cases.
+    boundary_escalation.find_suspicious_clauses] for the exact predicate.
+    """
+
+    clause_id: str
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BoundaryReview:
+    """The vision model's judgment for one flagged clause's boundary.
+
+    ``corrected_page_start``/``corrected_page_end`` are only meaningful
+    when ``confirmed`` is False; ``split_suggested``/``split_notes`` are a
+    separate, independent signal -- a model can confirm the *outer*
+    boundary while still suggesting an internal split.
+    """
+
+    confirmed: bool
+    corrected_page_start: int | None
+    corrected_page_end: int | None
+    split_suggested: bool
+    split_notes: str
+    reasoning: str
+
+
+@dataclass(frozen=True)
+class BoundaryEscalationOutcome:
+    """What happened for one flagged clause after review.
+
+    ``applied`` is False whenever the review was a no-op confirmation, a
+    split suggestion (never auto-applied -- see the module docstring in
+    [application.use_cases.boundary_escalation]), or a correction that
+    could not be safely applied (falls outside the rasterized margin, or
+    the clause/its neighbor lacks per-line page attribution). ``note``
+    always explains which case it was.
+    """
+
+    clause_id: str
+    reasons: tuple[str, ...]
+    review: BoundaryReview
+    applied: bool
+    note: str

--- a/app/src/domain/clause_tree.py
+++ b/app/src/domain/clause_tree.py
@@ -26,6 +26,19 @@ class HeadingConvention(Enum):
     UNNUMBERED_PART = "unnumbered_part"
 
 
+class BoundarySource(Enum):
+    """Which pass produced a given [Clause]'s final page boundary.
+
+    Mirrors [domain.clause_classification.TypeSource]'s rule/llm split, so
+    [M1-04d]'s vision-escalated boundaries stay measurable separately from
+    the deterministic pass downstream, the same way rule- vs LLM-assigned
+    clause types already are.
+    """
+
+    DETERMINISTIC = "deterministic"
+    VISION_ESCALATED = "vision_escalated"
+
+
 @dataclass(frozen=True)
 class Clause:
     """One node in a document's clause tree."""
@@ -45,6 +58,14 @@ class Clause:
     bundle_section: str | None = None
     bundle_confidence: str | None = None
     is_depth_anomaly: bool = False
+    # Parallel to content_lines: the page each line was extracted from.
+    # Empty for any clause built before [M1-04d] (hand-built fixtures, or a
+    # tree cached before this field existed) -- an honest "unknown" default,
+    # not a guess. See [application.use_cases.boundary_escalation] for why
+    # this per-line attribution is needed to apply a vision-proposed
+    # boundary correction without re-running heading detection.
+    content_line_pages: tuple[int, ...] = ()
+    boundary_source: BoundarySource = BoundarySource.DETERMINISTIC
 
 
 @dataclass(frozen=True)

--- a/app/src/infrastructure/config/settings.py
+++ b/app/src/infrastructure/config/settings.py
@@ -163,6 +163,7 @@ class LlmSettings(BaseSettings):
     llm_api_key: SecretStr = Field(alias="LLM_API_KEY")
     llm_model_fast: str = Field(alias="LLM_MODEL_FAST")
     llm_model_reasoning: str = Field(alias="LLM_MODEL_REASONING")
+    llm_model_vision: str | None = Field(alias="LLM_MODEL_VISION", default=None)
 
     # RAG settings
     embedding_model: str = Field(alias="EMBEDDING_MODEL")

--- a/app/src/infrastructure/parsing/boundary_escalation_cache.py
+++ b/app/src/infrastructure/parsing/boundary_escalation_cache.py
@@ -1,0 +1,112 @@
+"""Content-addressed, on-disk cache wrapping a BoundaryVisionReviewerPort.
+
+Mirrors [infrastructure.parsing.llm_classification_cache.
+CachingClauseClassifier]'s pattern exactly: a re-run against unchanged
+input must not silently reshuffle a clause's boundary_source or re-pay for
+a vision call already made, preserving [M1-07]'s clause_id determinism
+guarantee. Keyed by a hash of (model, clause title, claimed page range, page
+image bytes) -- the DoD's exact "hash of (model, page images,
+deterministic-pass claim)" requirement.
+"""
+
+import hashlib
+import json
+import threading
+from pathlib import Path
+
+from application.ports.boundary_vision_reviewer import BoundaryVisionReviewerPort
+from domain.boundary_escalation import BoundaryReview
+
+
+def _cache_key(
+    model: str,
+    clause_title: str,
+    claimed_page_start: int,
+    claimed_page_end: int,
+    page_images: tuple[bytes, ...],
+) -> str:
+    image_hashes = "|".join(hashlib.sha256(img).hexdigest() for img in page_images)
+    payload = (
+        f"{model}\x00{clause_title}\x00{claimed_page_start}\x00"
+        f"{claimed_page_end}\x00{image_hashes}"
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()[:32]
+
+
+class CachingBoundaryVisionReviewer:
+    """A [BoundaryVisionReviewerPort] that persists results to a JSON Lines file."""
+
+    def __init__(
+        self, inner: BoundaryVisionReviewerPort, model: str, cache_path: Path
+    ) -> None:
+        """Wrap ``inner``, caching its results under ``cache_path``."""
+        self._inner = inner
+        self._model = model
+        self._cache_path = cache_path
+        self._lock = threading.Lock()
+        self._cache: dict[str, BoundaryReview] = self._load()
+
+    def _load(self) -> dict[str, BoundaryReview]:
+        if not self._cache_path.exists():
+            return {}
+        cache: dict[str, BoundaryReview] = {}
+        with self._cache_path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                cache[record["key"]] = BoundaryReview(
+                    confirmed=record["confirmed"],
+                    corrected_page_start=record["corrected_page_start"],
+                    corrected_page_end=record["corrected_page_end"],
+                    split_suggested=record["split_suggested"],
+                    split_notes=record["split_notes"],
+                    reasoning=record["reasoning"],
+                )
+        return cache
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        """Review, serving from cache when this exact input was seen before."""
+        key = _cache_key(
+            self._model, clause_title, claimed_page_start, claimed_page_end, page_images
+        )
+        with self._lock:
+            cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        result = self._inner.review(
+            clause_title=clause_title,
+            claimed_page_start=claimed_page_start,
+            claimed_page_end=claimed_page_end,
+            page_images=page_images,
+        )
+
+        with self._lock:
+            self._cache[key] = result
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._cache_path.open("a", encoding="utf-8") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "key": key,
+                            "confirmed": result.confirmed,
+                            "corrected_page_start": result.corrected_page_start,
+                            "corrected_page_end": result.corrected_page_end,
+                            "split_suggested": result.split_suggested,
+                            "split_notes": result.split_notes,
+                            "reasoning": result.reasoning,
+                        }
+                    )
+                    + "\n"
+                )
+                f.flush()
+        return result

--- a/app/src/infrastructure/parsing/boundary_vision.py
+++ b/app/src/infrastructure/parsing/boundary_vision.py
@@ -1,0 +1,203 @@
+"""Vision-LLM boundary review for [M1-04d], and its rasterization port.
+
+``LangchainBoundaryVisionReviewer`` sends a flagged clause's claimed
+boundary plus the rasterized page images to a vision-capable model via the
+existing [infrastructure.config.llm_client_factory.build_chat_model]
+factory -- no new LLM client integration. ``PyMuPdfPageRasterizer`` reuses
+the exact PyMuPDF rasterization pattern already used for OCR (see
+[infrastructure.parsing.ocr.TesseractOcrExtractor]) and for [M1-08b]'s
+``scripts/validate_parsing_quality_sample.py``, with an idempotent disk
+cache so a rerun never re-rasterizes an already-cached page.
+
+Nothing outside this module (and its sibling parsing modules) imports
+``fitz``/``PIL`` directly -- same convention as [infrastructure.parsing.ocr].
+"""
+
+import base64
+import time
+from pathlib import Path
+from typing import cast
+
+import fitz
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from application.ports.boundary_vision_reviewer import BoundaryVisionReviewerPort
+from application.ports.page_rasterizer import PageRasterizerPort
+from domain.boundary_escalation import BoundaryReview
+
+BOUNDARY_ESCALATION_PAGE_CACHE_DIR = Path("data/cache/boundary_escalation_pages")
+
+
+class BoundaryEscalationOutput(BaseModel):
+    """Structured output expected from the vision-review model.
+
+    ``llm_``-prefixed fields, same convention as ``scripts.
+    validate_parsing_quality_sample.LLMValidationOutput``, to keep this
+    model's own output distinct from the domain's [BoundaryReview] it gets
+    mapped into.
+    """
+
+    llm_boundary_confirmed: bool = Field(
+        ...,
+        description=(
+            "Whether the deterministic parser's claimed page range for this "
+            "clause is correct in the attached pages -- not merged with a "
+            "neighboring clause, not cut off mid-content."
+        ),
+    )
+    llm_corrected_page_start: int | None = Field(
+        None,
+        description=(
+            "If not confirmed, the correct first page for this clause. "
+            "Must be one of the attached page numbers."
+        ),
+    )
+    llm_corrected_page_end: int | None = Field(
+        None,
+        description=(
+            "If not confirmed, the correct last page for this clause. "
+            "Must be one of the attached page numbers."
+        ),
+    )
+    llm_split_suggested: bool = Field(
+        False,
+        description=(
+            "Whether the attached pages show this clause actually containing "
+            "two or more distinct numbered sub-clauses that should be split "
+            "apart, independent of whether the outer boundary is correct."
+        ),
+    )
+    llm_split_notes: str = Field(
+        "",
+        description="If a split is suggested, a short note on where and why.",
+    )
+    llm_reasoning: str = Field(..., description="Short overall rationale.")
+
+
+class VisionCallStats:
+    """Mutable call/token/time accumulator for one reviewer instance."""
+
+    def __init__(self) -> None:
+        """Start every counter at zero."""
+        self.call_count = 0
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.total_seconds = 0.0
+
+
+def _build_boundary_review_message(
+    clause_title: str,
+    claimed_page_start: int,
+    claimed_page_end: int,
+    page_images: tuple[bytes, ...],
+) -> list[str | dict[str, object]]:
+    """Build the multimodal human-turn content: the parser's claim plus pages."""
+    prompt_text = (
+        "You are reviewing the boundary an automated Brazilian insurance "
+        "policy clause parser assigned to one clause, against the attached "
+        "page images. The pages are a window around the parser's claim: "
+        "one page of margin before the claimed start and after the claimed "
+        "end, so you can judge whether the boundary is correct, truncated, "
+        "or merged with a neighboring clause.\n\n"
+        f"Parser's claim:\n"
+        f"- Clause title: {clause_title}\n"
+        f"- Claimed page range: {claimed_page_start}-{claimed_page_end}\n\n"
+        "Judge, independently of the parser's claim:\n"
+        "1. Does the clause actually start and end on the claimed pages, or "
+        "is it truncated, merged with a neighbor, or misattributed?\n"
+        "2. If not, what is the correct page range? It must be one of the "
+        "attached pages.\n"
+        "3. Does this clause actually contain two or more distinct numbered "
+        "sub-clauses that should be split apart? This is independent of "
+        "whether the outer boundary above is correct.\n"
+        "Provide a short rationale tying these judgments together."
+    )
+    content: list[str | dict[str, object]] = [{"type": "text", "text": prompt_text}]
+    for image_bytes in page_images:
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{encoded}"},
+            }
+        )
+    return content
+
+
+class LangchainBoundaryVisionReviewer(BoundaryVisionReviewerPort):
+    """Uses a Langchain vision-capable BaseChatModel to review boundaries."""
+
+    def __init__(self, llm: BaseChatModel) -> None:
+        """Wrap ``llm``, tracking call/token/time stats as reviews run."""
+        self._chain = llm.with_structured_output(
+            BoundaryEscalationOutput, include_raw=True
+        )
+        self.stats = VisionCallStats()
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        """Send the claim and page images to the model, returning its judgment."""
+        content = _build_boundary_review_message(
+            clause_title, claimed_page_start, claimed_page_end, page_images
+        )
+        start = time.monotonic()
+        raw = cast(
+            dict[str, object], self._chain.invoke([HumanMessage(content=content)])
+        )
+        self.stats.total_seconds += time.monotonic() - start
+        self.stats.call_count += 1
+
+        usage = getattr(raw.get("raw"), "usage_metadata", None) or {}
+        self.stats.total_input_tokens += int(usage.get("input_tokens", 0) or 0)
+        self.stats.total_output_tokens += int(usage.get("output_tokens", 0) or 0)
+
+        parsed = cast(BoundaryEscalationOutput, raw["parsed"])
+        return BoundaryReview(
+            confirmed=parsed.llm_boundary_confirmed,
+            corrected_page_start=parsed.llm_corrected_page_start,
+            corrected_page_end=parsed.llm_corrected_page_end,
+            split_suggested=parsed.llm_split_suggested,
+            split_notes=parsed.llm_split_notes,
+            reasoning=parsed.llm_reasoning,
+        )
+
+
+class PyMuPdfPageRasterizer(PageRasterizerPort):
+    """Rasterizes PDF pages to PNG bytes, cached on disk by page number."""
+
+    def __init__(self, dpi: int) -> None:
+        """Configure rasterization DPI -- same setting OCR/M1-08b use."""
+        self._dpi = dpi
+
+    def rasterize(
+        self, pdf_path: Path, document_id: str, first_page: int, last_page: int
+    ) -> tuple[bytes, ...]:
+        """Rasterize ``pdf_path``'s pages ``[first_page, last_page]``, cached."""
+        cache_dir = BOUNDARY_ESCALATION_PAGE_CACHE_DIR / document_id
+        targets = {
+            page_num: cache_dir / f"page_{page_num:03d}.png"
+            for page_num in range(first_page, last_page + 1)
+        }
+        if not all(path.exists() for path in targets.values()):
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            document = fitz.open(pdf_path)
+            try:
+                zoom = self._dpi / 72
+                matrix = fitz.Matrix(zoom, zoom)
+                for page_num, png_path in targets.items():
+                    if png_path.exists():
+                        continue
+                    page = document.load_page(page_num - 1)
+                    pixmap = page.get_pixmap(matrix=matrix)
+                    pixmap.save(png_path)
+            finally:
+                document.close()
+        return tuple(targets[page_num].read_bytes() for page_num in sorted(targets))

--- a/app/src/infrastructure/parsing/clause_schema.py
+++ b/app/src/infrastructure/parsing/clause_schema.py
@@ -42,6 +42,7 @@ class ParsedClauseRecord(BaseModel):
     page_start: Annotated[int, Field(ge=1)]
     page_end: Annotated[int, Field(ge=1)]
     source: Literal["text", "ocr"]
+    boundary_source: str | None = None
     susep_process: _NonEmptyStr
     insurer: _NonEmptyStr
     cnpj: _NonEmptyStr
@@ -77,6 +78,7 @@ def flatten_typed_clause(
         page_start=clause.page_start,
         page_end=clause.page_end,
         source=source,
+        boundary_source=clause.boundary_source.value,
         susep_process=provenance.susep_process,
         insurer=provenance.insurer,
         cnpj=provenance.cnpj,

--- a/app/src/infrastructure/parsing/clause_tree_caching.py
+++ b/app/src/infrastructure/parsing/clause_tree_caching.py
@@ -18,6 +18,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from domain.clause_tree import (
+    BoundarySource,
     Clause,
     ClauseTree,
     ClauseTreeReport,
@@ -43,6 +44,8 @@ _ROW_SCHEMA = pa.schema(
         ("bundle_section", pa.string()),
         ("bundle_confidence", pa.string()),
         ("is_depth_anomaly", pa.bool_()),
+        ("content_line_pages", pa.string()),
+        ("boundary_source", pa.string()),
     ]
 )
 
@@ -76,6 +79,8 @@ def write_clause_tree_cache(tree: ClauseTree, path: Path) -> None:
             "bundle_section": clause.bundle_section or "",
             "bundle_confidence": clause.bundle_confidence or "",
             "is_depth_anomaly": clause.is_depth_anomaly,
+            "content_line_pages": ",".join(str(p) for p in clause.content_line_pages),
+            "boundary_source": clause.boundary_source.value,
         }
         for clause in tree.all_clauses
     ]
@@ -143,6 +148,18 @@ def read_clause_tree_cache(path: Path) -> ClauseTree:
             bundle_section=row["bundle_section"] or None,
             bundle_confidence=row["bundle_confidence"] or None,
             is_depth_anomaly=row["is_depth_anomaly"],
+            # .get(): pre-[M1-04d] cached Parquet files carry neither column
+            # -- an honest "unknown"/"deterministic" default, not a guess.
+            content_line_pages=(
+                tuple(int(p) for p in row["content_line_pages"].split(","))
+                if row.get("content_line_pages")
+                else ()
+            ),
+            boundary_source=(
+                BoundarySource(row["boundary_source"])
+                if row.get("boundary_source")
+                else BoundarySource.DETERMINISTIC
+            ),
         )
         for row in table.to_pylist()
     )

--- a/scripts/escalate_vision_boundaries.py
+++ b/scripts/escalate_vision_boundaries.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""[M1-04d]: run the vision-LLM boundary-escalation pass over the corpus.
+
+Opt-in, deliberately **not** part of `make parse` -- the DoD requires
+measuring this pass's actual corpus-wide cost (call count, estimated $
+cost, wall-clock time) before deciding whether it should run by default.
+This script measures and reports that cost (written to
+``eval/boundary_escalation_cost_report.json``); the decision to fold it
+into `make parse` by default is left to a human, informed by that report.
+
+For each document, loads the clause tree [scripts.build_clause_tree]
+already segmented and cached under ``data/cache/clause_trees/`` (never
+re-segments -- a missing cache means that script hasn't run yet, and
+silently re-deriving it here would hide that instead of failing loudly),
+flags suspicious clauses (see [application.use_cases.boundary_escalation.
+find_suspicious_clauses]), runs each through a vision-capable model, and
+**overwrites the same cache path** with the (possibly boundary-corrected)
+tree -- so the next `make parse`/`build-clause-tree` picks it up
+transparently (``build_clause_tree.py``'s own cache-write is a no-op once
+the file exists, so it won't clobber this).
+
+Run via `make escalate-vision-boundaries`, after `make build-clause-tree`.
+Use ``--document-ids`` to smoke-test a small subset before a full run.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from application.use_cases.boundary_escalation import escalate_boundaries
+from application.use_cases.clause_segmentation import CLAUSE_SEGMENTATION_VERSION
+from domain.clause_tree import ClauseTree
+from infrastructure.config.llm_client_factory import build_chat_model
+from infrastructure.config.settings import get_llm_settings, get_parsing_settings
+from infrastructure.parsing.boundary_escalation_cache import (
+    CachingBoundaryVisionReviewer,
+)
+from infrastructure.parsing.boundary_vision import (
+    LangchainBoundaryVisionReviewer,
+    PyMuPdfPageRasterizer,
+)
+from infrastructure.parsing.clause_tree_caching import (
+    clause_tree_cache_path,
+    compute_clause_tree_cache_key,
+    read_clause_tree_cache,
+    write_clause_tree_cache,
+)
+from infrastructure.parsing.manifest import read_manifest
+
+MANIFEST_PATH = Path("data/policies/manifest.csv")
+RAW_DIR = Path("data/policies/raw")
+BOUNDARY_ESCALATION_CACHE_PATH = Path("data/cache/boundary_escalation/cache.jsonl")
+COST_REPORT_PATH = Path("eval/boundary_escalation_cost_report.json")
+
+# Matches scripts/validate_parsing_quality_sample.py's existing pin for the
+# same model -- reused rather than reinvented, per the DoD's "no new LLM
+# client integration" ask. Fallback disabled so a transient provider outage
+# surfaces as an exception (caught and retried by _review_with_retry)
+# instead of silently rerouting to a different, unvalidated upstream.
+VISION_MODEL_PROVIDER_ORDER = ["google-vertex"]
+VISION_ALLOW_FALLBACKS = False
+
+# Rough, provider-published per-1M-token prices at time of writing -- check
+# against the provider's current pricing before treating estimated_cost_usd
+# as authoritative for a real budgeting decision.
+VISION_INPUT_COST_PER_1M_TOKENS_USD = 0.30
+VISION_OUTPUT_COST_PER_1M_TOKENS_USD = 2.50
+
+
+def load_clause_tree(document_id: str, filename: str) -> tuple[Path, ClauseTree]:
+    """Load a document's clause tree from its [M1-04] cache, plus its cache path.
+
+    Raises ``FileNotFoundError`` if that cache is missing -- run
+    ``scripts/build_clause_tree.py`` first.
+    """
+    cache_key = compute_clause_tree_cache_key(CLAUSE_SEGMENTATION_VERSION)
+    path = clause_tree_cache_path(document_id, cache_key)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No clause-tree cache for {filename} (document {document_id}) "
+            f"at {path}. Run `scripts/build_clause_tree.py` first."
+        )
+    return path, read_clause_tree_cache(path)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--document-ids",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated manifest document ids to run (default: the whole corpus)."
+        ),
+    )
+    parser.add_argument(
+        "--continue-on-failure",
+        action="store_true",
+        help=(
+            "Process every document even if one fails (e.g. exhausted "
+            "retries), raising a single aggregate error at the end instead "
+            "of failing fast."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the vision-escalation pass and write the cost report."""
+    args = _parse_args()
+    settings = get_llm_settings()
+    if settings.llm_model_vision is None:
+        raise ValueError(
+            "LLM_MODEL_VISION is not set. Set it in .env before running "
+            "`make escalate-vision-boundaries`."
+        )
+
+    llm = build_chat_model(
+        settings,
+        settings.llm_model_vision,
+        provider_order=VISION_MODEL_PROVIDER_ORDER,
+        allow_fallbacks=VISION_ALLOW_FALLBACKS,
+    )
+    inner_reviewer = LangchainBoundaryVisionReviewer(llm)
+    reviewer = CachingBoundaryVisionReviewer(
+        inner_reviewer,
+        model=settings.llm_model_vision,
+        cache_path=BOUNDARY_ESCALATION_CACHE_PATH,
+    )
+    parsing_settings = get_parsing_settings()
+    rasterizer = PyMuPdfPageRasterizer(dpi=parsing_settings.ocr_dpi)
+
+    manifest_records = read_manifest(MANIFEST_PATH)
+    if args.document_ids:
+        wanted = {doc_id.strip() for doc_id in args.document_ids.split(",")}
+        manifest_records = [r for r in manifest_records if r["id"] in wanted]
+        missing = wanted - {r["id"] for r in manifest_records}
+        if missing:
+            raise ValueError(f"Document id(s) not found in manifest: {sorted(missing)}")
+
+    documents_processed = 0
+    suspicious_clause_count = 0
+    applied_count = 0
+    split_suggested_count = 0
+    failures: list[Exception] = []
+
+    for entry in manifest_records:
+        document_id = entry["id"]
+        filename = entry["filename"]
+        page_count = int(entry["page_count"])
+        pdf_path = RAW_DIR / filename
+        try:
+            cache_path, tree = load_clause_tree(document_id, filename)
+            revised_tree, outcomes = escalate_boundaries(
+                tree,
+                pdf_path,
+                reviewer=reviewer,
+                rasterizer=rasterizer,
+                page_count=page_count,
+                max_page_span=parsing_settings.clause_max_page_span,
+                max_char_count=parsing_settings.clause_max_char_count,
+            )
+        except Exception as exc:  # noqa: BLE001 -- aggregated below
+            if args.continue_on_failure:
+                failures.append(exc)
+                continue
+            raise
+
+        documents_processed += 1
+        suspicious_clause_count += len(outcomes)
+        applied_count += sum(1 for outcome in outcomes if outcome.applied)
+        split_suggested_count += sum(
+            1 for outcome in outcomes if outcome.review.split_suggested
+        )
+        if outcomes:
+            write_clause_tree_cache(revised_tree, cache_path)
+        print(
+            f"{filename}: suspicious={len(outcomes)} "
+            f"applied={sum(1 for o in outcomes if o.applied)}"
+        )
+
+    stats = inner_reviewer.stats
+    estimated_cost_usd = (
+        stats.total_input_tokens / 1_000_000 * VISION_INPUT_COST_PER_1M_TOKENS_USD
+        + stats.total_output_tokens / 1_000_000 * VISION_OUTPUT_COST_PER_1M_TOKENS_USD
+    )
+    report = {
+        "documents_processed": documents_processed,
+        "suspicious_clause_count": suspicious_clause_count,
+        "applied_count": applied_count,
+        "split_suggested_count": split_suggested_count,
+        "cache_hit_count": suspicious_clause_count - stats.call_count,
+        "call_count": stats.call_count,
+        "total_input_tokens": stats.total_input_tokens,
+        "total_output_tokens": stats.total_output_tokens,
+        "wall_clock_seconds": stats.total_seconds,
+        "estimated_cost_usd": round(estimated_cost_usd, 4),
+        "pricing_note": (
+            "estimated_cost_usd uses hardcoded per-1M-token price constants "
+            "in this script -- check against the provider's current pricing "
+            "before treating it as authoritative."
+        ),
+    }
+    COST_REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    COST_REPORT_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if failures:
+        raise ExceptionGroup(f"{len(failures)} document(s) failed", failures)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/application/use_cases/test_boundary_escalation.py
+++ b/tests/unit/application/use_cases/test_boundary_escalation.py
@@ -1,0 +1,548 @@
+"""Tests for [M1-04d]'s vision-LLM boundary-escalation use case."""
+
+from pathlib import Path
+
+import pytest
+
+from application.use_cases.boundary_escalation import (
+    escalate_boundaries,
+    find_suspicious_clauses,
+)
+from domain.boundary_escalation import BoundaryReview
+from domain.clause_tree import (
+    BoundarySource,
+    Clause,
+    ClauseTree,
+    ClauseTreeReport,
+    HeadingConvention,
+)
+
+
+def _clause(
+    clause_id: str,
+    *,
+    title: str = "Title",
+    convention: HeadingConvention = HeadingConvention.NUMBERED_DECIMAL,
+    parent_id: str | None = None,
+    content_lines: tuple[str, ...] = (),
+    content_line_pages: tuple[int, ...] = (),
+    page_start: int,
+    page_end: int,
+    is_depth_anomaly: bool = False,
+) -> Clause:
+    return Clause(
+        document_id="d1",
+        clause_id=clause_id,
+        path=clause_id,
+        numbering_label="1",
+        title=title,
+        convention=convention,
+        depth=1,
+        parent_id=parent_id,
+        child_ids=(),
+        content_lines=content_lines,
+        page_start=page_start,
+        page_end=page_end,
+        is_depth_anomaly=is_depth_anomaly,
+        content_line_pages=content_line_pages,
+    )
+
+
+def _tree(clauses: tuple[Clause, ...], *, extraction_mode: str = "text") -> ClauseTree:
+    roots = tuple(clause for clause in clauses if clause.parent_id is None)
+    return ClauseTree(
+        document_id="d1",
+        filename="f.pdf",
+        roots=roots,
+        all_clauses=clauses,
+        report=ClauseTreeReport(
+            "d1", "f.pdf", len(clauses), 1, 0, 100, 0.0, extraction_mode, ()
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_suspicious_clauses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_find_suspicious_clauses_flags_oversized() -> None:
+    small = _clause(
+        "d1:a", content_lines=("x",), content_line_pages=(1,), page_start=1, page_end=1
+    )
+    big = _clause(
+        "d1:b",
+        content_lines=("y" * 50,),
+        content_line_pages=(2,),
+        page_start=2,
+        page_end=2,
+    )
+    tree = _tree((small, big))
+
+    flags = find_suspicious_clauses(tree, max_page_span=10, max_char_count=10)
+
+    assert {flag.clause_id: flag.reasons for flag in flags} == {"d1:b": ("oversized",)}
+
+
+@pytest.mark.unit
+def test_find_suspicious_clauses_flags_every_clause_in_an_ocr_document() -> None:
+    a = _clause(
+        "d1:a", content_lines=("x",), content_line_pages=(1,), page_start=1, page_end=1
+    )
+    b = _clause(
+        "d1:b", content_lines=("y",), content_line_pages=(2,), page_start=2, page_end=2
+    )
+    tree = _tree((a, b), extraction_mode="ocr_required")
+
+    flags = find_suspicious_clauses(tree, max_page_span=100, max_char_count=100000)
+
+    assert {flag.clause_id for flag in flags} == {"d1:a", "d1:b"}
+    assert all(flag.reasons == ("ocr",) for flag in flags)
+
+
+@pytest.mark.unit
+def test_find_suspicious_clauses_flags_depth_anomaly() -> None:
+    clause = _clause("d1:a", page_start=1, page_end=1, is_depth_anomaly=True)
+    tree = _tree((clause,))
+
+    flags = find_suspicious_clauses(tree, max_page_span=100, max_char_count=100000)
+
+    assert len(flags) == 1
+    assert flags[0].clause_id == "d1:a"
+    assert "depth_anomaly" in flags[0].reasons
+
+
+@pytest.mark.unit
+def test_find_suspicious_clauses_flags_neighbor_of_unnumbered_part() -> None:
+    part = _clause(
+        "d1:part",
+        convention=HeadingConvention.UNNUMBERED_PART,
+        page_start=1,
+        page_end=1,
+    )
+    after = _clause("d1:after", page_start=2, page_end=2)
+    tree = _tree((part, after))
+
+    flags = find_suspicious_clauses(tree, max_page_span=100, max_char_count=100000)
+
+    assert len(flags) == 1
+    assert flags[0].clause_id == "d1:after"
+    assert "unnumbered_part_adjacent" in flags[0].reasons
+
+
+@pytest.mark.unit
+def test_find_suspicious_clauses_clean_tree_yields_no_flags() -> None:
+    a = _clause(
+        "d1:a", content_lines=("x",), content_line_pages=(1,), page_start=1, page_end=1
+    )
+    b = _clause(
+        "d1:b", content_lines=("y",), content_line_pages=(2,), page_start=2, page_end=2
+    )
+    tree = _tree((a, b))
+
+    flags = find_suspicious_clauses(tree, max_page_span=100, max_char_count=100000)
+
+    assert flags == ()
+
+
+# ---------------------------------------------------------------------------
+# escalate_boundaries
+# ---------------------------------------------------------------------------
+
+
+class ScriptedReviewer:
+    """Returns a fixed BoundaryReview for every call; records calls made."""
+
+    def __init__(self, review: BoundaryReview) -> None:
+        self.review_to_return = review
+        self.calls: list[dict[str, object]] = []
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        self.calls.append(
+            {
+                "clause_title": clause_title,
+                "claimed_page_start": claimed_page_start,
+                "claimed_page_end": claimed_page_end,
+                "page_images": page_images,
+            }
+        )
+        return self.review_to_return
+
+
+class CountingReviewer:
+    """Fails the first ``calls_to_fail`` calls, then returns a fixed review."""
+
+    def __init__(self, calls_to_fail: int, review: BoundaryReview) -> None:
+        self.calls_to_fail = calls_to_fail
+        self.review_to_return = review
+        self.call_count = 0
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        self.call_count += 1
+        if self.call_count <= self.calls_to_fail:
+            raise RuntimeError("transient failure")
+        return self.review_to_return
+
+
+class FakeRasterizer:
+    """Returns deterministic placeholder page images; records calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Path, str, int, int]] = []
+
+    def rasterize(
+        self, pdf_path: Path, document_id: str, first_page: int, last_page: int
+    ) -> tuple[bytes, ...]:
+        self.calls.append((pdf_path, document_id, first_page, last_page))
+        return tuple(f"page-{p}".encode() for p in range(first_page, last_page + 1))
+
+
+def _three_clause_tree() -> tuple[ClauseTree, Clause, Clause, Clause]:
+    """A, B, C in document order. B alone trips the oversized-page-span flag."""
+    a = _clause(
+        "d1:a",
+        content_lines=("a1", "a2"),
+        content_line_pages=(1, 2),
+        page_start=1,
+        page_end=2,
+    )
+    b = _clause(
+        "d1:b",
+        content_lines=("b1", "b2", "b3"),
+        content_line_pages=(3, 4, 5),
+        page_start=3,
+        page_end=5,
+    )
+    c = _clause(
+        "d1:c",
+        content_lines=("c1", "c2"),
+        content_line_pages=(6, 7),
+        page_start=6,
+        page_end=7,
+    )
+    return _tree((a, b, c)), a, b, c
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_confirmed_no_op() -> None:
+    tree, a, b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=True,
+        corrected_page_start=None,
+        corrected_page_end=None,
+        split_suggested=False,
+        split_notes="",
+        reasoning="looks right",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].clause_id == "d1:b"
+    assert outcomes[0].applied is False
+    assert outcomes[0].note == "confirmed, no change"
+    assert rasterizer.calls == [(Path("doc.pdf"), "d1", 2, 6)]
+
+    revised = {clause.clause_id: clause for clause in revised_tree.all_clauses}
+    assert revised["d1:b"].content_lines == b.content_lines
+    assert revised["d1:b"].page_start == b.page_start
+    assert revised["d1:b"].page_end == b.page_end
+    assert revised["d1:b"].boundary_source == BoundarySource.VISION_ESCALATED
+    assert revised["d1:a"].boundary_source == BoundarySource.DETERMINISTIC
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_shrink_correction_moves_content_to_next_neighbor() -> None:
+    tree, _a, b, c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=3,
+        corrected_page_end=4,
+        split_suggested=False,
+        split_notes="",
+        reasoning="ends a page earlier than claimed",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert outcomes[0].applied is True
+    assert outcomes[0].note == "corrected page range applied"
+
+    revised = {clause.clause_id: clause for clause in revised_tree.all_clauses}
+    revised_b = revised["d1:b"]
+    assert revised_b.page_start == 3
+    assert revised_b.page_end == 4
+    assert revised_b.content_lines == ("b1", "b2")
+    assert revised_b.content_line_pages == (3, 4)
+
+    revised_c = revised["d1:c"]
+    assert revised_c.content_lines == ("b3", "c1", "c2")
+    assert revised_c.content_line_pages == (5, 6, 7)
+    assert revised_c.page_start == 5
+    assert revised_c.page_end == c.page_end
+    assert revised_c.boundary_source == BoundarySource.VISION_ESCALATED
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_extend_correction_pulls_from_previous_neighbor() -> None:
+    tree, a, _b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=2,
+        corrected_page_end=5,
+        split_suggested=False,
+        split_notes="",
+        reasoning="actually starts a page earlier",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert outcomes[0].applied is True
+
+    revised = {clause.clause_id: clause for clause in revised_tree.all_clauses}
+    revised_b = revised["d1:b"]
+    assert revised_b.page_start == 2
+    assert revised_b.content_lines == ("a2", "b1", "b2", "b3")
+    assert revised_b.content_line_pages == (2, 3, 4, 5)
+
+    revised_a = revised["d1:a"]
+    assert revised_a.content_lines == ("a1",)
+    assert revised_a.content_line_pages == (1,)
+    assert revised_a.page_end == 1
+    assert revised_a.page_start == a.page_start
+    assert revised_a.boundary_source == BoundarySource.VISION_ESCALATED
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_correction_outside_margin_not_applied() -> None:
+    tree, _a, b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=1,
+        corrected_page_end=5,
+        split_suggested=False,
+        split_notes="",
+        reasoning="way outside what was shown",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert outcomes[0].applied is False
+    assert "outside the rasterized margin" in outcomes[0].note
+
+    revised_b = next(
+        clause for clause in revised_tree.all_clauses if clause.clause_id == "d1:b"
+    )
+    assert revised_b.content_lines == b.content_lines
+    assert revised_b.page_start == b.page_start
+    assert revised_b.page_end == b.page_end
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_neighbor_without_page_attribution_not_applied() -> None:
+    a = _clause(
+        "d1:a",
+        content_lines=("a1", "a2"),
+        content_line_pages=(1, 2),
+        page_start=1,
+        page_end=2,
+    )
+    b = _clause(
+        "d1:b",
+        content_lines=("b1", "b2", "b3"),
+        content_line_pages=(3, 4, 5),
+        page_start=3,
+        page_end=5,
+    )
+    # Simulates a pre-[M1-04d] cached clause: content but no per-line pages.
+    c = _clause(
+        "d1:c",
+        content_lines=("c1", "c2"),
+        content_line_pages=(),
+        page_start=6,
+        page_end=7,
+    )
+    tree = _tree((a, b, c))
+    review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=3,
+        corrected_page_end=4,
+        split_suggested=False,
+        split_notes="",
+        reasoning="ends a page earlier than claimed",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert outcomes[0].applied is False
+    assert "per-line page attribution" in outcomes[0].note
+
+    revised_b = next(
+        clause for clause in revised_tree.all_clauses if clause.clause_id == "d1:b"
+    )
+    assert revised_b.content_lines == b.content_lines
+    assert revised_b.boundary_source == BoundarySource.VISION_ESCALATED
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_split_suggestion_is_recorded_not_applied() -> None:
+    tree, _a, b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=True,
+        corrected_page_start=None,
+        corrected_page_end=None,
+        split_suggested=True,
+        split_notes="Looks like two sub-clauses on page 4.",
+        reasoning="boundary ok but content should split",
+    )
+    reviewer = ScriptedReviewer(review)
+    rasterizer = FakeRasterizer()
+
+    revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+    )
+
+    assert outcomes[0].applied is False
+    assert "not auto-applied" in outcomes[0].note
+    assert outcomes[0].review.split_suggested is True
+    assert outcomes[0].review.split_notes == "Looks like two sub-clauses on page 4."
+
+    revised = {clause.clause_id: clause for clause in revised_tree.all_clauses}
+    assert revised["d1:b"].content_lines == b.content_lines
+    assert revised["d1:b"].boundary_source == BoundarySource.VISION_ESCALATED
+    assert revised["d1:a"].boundary_source == BoundarySource.DETERMINISTIC
+    assert revised["d1:c"].boundary_source == BoundarySource.DETERMINISTIC
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_retries_then_succeeds() -> None:
+    tree, _a, _b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=True,
+        corrected_page_start=None,
+        corrected_page_end=None,
+        split_suggested=False,
+        split_notes="",
+        reasoning="ok",
+    )
+    reviewer = CountingReviewer(calls_to_fail=1, review=review)
+    rasterizer = FakeRasterizer()
+    sleeps: list[float] = []
+
+    _revised_tree, outcomes = escalate_boundaries(
+        tree,
+        Path("doc.pdf"),
+        reviewer=reviewer,
+        rasterizer=rasterizer,
+        page_count=10,
+        max_page_span=2,
+        max_char_count=1000,
+        sleep=sleeps.append,
+    )
+
+    assert reviewer.call_count == 2
+    assert sleeps == [5.0]
+    assert outcomes[0].applied is False
+    assert outcomes[0].note == "confirmed, no change"
+
+
+@pytest.mark.unit
+def test_escalate_boundaries_exhausts_retries_and_reraises() -> None:
+    tree, _a, _b, _c = _three_clause_tree()
+    review = BoundaryReview(
+        confirmed=True,
+        corrected_page_start=None,
+        corrected_page_end=None,
+        split_suggested=False,
+        split_notes="",
+        reasoning="ok",
+    )
+    reviewer = CountingReviewer(calls_to_fail=99, review=review)
+    rasterizer = FakeRasterizer()
+    sleeps: list[float] = []
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        escalate_boundaries(
+            tree,
+            Path("doc.pdf"),
+            reviewer=reviewer,
+            rasterizer=rasterizer,
+            page_count=10,
+            max_page_span=2,
+            max_char_count=1000,
+            sleep=sleeps.append,
+        )
+
+    assert reviewer.call_count == 3
+    assert sleeps == [5.0, 5.0]

--- a/tests/unit/application/use_cases/test_clause_segmentation.py
+++ b/tests/unit/application/use_cases/test_clause_segmentation.py
@@ -1502,3 +1502,33 @@ def test_find_oversized_clauses_flags_page_span_and_char_count_outliers() -> Non
     )
 
     assert {c.clause_id for c in oversized} == {"d1:2", "d1:3"}
+
+
+# ---------------------------------------------------------------------------
+# 17. Per-line page attribution (M1-04d)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_content_line_pages_parallels_content_lines_across_a_page_break() -> None:
+    """[M1-04d] needs to know which page each content line came from, to
+    apply a vision-proposed boundary correction without re-running heading
+    detection -- see [application.use_cases.boundary_escalation]."""
+    spans = [
+        _heading_line(1, 0, "1. Riscos Cobertos"),
+        _body_line(1, 1, "Primeira linha de corpo na pagina 1."),
+        _body_line(2, 0, "Segunda linha de corpo na pagina 2."),
+        _body_line(2, 1, "Terceira linha de corpo na pagina 2."),
+    ]
+    document = _document([_page(1, spans[0:2]), _page(2, spans[2:4])])
+
+    tree = segment_document(document)
+
+    clause = _find(tree, "1")
+    assert clause.content_lines == (
+        "Primeira linha de corpo na pagina 1.",
+        "Segunda linha de corpo na pagina 2.",
+        "Terceira linha de corpo na pagina 2.",
+    )
+    assert clause.content_line_pages == (1, 2, 2)
+    assert len(clause.content_line_pages) == len(clause.content_lines)

--- a/tests/unit/infrastructure/config/test_settings.py
+++ b/tests/unit/infrastructure/config/test_settings.py
@@ -43,6 +43,38 @@ def test_llm_api_key_is_redacted_from_repr_and_str() -> None:
 
 
 @pytest.mark.unit
+def test_llm_model_vision_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LLM_MODEL_VISION", raising=False)
+    settings = LlmSettings(
+        LLM_PROVIDER=LlmProvider.OPENAI,
+        LLM_API_KEY=SECRET_VALUE,
+        LLM_MODEL_FAST="gpt-fast",
+        LLM_MODEL_REASONING="gpt-reasoning",
+        EMBEDDING_MODEL="embed-model",
+        RERANKER_MODEL="rerank-model",
+        _env_file=None,
+    )
+
+    assert settings.llm_model_vision is None
+
+
+@pytest.mark.unit
+def test_llm_model_vision_can_be_set() -> None:
+    settings = LlmSettings(
+        LLM_PROVIDER=LlmProvider.OPENAI,
+        LLM_API_KEY=SECRET_VALUE,
+        LLM_MODEL_FAST="gpt-fast",
+        LLM_MODEL_REASONING="gpt-reasoning",
+        LLM_MODEL_VISION="google/gemini-3.7-flash",
+        EMBEDDING_MODEL="embed-model",
+        RERANKER_MODEL="rerank-model",
+        _env_file=None,
+    )
+
+    assert settings.llm_model_vision == "google/gemini-3.7-flash"
+
+
+@pytest.mark.unit
 def test_langfuse_secret_key_is_redacted_from_repr_and_str() -> None:
     settings = ObservabilitySettings(LANGFUSE_SECRET_KEY=SECRET_VALUE)
 

--- a/tests/unit/infrastructure/parsing/test_boundary_escalation_cache.py
+++ b/tests/unit/infrastructure/parsing/test_boundary_escalation_cache.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+
+import pytest
+
+from domain.boundary_escalation import BoundaryReview
+from infrastructure.parsing.boundary_escalation_cache import (
+    CachingBoundaryVisionReviewer,
+)
+
+
+class CountingReviewer:
+    """Mock that records how many times it was actually invoked."""
+
+    def __init__(self, result: BoundaryReview) -> None:
+        self.result = result
+        self.call_count = 0
+
+    def review(
+        self,
+        *,
+        clause_title: str,
+        claimed_page_start: int,
+        claimed_page_end: int,
+        page_images: tuple[bytes, ...],
+    ) -> BoundaryReview:
+        self.call_count += 1
+        return self.result
+
+
+_REVIEW = BoundaryReview(
+    confirmed=True,
+    corrected_page_start=None,
+    corrected_page_end=None,
+    split_suggested=False,
+    split_notes="",
+    reasoning="ok",
+)
+
+
+@pytest.mark.unit
+def test_cache_miss_calls_inner_and_persists(tmp_path: Path) -> None:
+    inner = CountingReviewer(_REVIEW)
+    cache_path = tmp_path / "cache.jsonl"
+    reviewer = CachingBoundaryVisionReviewer(inner, model="m", cache_path=cache_path)
+
+    result = reviewer.review(
+        clause_title="Riscos Excluídos",
+        claimed_page_start=1,
+        claimed_page_end=2,
+        page_images=(b"page-1",),
+    )
+
+    assert result == _REVIEW
+    assert inner.call_count == 1
+    assert cache_path.exists()
+    assert len(cache_path.read_text(encoding="utf-8").strip().splitlines()) == 1
+
+
+@pytest.mark.unit
+def test_cache_hit_skips_inner(tmp_path: Path) -> None:
+    inner = CountingReviewer(_REVIEW)
+    cache_path = tmp_path / "cache.jsonl"
+    reviewer = CachingBoundaryVisionReviewer(inner, model="m", cache_path=cache_path)
+
+    first = reviewer.review(
+        clause_title="Coberturas",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+    second = reviewer.review(
+        clause_title="Coberturas",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    assert first == second == _REVIEW
+    assert inner.call_count == 1
+
+
+@pytest.mark.unit
+def test_cache_persists_across_instances(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    first_inner = CountingReviewer(_REVIEW)
+    CachingBoundaryVisionReviewer(first_inner, model="m", cache_path=cache_path).review(
+        clause_title="Definições",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    other_review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=2,
+        corrected_page_end=3,
+        split_suggested=False,
+        split_notes="",
+        reasoning="different",
+    )
+    second_inner = CountingReviewer(other_review)
+    second = CachingBoundaryVisionReviewer(
+        second_inner, model="m", cache_path=cache_path
+    )
+    result = second.review(
+        clause_title="Definições",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    assert result == _REVIEW
+    assert second_inner.call_count == 0
+
+
+@pytest.mark.unit
+def test_different_model_is_a_separate_cache_key(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    inner_a = CountingReviewer(_REVIEW)
+    CachingBoundaryVisionReviewer(
+        inner_a, model="model-a", cache_path=cache_path
+    ).review(
+        clause_title="Procedimento",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    other_review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=2,
+        corrected_page_end=2,
+        split_suggested=False,
+        split_notes="",
+        reasoning="different",
+    )
+    inner_b = CountingReviewer(other_review)
+    result = CachingBoundaryVisionReviewer(
+        inner_b, model="model-b", cache_path=cache_path
+    ).review(
+        clause_title="Procedimento",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    assert result == other_review
+    assert inner_b.call_count == 1
+
+
+@pytest.mark.unit
+def test_different_page_images_is_a_separate_cache_key(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    inner_a = CountingReviewer(_REVIEW)
+    CachingBoundaryVisionReviewer(inner_a, model="m", cache_path=cache_path).review(
+        clause_title="Procedimento",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1",),
+    )
+
+    other_review = BoundaryReview(
+        confirmed=False,
+        corrected_page_start=2,
+        corrected_page_end=2,
+        split_suggested=False,
+        split_notes="",
+        reasoning="different image",
+    )
+    inner_b = CountingReviewer(other_review)
+    result = CachingBoundaryVisionReviewer(
+        inner_b, model="m", cache_path=cache_path
+    ).review(
+        clause_title="Procedimento",
+        claimed_page_start=1,
+        claimed_page_end=1,
+        page_images=(b"page-1-different-bytes",),
+    )
+
+    assert result == other_review
+    assert inner_b.call_count == 1

--- a/tests/unit/infrastructure/parsing/test_boundary_vision.py
+++ b/tests/unit/infrastructure/parsing/test_boundary_vision.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from typing import Any, cast
+
+import fitz
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from domain.boundary_escalation import BoundaryReview
+from infrastructure.parsing import boundary_vision
+from infrastructure.parsing.boundary_vision import (
+    BoundaryEscalationOutput,
+    LangchainBoundaryVisionReviewer,
+    PyMuPdfPageRasterizer,
+)
+
+
+class _FakeRawMessage:
+    """Stand-in for the AIMessage returned alongside a structured parse."""
+
+    def __init__(self, usage_metadata: dict[str, int] | None) -> None:
+        self.usage_metadata = usage_metadata
+
+
+class FakeChatModel:
+    """Stand-in for a Langchain ``BaseChatModel`` supporting ``include_raw=True``."""
+
+    def __init__(
+        self,
+        parsed: BoundaryEscalationOutput,
+        usage_metadata: dict[str, int] | None = None,
+    ) -> None:
+        self.parsed = parsed
+        self.usage_metadata = usage_metadata
+        self.received_content: list[object] = []
+
+    def with_structured_output(
+        self, schema: type, include_raw: bool = False
+    ) -> Runnable[Any, Any]:
+        def _invoke(messages: Any) -> dict[str, object]:
+            self.received_content.append(messages)
+            return {"parsed": self.parsed, "raw": _FakeRawMessage(self.usage_metadata)}
+
+        return RunnableLambda(_invoke)
+
+
+@pytest.mark.unit
+def test_review_maps_parsed_fields_into_boundary_review() -> None:
+    parsed = BoundaryEscalationOutput(
+        llm_boundary_confirmed=False,
+        llm_corrected_page_start=4,
+        llm_corrected_page_end=6,
+        llm_split_suggested=True,
+        llm_split_notes="split here",
+        llm_reasoning="because",
+    )
+    fake_llm = cast(
+        BaseChatModel, FakeChatModel(parsed, {"input_tokens": 100, "output_tokens": 20})
+    )
+    reviewer = LangchainBoundaryVisionReviewer(fake_llm)
+
+    result = reviewer.review(
+        clause_title="Riscos Excluídos",
+        claimed_page_start=3,
+        claimed_page_end=5,
+        page_images=(b"fake-png-bytes",),
+    )
+
+    assert result == BoundaryReview(
+        confirmed=False,
+        corrected_page_start=4,
+        corrected_page_end=6,
+        split_suggested=True,
+        split_notes="split here",
+        reasoning="because",
+    )
+    assert reviewer.stats.call_count == 1
+    assert reviewer.stats.total_input_tokens == 100
+    assert reviewer.stats.total_output_tokens == 20
+    assert reviewer.stats.total_seconds >= 0.0
+
+
+@pytest.mark.unit
+def test_review_accumulates_stats_across_calls() -> None:
+    parsed = BoundaryEscalationOutput(llm_boundary_confirmed=True, llm_reasoning="ok")
+    fake_llm = cast(
+        BaseChatModel, FakeChatModel(parsed, {"input_tokens": 10, "output_tokens": 5})
+    )
+    reviewer = LangchainBoundaryVisionReviewer(fake_llm)
+
+    reviewer.review(
+        clause_title="A", claimed_page_start=1, claimed_page_end=1, page_images=(b"x",)
+    )
+    reviewer.review(
+        clause_title="B", claimed_page_start=2, claimed_page_end=2, page_images=(b"y",)
+    )
+
+    assert reviewer.stats.call_count == 2
+    assert reviewer.stats.total_input_tokens == 20
+    assert reviewer.stats.total_output_tokens == 10
+
+
+@pytest.mark.unit
+def test_review_tolerates_missing_usage_metadata() -> None:
+    parsed = BoundaryEscalationOutput(llm_boundary_confirmed=True, llm_reasoning="ok")
+    fake_llm = cast(BaseChatModel, FakeChatModel(parsed, usage_metadata=None))
+    reviewer = LangchainBoundaryVisionReviewer(fake_llm)
+
+    reviewer.review(
+        clause_title="A", claimed_page_start=1, claimed_page_end=1, page_images=(b"x",)
+    )
+
+    assert reviewer.stats.call_count == 1
+    assert reviewer.stats.total_input_tokens == 0
+    assert reviewer.stats.total_output_tokens == 0
+
+
+def _make_pdf(tmp_path: Path, page_count: int) -> Path:
+    """Write a minimal real PDF (blank pages), same pattern as test_ocr.py."""
+    document = fitz.open()
+    for _ in range(page_count):
+        document.new_page(width=100.0, height=50.0)
+    path = tmp_path / "synthetic.pdf"
+    document.save(path)
+    document.close()
+    return path
+
+
+@pytest.mark.unit
+def test_rasterize_returns_one_png_per_requested_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        boundary_vision, "BOUNDARY_ESCALATION_PAGE_CACHE_DIR", tmp_path / "cache"
+    )
+    pdf_path = _make_pdf(tmp_path, page_count=4)
+
+    rasterizer = PyMuPdfPageRasterizer(dpi=72)
+    images = rasterizer.rasterize(pdf_path, "doc-1", 2, 3)
+
+    assert len(images) == 2
+    for image_bytes in images:
+        assert image_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.unit
+def test_rasterize_caches_pages_on_disk_and_survives_source_deletion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        boundary_vision, "BOUNDARY_ESCALATION_PAGE_CACHE_DIR", cache_dir
+    )
+    pdf_path = _make_pdf(tmp_path, page_count=1)
+
+    rasterizer = PyMuPdfPageRasterizer(dpi=72)
+    rasterizer.rasterize(pdf_path, "doc-1", 1, 1)
+
+    cached_png = cache_dir / "doc-1" / "page_001.png"
+    assert cached_png.exists()
+
+    pdf_path.unlink()
+    images = rasterizer.rasterize(pdf_path, "doc-1", 1, 1)
+
+    assert len(images) == 1
+    assert images[0] == cached_png.read_bytes()

--- a/tests/unit/infrastructure/parsing/test_clause_schema.py
+++ b/tests/unit/infrastructure/parsing/test_clause_schema.py
@@ -12,7 +12,7 @@ from domain.clause_classification import (
     TypedClause,
     TypeSource,
 )
-from domain.clause_tree import Clause, HeadingConvention
+from domain.clause_tree import BoundarySource, Clause, HeadingConvention
 from infrastructure.parsing.clause_schema import SCHEMA_VERSION, flatten_typed_clause
 
 
@@ -71,6 +71,20 @@ def test_flatten_typed_clause_produces_valid_record() -> None:
     assert record.text == "Texto da cobertura."
     assert record.filing_year == "2019"
     assert record.source == "text"
+    assert record.boundary_source == "deterministic"
+
+
+@pytest.mark.unit
+def test_flatten_typed_clause_propagates_vision_escalated_boundary_source() -> None:
+    typed = _typed_clause()
+    escalated_clause = replace(
+        typed.clause, boundary_source=BoundarySource.VISION_ESCALATED
+    )
+    typed = replace(typed, clause=escalated_clause)
+
+    record = flatten_typed_clause(typed, source="text")
+
+    assert record.boundary_source == "vision_escalated"
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/parsing/test_clause_tree_caching.py
+++ b/tests/unit/infrastructure/parsing/test_clause_tree_caching.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from domain.clause_tree import (
+    BoundarySource,
     Clause,
     ClauseTree,
     ClauseTreeReport,
@@ -51,6 +54,8 @@ def _tree() -> ClauseTree:
         bundle_section=None,
         bundle_confidence=None,
         is_depth_anomaly=False,
+        content_line_pages=(1,),
+        boundary_source=BoundarySource.VISION_ESCALATED,
     )
     child = Clause(
         document_id="17",
@@ -127,3 +132,64 @@ def test_write_then_read_clause_tree_cache_preserves_no_clauses(tmp_path: Path) 
     assert restored.all_clauses == ()
     assert restored.roots == ()
     assert restored.report.clause_count == 0
+
+
+@pytest.mark.unit
+def test_read_clause_tree_cache_defaults_missing_m1_04d_columns(tmp_path: Path) -> None:
+    """A pre-[M1-04d] cached Parquet file has neither column at all -- must
+    still read back with the honest "unknown"/"deterministic" defaults,
+    without forcing a full corpus rebuild."""
+    pre_m1_04d_schema = pa.schema(
+        [
+            ("clause_id", pa.string()),
+            ("path", pa.string()),
+            ("numbering_label", pa.string()),
+            ("title", pa.string()),
+            ("convention", pa.string()),
+            ("depth", pa.int64()),
+            ("parent_id", pa.string()),
+            ("child_ids", pa.string()),
+            ("content_lines", pa.string()),
+            ("page_start", pa.int64()),
+            ("page_end", pa.int64()),
+            ("bundle_section", pa.string()),
+            ("bundle_confidence", pa.string()),
+            ("is_depth_anomaly", pa.bool_()),
+        ]
+    )
+    row = {
+        "clause_id": "9:1",
+        "path": "1",
+        "numbering_label": "1",
+        "title": "1. OBJETO",
+        "convention": HeadingConvention.NUMBERED_DECIMAL.value,
+        "depth": 1,
+        "parent_id": "",
+        "child_ids": "",
+        "content_lines": "Corpo.",
+        "page_start": 1,
+        "page_end": 1,
+        "bundle_section": "",
+        "bundle_confidence": "",
+        "is_depth_anomaly": False,
+    }
+    table = pa.Table.from_pylist([row], schema=pre_m1_04d_schema)
+    table = table.replace_schema_metadata(
+        {
+            "document_id": "9",
+            "filename": "old.pdf",
+            "orphan_char_count": "0",
+            "total_char_count": "6",
+            "orphan_ratio": "0.0",
+            "extraction_mode": "text",
+            "warnings_json": "[]",
+        }
+    )
+    path = tmp_path / "9__old.parquet"
+    pq.write_table(table, path)
+
+    restored = read_clause_tree_cache(path)
+
+    clause = restored.all_clauses[0]
+    assert clause.content_line_pages == ()
+    assert clause.boundary_source == BoundarySource.DETERMINISTIC


### PR DESCRIPTION
## Summary

Adds a narrow, last-resort vision-LLM escalation pass on top of the
deterministic clause-boundary detector. [M1-08b] measured 82.0% boundary
accuracy — up from [M1-08]'s 60.0%, but still short of M1's ≥90% exit bar —
with the remaining gap concentrated in two failure modes the deterministic
detector structurally cannot see (adjacent sub-clauses merging, content
truncating at a page boundary), since it only ever sees extracted text and
font/position metadata, never the rendered page.

This does **not** replace the deterministic pipeline — that trade was
evaluated and rejected in the issue as disproportionate (cost, loss of
`clause_id` determinism, no evidence a vision read beats the calibrated
heuristic on dense Portuguese legal text). Instead, only clauses the
deterministic pass already flags as suspicious (oversized per
`find_oversized_clauses`, OCR-derived, or adjacent to an `UNNUMBERED_PART`
boundary or a `depth_anomaly` warning) get a second, vision-based review.

Key design points:

- A vision-proposed **page-range correction** is applied automatically via a
  bounded, mechanical line reassignment between the flagged clause and its
  immediate document-order neighbor, using a new per-line page attribution
  (`Clause.content_line_pages`) the deterministic pass now records. A
  correction is only trusted if it falls inside the page range actually
  rasterized and shown to the model.
- A vision-proposed **sub-clause split is recorded, never auto-applied** —
  splitting would mint new `clause_id`/`path` values and risk exactly the
  `clause_id` churn [M1-07]'s determinism guarantee exists to prevent. This
  scope call was confirmed with the project owner before implementation.
- Every reviewed clause is stamped `boundary_source` (`deterministic` /
  `vision_escalated`), mirroring `type_source`'s existing rule/llm split, so
  escalated and non-escalated clauses stay measurable separately downstream.
- The vision pass's own output is cached by a hash of (model, page images,
  deterministic-pass claim), mirroring `CachingClauseClassifier`'s existing
  pattern, so a re-run against unchanged input never reshuffles ids.
- Reuses existing infrastructure end to end: PyMuPDF rasterization (same
  pattern as `ocr.py`/`validate_parsing_quality_sample.py`), the
  `build_chat_model` OpenRouter provider-pinning factory (vision pinned to
  `google/gemini-3.7-flash` via `google-vertex`, no fallback), and the
  3-attempt/5s-sleep retry convention — which **re-raises** on exhaustion
  rather than silently falling back, since a wrongly-"confirmed" boundary
  would be indistinguishable from a real confirmation.
- Ships as an explicit opt-in target, `make escalate-vision-boundaries`,
  **not** folded into `make parse` — the DoD requires measuring the pass's
  actual corpus-wide cost (call count, tokens, estimated $, wall-clock time,
  written to `eval/boundary_escalation_cost_report.json`) before that
  decision is made.

New/changed files: `domain/boundary_escalation.py`,
`application/ports/{page_rasterizer,boundary_vision_reviewer}.py`,
`application/use_cases/boundary_escalation.py`,
`infrastructure/parsing/{boundary_vision,boundary_escalation_cache}.py`,
`scripts/escalate_vision_boundaries.py`, plus backward-compatible additions
to `domain/clause_tree.py`, `clause_segmentation.py`, `clause_tree_caching.py`,
`clause_schema.py`, `settings.py`, `Makefile`, `.env.example`.

## Related issue

[M1-04d]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) —
      new unit suites for suspicion-flagging, boundary correction/rejection
      paths, retry/re-raise behavior, the vision reviewer and its cache
      (all against fakes/mocks — no live LLM calls), plus backward-
      compatibility coverage for pre-existing cached clause trees.
- [ ] Docs updated (`README.md`, `docs/`, or other affected doc) — not
      needed for this issue: `docs/PARSING.md` is explicitly out of scope
      here per the DoD (a fresh measurement over this pass is [M1-08c]'s
      job, not this PR's).
- [x] Evaluation impact considered — does this change affect parsing,
      retrieval, or evaluation numbers? If so, note it here — no default
      impact: the pass is opt-in (`make escalate-vision-boundaries`) and
      not part of `make parse`, so the existing corpus/build output is
      unchanged unless someone runs it explicitly. When run, it can revise
      cached clause trees in place (`data/cache/clause_trees/`) for the
      documents processed.
- [x] `make check` passes locally