### PR TITLE
feat(evaluation): add deterministic candidate-clause search script fo…

### DIFF
--- a/scripts/find_candidate_clauses.py
+++ b/scripts/find_candidate_clauses.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+r"""Deterministic candidate-clause search for golden-set curation [M2-08].
+
+Supports the author's completeness check in [M2-01]'s three-layer authoring
+flow (see ``docs/EVALUATION.md``): given a ``clause_id``, print a short list
+of *structurally* related clauses in the same document that a human should
+look at when deciding whether a golden question's ``reference_clause_ids``
+is complete. This is conceptually an early, reduced version of [M3-06]'s
+exclusion co-retrieval, brought forward as a curation tool before it exists
+as part of the product.
+
+Purely structural/deterministic -- no LLM call, no content judgment. Three
+signals, computed against clauses in the same document, merged per candidate
+when more than one applies:
+
+- shared ``parent_id`` with the query clause (siblings in the M1 clause tree)
+- matching ``bundle_section``
+- a textual cross-reference ("cláusula N[.M...]") in the query clause's body
+  that points at the candidate's numbering (its ``path``'s last segment)
+
+Candidates are sorted by number of matching signals (most first), then by
+``clause_id``, and capped at ``--max-candidates`` (default 10).
+
+IMPORTANT: an empty candidate list does NOT mean no related clause exists.
+This script only surfaces structural signals already present in the M1
+clause tree -- it never decides relevance and cannot see relationships it
+has no structural signal for. Checking for that false negative remains the
+author's responsibility as part of [M2-01]'s completeness check, not this
+script's.
+
+Reads ``build/parsed_clauses.jsonl`` (run `make fetch-corpus-artifacts` or
+`make parse` first if missing). Run directly:
+
+    PYTHONPATH=app/src uv run python scripts/find_candidate_clauses.py \\
+        --clause-id "<clause_id>"
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import JSONL_PATH, read_parsed_clauses_jsonl
+
+DEFAULT_MAX_CANDIDATES = 10
+
+_CROSS_REFERENCE_PATTERN = re.compile(r"cl[áa]usulas?\s+(\d+(?:\.\d+)*)", re.IGNORECASE)
+
+
+class ClauseNotFoundError(Exception):
+    """Raised when the requested clause_id isn't in the parsed corpus."""
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One candidate clause, with the structural signal(s) that matched it."""
+
+    clause_id: str
+    title: str
+    reasons: tuple[str, ...]
+
+
+def load_corpus() -> list[ParsedClauseRecord]:
+    """Load the parsed corpus, failing loudly if `make parse` hasn't run."""
+    if not JSONL_PATH.exists():
+        raise FileNotFoundError(
+            f"{JSONL_PATH} does not exist. Run `make fetch-corpus-artifacts` "
+            "(pre-built corpus) or `make parse` (full rebuild) first."
+        )
+    return read_parsed_clauses_jsonl(JSONL_PATH)
+
+
+def find_clause(
+    records: list[ParsedClauseRecord], clause_id: str
+) -> ParsedClauseRecord:
+    """Return the record matching `clause_id`, or raise ClauseNotFoundError."""
+    for record in records:
+        if record.clause_id == clause_id:
+            return record
+    raise ClauseNotFoundError(f"clause_id {clause_id!r} not found in {JSONL_PATH}")
+
+
+def extract_cross_references(text: str) -> set[str]:
+    """Return the numbering tokens textually referenced in `text`.
+
+    Reduced-scope version of the cross-reference detection [M3-06] will
+    later formalise for production co-retrieval: matches "cláusula 12",
+    "Cláusula 4.2", etc. and returns the bare numbering ("12", "4.2").
+    """
+    return {match.group(1) for match in _CROSS_REFERENCE_PATTERN.finditer(text)}
+
+
+def find_candidates(
+    records: list[ParsedClauseRecord],
+    clause_id: str,
+    *,
+    max_candidates: int = DEFAULT_MAX_CANDIDATES,
+) -> list[Candidate]:
+    """Return up to `max_candidates` structurally-related clauses for `clause_id`.
+
+    See the module docstring for the three signals and their semantics. This
+    is a short list to *look at*, not a verdict.
+    """
+    target = find_clause(records, clause_id)
+    referenced_numbers = extract_cross_references(target.text)
+
+    reasons_by_id: dict[str, list[str]] = {}
+    titles_by_id: dict[str, str] = {}
+
+    for record in records:
+        if (
+            record.document_id != target.document_id
+            or record.clause_id == target.clause_id
+        ):
+            continue
+        reasons: list[str] = []
+        if target.parent_id is not None and record.parent_id == target.parent_id:
+            reasons.append("shared_parent")
+        if (
+            target.bundle_section is not None
+            and record.bundle_section == target.bundle_section
+        ):
+            reasons.append("matching_bundle_section")
+        numbering = record.path.rsplit("/", 1)[-1]
+        if numbering in referenced_numbers:
+            reasons.append(f"cross_reference:{numbering}")
+        if reasons:
+            reasons_by_id[record.clause_id] = reasons
+            titles_by_id[record.clause_id] = record.title
+
+    candidates = [
+        Candidate(clause_id=cid, title=titles_by_id[cid], reasons=tuple(reasons))
+        for cid, reasons in reasons_by_id.items()
+    ]
+    candidates.sort(key=lambda c: (-len(c.reasons), c.clause_id))
+    return candidates[:max_candidates]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clause-id",
+        required=True,
+        help="Query clause_id to find candidates for, e.g. '1:.../7'.",
+    )
+    parser.add_argument(
+        "--max-candidates",
+        type=int,
+        default=DEFAULT_MAX_CANDIDATES,
+        help=f"Cap on candidates returned (default {DEFAULT_MAX_CANDIDATES}).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Look up candidates for --clause-id and print them."""
+    args = _parse_args()
+    records = load_corpus()
+    candidates = find_candidates(
+        records, args.clause_id, max_candidates=args.max_candidates
+    )
+
+    if not candidates:
+        print(f"No structural candidates found for {args.clause_id!r}.")
+        print(
+            "This does NOT mean no related clause exists -- checking for that "
+            "false negative is the author's responsibility, not this script's."
+        )
+        return
+
+    print(f"Candidates for {args.clause_id!r} ({len(candidates)}):")
+    for candidate in candidates:
+        reasons = ", ".join(candidate.reasons)
+        print(f"  {candidate.clause_id}  [{reasons}]  {candidate.title}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_find_candidate_clauses.py
+++ b/tests/unit/scripts/test_find_candidate_clauses.py
@@ -1,0 +1,211 @@
+"""Tests for the deterministic candidate-clause search script."""
+
+import pytest
+from scripts.find_candidate_clauses import (
+    ClauseNotFoundError,
+    extract_cross_references,
+    find_candidates,
+)
+
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+
+
+def make_record(**overrides: object) -> ParsedClauseRecord:
+    """Build a valid ParsedClauseRecord, overridable per test."""
+    fields: dict[str, object] = {
+        "schema_version": "v1",
+        "clause_id": "1:cond-gerais/7",
+        "document_id": "1",
+        "parent_id": "1:cond-gerais",
+        "path": "cond-gerais/7",
+        "title": "7. INFORMAÇÕES PRESTADAS NO MOMENTO DA CONTRATAÇÃO",
+        "text": "conforme Cláusula 12 – Perda de Direitos, alínea a",
+        "clause_type": "other",
+        "type_source": "rule",
+        "confidence": None,
+        "bundle_section": "CONDIÇÕES CONTRATUAIS GERAIS",
+        "page_start": 1,
+        "page_end": 1,
+        "source": "text",
+        "boundary_source": None,
+        "susep_process": "123",
+        "insurer": "Porto Seguro",
+        "cnpj": "00.000.000/0001-00",
+        "product_line": "auto",
+        "indemnity_regime": "indenização",
+        "filing_year": "2024",
+    }
+    fields.update(overrides)
+    return ParsedClauseRecord.model_validate(fields)
+
+
+@pytest.mark.unit
+def test_extract_cross_references_finds_number() -> None:
+    assert extract_cross_references("conforme Cláusula 12 – Perda de Direitos") == {
+        "12"
+    }
+
+
+@pytest.mark.unit
+def test_extract_cross_references_finds_decimal_number() -> None:
+    assert extract_cross_references("ver cláusula 4.2 acima") == {"4.2"}
+
+
+@pytest.mark.unit
+def test_extract_cross_references_no_match_returns_empty_set() -> None:
+    assert extract_cross_references("nenhuma referência aqui") == set()
+
+
+@pytest.mark.unit
+def test_find_candidates_matches_shared_parent() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7", parent_id="1:cond-gerais", text=""
+    )
+    sibling = make_record(
+        clause_id="1:cond-gerais/8",
+        path="cond-gerais/8",
+        parent_id="1:cond-gerais",
+        bundle_section="OUTRA SEÇÃO",
+        title="8. OUTRA",
+    )
+    candidates = find_candidates([target, sibling], target.clause_id)
+    assert [c.clause_id for c in candidates] == ["1:cond-gerais/8"]
+    assert candidates[0].reasons == ("shared_parent",)
+
+
+@pytest.mark.unit
+def test_find_candidates_matches_bundle_section() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7",
+        parent_id="1:cond-gerais",
+        bundle_section="SEÇÃO A",
+        text="",
+    )
+    other = make_record(
+        clause_id="1:cond-gerais/9",
+        path="cond-gerais/9",
+        parent_id="1:cond-gerais/other",
+        bundle_section="SEÇÃO A",
+        title="9. OUTRA",
+    )
+    candidates = find_candidates([target, other], target.clause_id)
+    assert [c.clause_id for c in candidates] == ["1:cond-gerais/9"]
+    assert candidates[0].reasons == ("matching_bundle_section",)
+
+
+@pytest.mark.unit
+def test_find_candidates_matches_textual_cross_reference() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7",
+        parent_id="1:cond-gerais",
+        bundle_section="SEÇÃO A",
+        text="conforme Cláusula 12 – Perda de Direitos",
+    )
+    referenced = make_record(
+        clause_id="1:cond-gerais/12",
+        path="cond-gerais/12",
+        parent_id="1:cond-gerais/other",
+        bundle_section="OUTRA SEÇÃO",
+        title="12. PERDA DE DIREITOS",
+    )
+    candidates = find_candidates([target, referenced], target.clause_id)
+    assert [c.clause_id for c in candidates] == ["1:cond-gerais/12"]
+    assert candidates[0].reasons == ("cross_reference:12",)
+
+
+@pytest.mark.unit
+def test_find_candidates_merges_reasons_and_sorts_first() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7",
+        parent_id="1:cond-gerais",
+        bundle_section="SEÇÃO A",
+        text="conforme Cláusula 8",
+    )
+    multi_signal = make_record(
+        clause_id="1:cond-gerais/8",
+        path="cond-gerais/8",
+        parent_id="1:cond-gerais",
+        bundle_section="OUTRA SEÇÃO",
+        title="8. OUTRA",
+    )
+    single_signal = make_record(
+        clause_id="1:cond-gerais/9",
+        path="cond-gerais/9",
+        parent_id="1:cond-gerais",
+        bundle_section="OUTRA SEÇÃO",
+        title="9. OUTRA",
+    )
+    candidates = find_candidates(
+        [target, multi_signal, single_signal], target.clause_id
+    )
+    assert [c.clause_id for c in candidates] == ["1:cond-gerais/8", "1:cond-gerais/9"]
+    assert set(candidates[0].reasons) == {"shared_parent", "cross_reference:8"}
+
+
+@pytest.mark.unit
+def test_find_candidates_excludes_other_documents() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7", parent_id="1:cond-gerais", text=""
+    )
+    other_doc = make_record(
+        clause_id="2:cond-gerais/8",
+        document_id="2",
+        path="cond-gerais/8",
+        parent_id="1:cond-gerais",
+        title="8. OUTRA",
+    )
+    assert find_candidates([target, other_doc], target.clause_id) == []
+
+
+@pytest.mark.unit
+def test_find_candidates_excludes_query_clause_itself() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7", parent_id="1:cond-gerais", text=""
+    )
+    assert find_candidates([target], target.clause_id) == []
+
+
+@pytest.mark.unit
+def test_find_candidates_respects_max_candidates() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7", parent_id="1:cond-gerais", text=""
+    )
+    siblings = [
+        make_record(
+            clause_id=f"1:cond-gerais/{i}",
+            path=f"cond-gerais/{i}",
+            parent_id="1:cond-gerais",
+            title=f"{i}. OUTRA",
+        )
+        for i in range(8, 20)
+    ]
+    candidates = find_candidates(
+        [target, *siblings], target.clause_id, max_candidates=3
+    )
+    assert len(candidates) == 3
+    assert [c.clause_id for c in candidates] == sorted(c.clause_id for c in candidates)
+
+
+@pytest.mark.unit
+def test_find_candidates_no_signals_returns_empty_list() -> None:
+    target = make_record(
+        clause_id="1:cond-gerais/7",
+        parent_id="1:cond-gerais",
+        bundle_section="SEÇÃO A",
+        text="",
+    )
+    unrelated = make_record(
+        clause_id="1:cond-gerais/9",
+        path="cond-gerais/9",
+        parent_id="1:cond-gerais/other",
+        bundle_section="OUTRA SEÇÃO",
+        title="9. OUTRA",
+    )
+    assert find_candidates([target, unrelated], target.clause_id) == []
+
+
+@pytest.mark.unit
+def test_find_candidates_raises_for_unknown_clause_id() -> None:
+    target = make_record()
+    with pytest.raises(ClauseNotFoundError, match="not found"):
+        find_candidates([target], "does-not-exist")


