### PR TITLE
Dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration check extract-text remove-boilerplate build-clause-tree parse sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries
+.PHONY: install lint format format-check typecheck test test-integration check extract-text remove-boilerplate build-clause-tree parse sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts
 
 help:
 	@echo "Available targets:"
@@ -20,6 +20,8 @@ help:
 	@echo "  validate-parsing-quality-sample - Automated LLM validation of the M1-08b sample (fills judgment columns)"
 	@echo "  score-parsing-quality  - Score the annotated M1-08 sample and write eval/parsing_quality_results.md"
 	@echo "  escalate-vision-boundaries - M1-04d: vision-LLM boundary review of suspicious clauses (opt-in, not part of parse)"
+	@echo "  fetch-corpus-artifacts - Download the pre-computed corpus/LLM caches instead of running make parse"
+	@echo "  package-corpus-artifacts - Maintainer-only: build the release tarball fetch-corpus-artifacts downloads"
 
 install:
 	uv sync
@@ -67,3 +69,9 @@ score-parsing-quality:
 
 escalate-vision-boundaries:
 	PYTHONPATH=app/src uv run python scripts/escalate_vision_boundaries.py
+
+fetch-corpus-artifacts:
+	PYTHONPATH=app/src uv run python scripts/fetch_corpus_artifacts.py
+
+package-corpus-artifacts:
+	PYTHONPATH=app/src uv run python scripts/package_corpus_artifacts.py

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ inconsistent with the conditions of a registered insurance product — it
 cannot say whether a real claim is covered or denied. See
 [`docs/SCOPE.md`](docs/SCOPE.md) for the full statement.
 
+## Fast start: inspect the parsed corpus without running the pipeline
+
+The full M1 parsing pipeline (OCR, LLM clause classification, the vision-LLM
+boundary-escalation pass, LLM validation) costs real tokens and real
+wall-clock time. If you just want to inspect the already-published result —
+the finished 4,925-clause corpus and the LLM caches behind it — run this
+instead of `make parse`:
+
+```bash
+make fetch-corpus-artifacts
+```
+
+This downloads a small (~10MB) release asset and needs no `.env`/LLM
+credentials. See [`docs/PARSING.md`](docs/PARSING.md) for the published
+accuracy numbers this corpus was measured against. Note: if you later run
+`make parse` locally anyway, `git status`/`git diff` on `build/manifest.json`
+will show a one-line difference on the `built_at_utc` timestamp field only —
+everything else reproduces byte-identical.
+
 ## Development Commands
 
 ### System dependencies