### PR DESCRIPTION
## Summary

Adds scripts/find_candidate_clauses.py, a purely deterministic (no-LLM) CLI tool that, given a clause_id, surfaces up to --max-candidates (default 10) structurally related clauses in the same document — via shared parent_id, matching bundle_section, or a textual "cláusula N" cross-reference resolved against the M1 clause tree. It supports (never replaces) the author's completeness check in M2-01's three-layer authoring flow, and previews in reduced scope the cross-reference detection M3-06 will later formalize for production exclusion co-retrieval. Reuses the existing read_parsed_clauses_jsonl/build/parsed_clauses.jsonl loader — no reparsing. The docstring and CLI output both state explicitly that an empty result does not imply no related clause exists.

## Related issue

[M2-08]

## Checklist

- [x] Tests added/updated — tests/unit/scripts/test_find_candidate_clauses.py (12 unit tests: each signal, multi-signal merging/sort order, document scoping, the max_candidates cap, unknown-clause_id error path)
- [ ] Docs updated — not in this PR: wiring this tool into docs/EVALUATION.md's authoring protocol is M2-07's DoD, not M2-08's
- [ ] Evaluation impact considered — none; this is a curation-time helper only, it doesn't touch the parsing, retrieval, or evaluation pipelines or any numbers
- [x] make check passes locally