--- a/scripts/fetch_corpus_artifacts.py
+++ b/scripts/fetch_corpus_artifacts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Fetch the pre-computed M1 corpus artifacts from GitHub Releases.
+
+Running the full parsing pipeline (OCR, LLM clause classification, the
+vision-LLM boundary-escalation pass, LLM validation) costs real tokens and
+real wall-clock time -- on the order of hours for the escalation pass alone
+(see ``docs/PARSING.md``'s "Known limitations"). Anyone who only wants to
+inspect the already-published result should not have to pay that cost.
+
+This script downloads a single release asset -- a tarball of the four
+LLM-cost-bearing artifacts (the finished corpus under ``build/``, the two
+LLM classification/escalation caches, and the validation judgment JSONs
+under ``eval/temp/sample_validations/``) -- verifies its checksum, and
+extracts it on top of the existing (gitignored) directory structure. It
+never touches ``data/policies/raw/`` or anything already committed to git,
+and it needs no ``.env``/LLM credentials -- this is a plain download.
+
+Large-but-cheap-to-regenerate caches (rasterized page images, ~312MB
+combined) are intentionally not part of this bundle: they carry no LLM cost
+and reconstruct deterministically from the already-committed PDFs, so
+shipping them would just be dead weight. Run `make parse` /
+`make escalate-vision-boundaries` / `make validate-parsing-quality-sample`
+if you need those instead.
+
+Run via `make fetch-corpus-artifacts`. See `scripts/package_corpus_artifacts.py`
+for the maintainer-side counterpart that produces the release assets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_REPO = "wrlxavier/insurance-claims-multiagent-rag"
+
+# Pinned, not "latest" -- a given commit should always resolve to the exact
+# artifacts it was built and verified against. Bump this when publishing a
+# new version via `make package-corpus-artifacts` plus a new GitHub Release,
+# per that script's docstring.
+ARTIFACTS_RELEASE_TAG = "m1-artifacts-v1"
+
+ARCHIVE_ASSET_NAME = "corpus-artifacts.tar.gz"
+CHECKSUM_ASSET_NAME = "corpus-artifacts.sha256"
+
+RELEASE_BASE_URL = (
+    f"https://github.com/{GITHUB_REPO}/releases/download/{ARTIFACTS_RELEASE_TAG}"
+)
+
+DOWNLOAD_TIMEOUT_SECONDS = 60
+EXTRACT_ROOT = Path(".")
+
+
+def download_file(url: str, dest: Path) -> None:
+    """Download `url` to `dest`, creating parent directories as needed."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(  # noqa: S310 -- fixed https:// GitHub Releases URL
+            url, timeout=DOWNLOAD_TIMEOUT_SECONDS
+        ) as response:
+            dest.write_bytes(response.read())
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"Failed to download {url} ({exc.code} {exc.reason}). "
+            f"Has release `{ARTIFACTS_RELEASE_TAG}` been published on "
+            f"github.com/{GITHUB_REPO}/releases?"
+        ) from exc
+
+
+def read_expected_checksum(checksum_path: Path) -> str:
+    """Parse a `sha256sum`-format file (`<hex digest>  <filename>`)."""
+    content = checksum_path.read_text(encoding="utf-8").strip()
+    digest, _, _name = content.partition(" ")
+    if len(digest) != 64:
+        raise ValueError(f"Malformed checksum file {checksum_path}: {content!r}")
+    return digest
+
+
+def verify_checksum(archive_path: Path, expected_sha256: str) -> None:
+    """Raise ValueError if `archive_path`'s SHA-256 does not match `expected_sha256`."""
+    actual = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if actual != expected_sha256:
+        raise ValueError(
+            f"Checksum mismatch for {archive_path}: expected {expected_sha256}, "
+            f"got {actual}. The download may be corrupted or incomplete -- try again."
+        )
+
+
+def extract_archive(archive_path: Path, dest_dir: Path) -> list[str]:
+    """Extract `archive_path` into `dest_dir`. Returns the extracted member names."""
+    with tarfile.open(archive_path, "r:gz") as archive:
+        archive.extractall(dest_dir, filter="data")
+        return archive.getnames()
+
+
+def main() -> None:
+    """Download, verify and extract the pinned corpus-artifacts release."""
+    archive_url = f"{RELEASE_BASE_URL}/{ARCHIVE_ASSET_NAME}"
+    checksum_url = f"{RELEASE_BASE_URL}/{CHECKSUM_ASSET_NAME}"
+
+    with tempfile.TemporaryDirectory(prefix="corpus-artifacts-") as tmp:
+        tmp_dir = Path(tmp)
+        archive_path = tmp_dir / ARCHIVE_ASSET_NAME
+        checksum_path = tmp_dir / CHECKSUM_ASSET_NAME
+
+        print(f"Downloading {checksum_url} ...")
+        download_file(checksum_url, checksum_path)
+        expected_sha256 = read_expected_checksum(checksum_path)
+
+        print(f"Downloading {archive_url} ...")
+        download_file(archive_url, archive_path)
+
+        print("Verifying checksum ...")
+        verify_checksum(archive_path, expected_sha256)
+
+        print(f"Extracting into {EXTRACT_ROOT.resolve()} ...")
+        members = extract_archive(archive_path, EXTRACT_ROOT)
+
+    print(f"Fetched {ARTIFACTS_RELEASE_TAG}: wrote {len(members)} files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package_corpus_artifacts.py
+++ b/scripts/package_corpus_artifacts.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Package the LLM-cost-bearing corpus artifacts for a GitHub Release.
+
+Maintainer-only. Bundles the four paths `scripts/fetch_corpus_artifacts.py`
+knows how to unpack -- `build/`, the two LLM-classification/boundary-
+escalation caches, and the validation judgment JSONs -- into a single
+tarball plus a SHA-256 checksum file under `dist/` (already gitignored,
+Python packaging boilerplate), ready to attach to a GitHub Release.
+
+After running this:
+
+1. Publish both files, e.g. `gh release create <tag>
+   dist/corpus-artifacts.tar.gz dist/corpus-artifacts.sha256 --title "<title>"
+   --notes "<notes>"` (or the GitHub web UI).
+2. Bump `ARTIFACTS_RELEASE_TAG` in `scripts/fetch_corpus_artifacts.py` to
+   `<tag>` and commit.
+
+Run via `make package-corpus-artifacts`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+from pathlib import Path
+
+OUTPUT_DIR = Path("dist")
+ARCHIVE_PATH = OUTPUT_DIR / "corpus-artifacts.tar.gz"
+CHECKSUM_PATH = OUTPUT_DIR / "corpus-artifacts.sha256"
+
+# Kept in sync with fetch_corpus_artifacts.py's module docstring -- what one
+# script packs, the other must unpack.
+SOURCE_PATHS = (
+    Path("build"),
+    Path("data/cache/llm_classification/cache.jsonl"),
+    Path("data/cache/boundary_escalation/cache.jsonl"),
+    Path("eval/temp/sample_validations"),
+)
+
+
+def build_archive(source_paths: tuple[Path, ...], archive_path: Path) -> None:
+    """Tar+gzip every path in `source_paths`, preserving their relative layout."""
+    missing = [path for path in source_paths if not path.exists()]
+    if missing:
+        joined_missing = ", ".join(str(path) for path in missing)
+        raise FileNotFoundError(
+            f"Missing source path(s): {joined_missing}. Run `make parse`, "
+            "`make escalate-vision-boundaries` and "
+            "`make validate-parsing-quality-sample` first."
+        )
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "w:gz") as archive:
+        for path in source_paths:
+            archive.add(path, arcname=str(path))
+
+
+def write_checksum(archive_path: Path, checksum_path: Path) -> None:
+    """Write a `sha256sum`-format checksum file for `archive_path`."""
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    checksum_path.write_text(f"{digest}  {archive_path.name}\n", encoding="utf-8")
+
+
+def main() -> None:
+    """Build the release tarball and its checksum under dist/."""
+    build_archive(SOURCE_PATHS, ARCHIVE_PATH)
+    write_checksum(ARCHIVE_PATH, CHECKSUM_PATH)
+    size_mb = ARCHIVE_PATH.stat().st_size / 1_000_000
+    print(f"Wrote {ARCHIVE_PATH} ({size_mb:.1f}MB) and {CHECKSUM_PATH}.")
+    print(
+        "Publish both to a GitHub Release, e.g.:\n"
+        f"  gh release create <tag> {ARCHIVE_PATH} {CHECKSUM_PATH} "
+        '--title "<title>" --notes "<notes>"\n'
+        "then bump ARTIFACTS_RELEASE_TAG in scripts/fetch_corpus_artifacts.py."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_fetch_corpus_artifacts.py
+++ b/tests/unit/scripts/test_fetch_corpus_artifacts.py
@@ -1,0 +1,106 @@
+"""Tests for the corpus-artifacts fetch script."""
+
+import hashlib
+import tarfile
+import urllib.request
+from pathlib import Path
+
+import pytest
+from scripts.fetch_corpus_artifacts import (
+    download_file,
+    extract_archive,
+    read_expected_checksum,
+    verify_checksum,
+)
+
+
+@pytest.mark.unit
+def test_read_expected_checksum_parses_sha256sum_format(tmp_path: Path) -> None:
+    checksum_path = tmp_path / "corpus-artifacts.sha256"
+    digest = "a" * 64
+    checksum_path.write_text(f"{digest}  corpus-artifacts.tar.gz\n", encoding="utf-8")
+
+    assert read_expected_checksum(checksum_path) == digest
+
+
+@pytest.mark.unit
+def test_read_expected_checksum_rejects_malformed_content(tmp_path: Path) -> None:
+    checksum_path = tmp_path / "corpus-artifacts.sha256"
+    checksum_path.write_text("not-a-valid-digest\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Malformed checksum file"):
+        read_expected_checksum(checksum_path)
+
+
+@pytest.mark.unit
+def test_verify_checksum_passes_for_matching_digest(tmp_path: Path) -> None:
+    archive_path = tmp_path / "archive.tar.gz"
+    archive_path.write_bytes(b"some archive bytes")
+    expected = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+
+    verify_checksum(archive_path, expected)
+
+
+@pytest.mark.unit
+def test_verify_checksum_raises_on_mismatch(tmp_path: Path) -> None:
+    archive_path = tmp_path / "archive.tar.gz"
+    archive_path.write_bytes(b"some archive bytes")
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        verify_checksum(archive_path, "0" * 64)
+
+
+@pytest.mark.unit
+def test_extract_archive_writes_files_preserving_relative_layout(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "source"
+    (source_dir / "build").mkdir(parents=True)
+    (source_dir / "build" / "manifest.json").write_text("{}", encoding="utf-8")
+    cache_dir = source_dir / "data" / "cache" / "llm_classification"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "cache.jsonl").write_text('{"key": "value"}\n', encoding="utf-8")
+
+    archive_path = tmp_path / "archive.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(source_dir / "build", arcname="build")
+        archive.add(
+            cache_dir / "cache.jsonl",
+            arcname="data/cache/llm_classification/cache.jsonl",
+        )
+
+    dest_dir = tmp_path / "dest"
+    members = extract_archive(archive_path, dest_dir)
+
+    assert (dest_dir / "build" / "manifest.json").read_text(encoding="utf-8") == "{}"
+    assert (
+        dest_dir / "data" / "cache" / "llm_classification" / "cache.jsonl"
+    ).read_text(encoding="utf-8") == '{"key": "value"}\n'
+    assert "build/manifest.json" in members
+    assert "data/cache/llm_classification/cache.jsonl" in members
+
+
+@pytest.mark.unit
+def test_download_file_writes_response_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _FakeResponse:
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"fake bytes"
+
+    def _fake_urlopen(url: str, timeout: float | None = None) -> _FakeResponse:
+        assert url == "https://example.com/file"
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    dest = tmp_path / "nested" / "file.bin"
+    download_file("https://example.com/file", dest)
+
+    assert dest.read_bytes() == b"fake bytes"

--- a/tests/unit/scripts/test_package_corpus_artifacts.py
+++ b/tests/unit/scripts/test_package_corpus_artifacts.py
@@ -1,0 +1,59 @@
+"""Tests for the corpus-artifacts packaging script."""
+
+from pathlib import Path
+
+import pytest
+from scripts.fetch_corpus_artifacts import (
+    extract_archive,
+    read_expected_checksum,
+    verify_checksum,
+)
+from scripts.package_corpus_artifacts import build_archive, write_checksum
+
+
+@pytest.mark.unit
+def test_build_archive_raises_on_missing_source_path(tmp_path: Path) -> None:
+    missing = tmp_path / "build"
+
+    with pytest.raises(FileNotFoundError, match="Missing source path"):
+        build_archive((missing,), tmp_path / "archive.tar.gz")
+
+
+@pytest.mark.unit
+def test_build_archive_and_checksum_round_trip_through_fetch_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What package_corpus_artifacts packs, fetch_corpus_artifacts must unpack.
+
+    ``build_archive`` uses each source path's own string form as the tar
+    arcname, so -- matching real usage, where the script always runs from
+    the repo root with relative ``SOURCE_PATHS`` -- this test runs from a
+    working directory of ``tmp_path`` with relative paths, not absolute ones.
+    """
+    monkeypatch.chdir(tmp_path)
+    build_dir = Path("build")
+    build_dir.mkdir()
+    (build_dir / "manifest.json").write_text(
+        '{"total_clause_count": 4925}', encoding="utf-8"
+    )
+    cache_file = Path("cache.jsonl")
+    cache_file.write_text('{"key": "value"}\n', encoding="utf-8")
+
+    archive_path = Path("dist") / "corpus-artifacts.tar.gz"
+    checksum_path = Path("dist") / "corpus-artifacts.sha256"
+    build_archive((build_dir, cache_file), archive_path)
+    write_checksum(archive_path, checksum_path)
+
+    expected_sha256 = read_expected_checksum(checksum_path)
+    verify_checksum(archive_path, expected_sha256)  # does not raise
+
+    dest_dir = Path("dest")
+    members = extract_archive(archive_path, dest_dir)
+
+    assert (dest_dir / "build" / "manifest.json").read_text(
+        encoding="utf-8"
+    ) == '{"total_clause_count": 4925}'
+    assert (dest_dir / "cache.jsonl").read_text(
+        encoding="utf-8"
+    ) == '{"key": "value"}\n'
+    assert "build/manifest.json" in members


### PR DESCRIPTION
## Summary

  Running the full M1 pipeline (OCR, LLM clause classification, the vision-LLM boundary-escalation pass, LLM validation) costs real tokens and real wall-clock time — hours, for the escalation pass alone. Anyone cloning this repo to review the parsing result (a technical reviewer, in particular — this is a portfolio project) shouldn't have to pay that cost just to inspect what's already measured and published in `docs/PARSING.md`.

  - `scripts/package_corpus_artifacts.py` (maintainer-only): bundles the four LLM-cost-bearing artifacts — `build/` (the finished corpus), the two LLM classification/boundary-escalation caches, and the validation judgment JSONs under `eval/temp/sample_validations/` — into `dist/corpus-artifacts.tar.gz` plus a `.sha256` checksum. Large-but-cheap-to-regenerate caches (rasterized page images, ~312MB) are deliberately excluded — they carry no LLM cost and reconstruct deterministically from the already-committed PDFs.
  - `scripts/fetch_corpus_artifacts.py`: downloads that tarball + checksum from a pinned GitHub Release tag (`m1-artifacts-v1`, not "latest" — so a given commit always resolves to the artifacts it was actually verified against), verifies the SHA-256, and extracts on top of the existing gitignored directory structure. Plain HTTPS, no `gh` CLI dependency, no `.env`/LLM credentials needed.
  - `make fetch-corpus-artifacts` / `make package-corpus-artifacts`, wired into `make help`.
  - README "Fast start" section documenting the one-command path.
  - No `.gitignore` changes — `dist/` is already covered by the standard Python-packaging ignore rule, and downloads land in a real temp directory outside the repo.

  **Verified locally**: ran `package_corpus_artifacts.py` for real against the current corpus — produced a 3.5MB tarball (compressed from ~10.4MB raw) — then fed it back through `fetch_corpus_artifacts.py`'s own verification/extraction functions and confirmed the manifest, all 50 validation JSONs, and the byte-exact LLM classification cache round-tripped correctly. The actual GitHub Release (`m1-artifacts-v1`) has not been published yet — that's a manual follow-up step after this merges, since it needs to run under my own GitHub credentials.

  ## Related issue

  Closes the standalone issue "Ship pre-processed M1 corpus artifacts via GitHub Releases" (not part of a milestone).

  ## Checklist

  - [x] Tests added/updated for the change (or explained why not needed) — `tests/unit/scripts/test_fetch_corpus_artifacts.py` and `test_package_corpus_artifacts.py`, including a pack→fetch round-trip test; 228 tests passing
  - [x] Docs updated (`README.md`, `docs/`, or other affected doc) — new "Fast start" section
  - [x] Evaluation impact considered — does this change affect parsing, retrieval, or evaluation numbers? If so, note it here — none; this only packages/distributes already-published artifacts, no pipeline logic touched
  - [x] `make check` passes locally
  EOF)
## Summary

Running the full M1 pipeline (OCR, LLM clause classification, the vision-LLM boundary-escalation pass, LLM validation) costs real tokens and real wall-clock time — hours, for the escalation pass alone. Anyone cloning this repo to review the parsing result (a technical reviewer, in particular — this is a portfolio project) shouldn't have to pay that cost just to inspect what's already measured and published in `docs/PARSING.md`.

- `script
- `scripts/fetch_corpus_artifacts.py`: downloads that tarball + checksum from a pinned GitHub Release tag (`m1-artifacts-v1`, not "latest" — so a given commit always resolves to the artifacts it was actually verified against), verifies the SHA-256, and extracts on top of the existing gitignored directory structure. Plain HTTPS, no `gh` CLI dependency, no `.env`/LLM credentials needed.
- `make fetch-corpus-artifacts` / `make package-corpus-artifacts`, wired into `make help`.
- README "Fast start" section documenting the one-command path.
- No `.gitignore` changes — `dist/` is already covered by the standard Python-packaging ignore rule, and downloads land in a real temp directory outside the repo.

**Verified locally**: ran `package_corpus_artifacts.py` for real against the current corpus — produced a 3.5MB tarball (compressed from ~10.4MB raw) — then fed it back through `fetch_corpus_artifacts.py`'s own verification/extraction functions and confirmed the manifest, all 50 validation JSONs, and the byte-exact LLM classification cache round-tripped correctly. The actual GitHub Release (`m1-artifacts-v1`) has not been published yet — that's a manual follow-up step after this merges, since it needs to run under my own GitHub credentials.

## Related issue

Closes the standalone issue "Ship pre-processed M1 corpus artifacts via GitHub Releases" (not part of a milestone).

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) — `tests/unit/scripts/test_fetch_corpus_artifacts.py` and `test_package_corpus_artifacts.py`, including a pack→fetch round-trip test; 228 tests passing
- [x] Docs updated (`README.md`, `docs/`, or other affected doc) — new "Fast start" section
- [x] Evaluation impact considered — does this change affect parsing, retrieval, or evaluation numbers? If so, note it here — none; this only packages/distributes already-published artifacts, no pipeline logic touched
- [x] `make check` passes locally