### PR TITLE
feat(rag): fuse the BM25 and dense legs behind one filtered retrieval…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -47,6 +47,8 @@ help:
 	@echo "  finalize-unanswerable-questions - M2-05: promote approved rows from eval/unanswerable_draft.csv into data/golden_set/unanswerable.jsonl"
 	@echo "  eval-retrieval    - M2-06: score Recall@{1,5,10}/MRR/nDCG@10 against the golden set, broken down by question_type/product_line/extraction_mode, plus exclusion-clause recall (built-in random-retriever self-test; writes eval/runs/retrieval_eval_random.{md,json})"
 	@echo "  eval-retrieval-lexical - M3-03: score the BM25 lexical retriever (Portuguese tokenisation + Snowball stemming over build/chunks.jsonl, no metadata filter) on the golden set; writes eval/runs/retrieval_eval_lexical.{md,json}"
+	@echo "  eval-retrieval-dense - M3-04: score the dense pgvector retriever with the SUSEP-process+CNPJ pre-filter (needs a running Postgres with loaded+embedded chunks; runs the optional embed uv group); writes eval/runs/retrieval_eval_dense_filter-default.{md,json}"
+	@echo "  eval-retrieval-hybrid - M3-04: score the hybrid (RRF fusion of lexical+dense) retriever with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement as eval-retrieval-dense; pass --fusion weighted / --filter none on the script for the comparison); writes eval/runs/retrieval_eval_hybrid_*.{md,json}. Comparison and verdict: docs/HYBRID_RETRIEVAL.md"
 	@echo "  review-golden-set-sample - Independent second-reviewer pass over a stratified golden-set-v1 sample (--dry-run prints the sample composition, no model calls); writes data/golden_set/review/review_v1.jsonl and eval/runs/golden_set_review_v1.{md,json}"
 
 install:
@@ -192,6 +194,12 @@ eval-retrieval:
 
 eval-retrieval-lexical:
 	PYTHONPATH=app/src uv run python scripts/eval_retrieval.py --retriever lexical
+
+eval-retrieval-dense:
+	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever dense --filter default
+
+eval-retrieval-hybrid:
+	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default
 
 review-golden-set-sample:
 	PYTHONPATH=app/src uv run python scripts/review_golden_set_sample.py

--- a/app/src/infrastructure/database/chunk_repository.py
+++ b/app/src/infrastructure/database/chunk_repository.py
@@ -1,6 +1,4 @@
-"""Write paths for the chunk table -- [M3-02].
-
-Two sinks, deliberately separate:
+"""Read and write paths for the chunk table -- [M3-02], [M3-04].
 
 * ``upsert_chunks`` -- the metadata write path. ``chunk_id`` is deterministic
   upstream ([M3-01]/[M1-07]), so writing the chunk corpus is an upsert on that
@@ -10,17 +8,20 @@ Two sinks, deliberately separate:
 * ``fetch_chunks_missing_embedding`` / ``write_chunk_embeddings`` -- the
   embedding pipeline's read cursor and vector sink. The pipeline owns the
   ``embedding`` column exclusively.
+* ``search_chunks_by_vector`` -- [M3-04]'s dense-retrieval read path: exact
+  ``<=>`` cosine search over the metadata-filtered partition.
 """
 
 from collections.abc import Iterable, Mapping, Sequence
 from itertools import batched
 
-from sqlalchemy import select, text, update
+from sqlalchemy import ColumnElement, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from infrastructure.database.models import ChunkRow
 from infrastructure.rag.chunk_schema import ChunkRecord
+from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 # Every column except the conflict key and ``embedding`` is refreshed from the
 # incoming row, so a changed chunk (new text, new type) overwrites the stored
@@ -133,3 +134,69 @@ def write_chunk_embeddings(
     )
     session.flush()
     return len(vectors)
+
+
+def _metadata_filter_clauses(
+    metadata_filter: RetrievalFilter,
+) -> list[ColumnElement[bool]]:
+    """Translate a [RetrievalFilter] into ``WHERE`` clauses over ``ChunkRow``.
+
+    Insurers are matched by CNPJ, never by the ``insurer`` name column ([M1-05]:
+    HDI Seguros and HDI Global share a brand). ``bundle_section`` is lenient by
+    default -- ``= :x OR IS NULL`` -- so an unknown-bundle chunk is not silently
+    dropped ([M1-06] cross-note in [M3-04]); ``strict_bundle`` makes it exact.
+    """
+    clauses: list[ColumnElement[bool]] = []
+    if metadata_filter.susep_process is not None:
+        clauses.append(ChunkRow.susep_process == metadata_filter.susep_process)
+    if metadata_filter.cnpj is not None:
+        clauses.append(ChunkRow.cnpj == metadata_filter.cnpj)
+    if metadata_filter.product_line is not None:
+        clauses.append(ChunkRow.product_line == metadata_filter.product_line)
+    if metadata_filter.clause_type is not None:
+        clauses.append(ChunkRow.clause_type == metadata_filter.clause_type.value)
+    if metadata_filter.bundle_section is not None:
+        if metadata_filter.strict_bundle:
+            clauses.append(ChunkRow.bundle_section == metadata_filter.bundle_section)
+        else:
+            clauses.append(
+                or_(
+                    ChunkRow.bundle_section == metadata_filter.bundle_section,
+                    ChunkRow.bundle_section.is_(None),
+                )
+            )
+    return clauses
+
+
+def search_chunks_by_vector(
+    session: Session,
+    query_vector: Sequence[float],
+    *,
+    k: int,
+    metadata_filter: RetrievalFilter | None = None,
+) -> list[tuple[str, list[str], float]]:
+    """Top-``k`` ``(chunk_id, source_clause_ids, cosine_distance)`` for the query.
+
+    Exact ``<=>`` search over the metadata-filtered partition -- [M3-04]'s
+    default path, per ``docs/EMBEDDINGS.md``'s verdict that the HNSW index does
+    not earn its place at this corpus size and the composite
+    ``(susep_process, cnpj)`` btree + exact sort is what the planner picks
+    anyway. ``embedding IS NULL`` rows are excluded. Rows come back in ascending
+    distance order (nearest first). Returns up to ``k`` rows -- fewer when the
+    filter admits fewer, which is a real insufficient-context signal ([M3-07]),
+    never padded.
+    """
+    if k <= 0:
+        return []
+    distance = ChunkRow.embedding.cosine_distance(list(query_vector)).label("distance")
+    statement = select(ChunkRow.chunk_id, ChunkRow.source_clause_ids, distance).where(
+        ChunkRow.embedding.is_not(None)
+    )
+    if metadata_filter is not None:
+        statement = statement.where(*_metadata_filter_clauses(metadata_filter))
+    statement = statement.order_by(distance).limit(k)
+    rows = session.execute(statement).all()
+    return [
+        (chunk_id, list(source_clause_ids), float(chunk_distance))
+        for chunk_id, source_clause_ids, chunk_distance in rows
+    ]

--- a/app/src/infrastructure/evaluation/retrieval_run_schema.py
+++ b/app/src/infrastructure/evaluation/retrieval_run_schema.py
@@ -9,15 +9,17 @@ larger report dict both the JSON and Markdown outputs render from (see
 a frozen schema, since its shape is expected to grow with new breakdowns.
 
 ``v2`` [M3-03]: the lexical retriever adds the chunk-corpus identity and its
-BM25/analyzer contract. Every added field is optional -- the ``random``
-retriever leaves them ``None`` and its report is byte-identical to ``v1``.
+BM25/analyzer contract. ``v3`` [M3-04]: the dense and hybrid retrievers add the
+metadata-filter mode, the fusion strategy and its constants, and the embedding /
+hybrid config fingerprints. Every added field is optional -- ``random`` and
+``lexical`` leave the new ones ``None``.
 """
 
 from datetime import datetime
 
 from pydantic import BaseModel
 
-SCHEMA_VERSION = "v2"
+SCHEMA_VERSION = "v3"
 
 
 class RetrievalRunConfig(BaseModel):
@@ -34,7 +36,8 @@ class RetrievalRunConfig(BaseModel):
     seed: int | None
     run_at_utc: datetime
 
-    # [M3-03] lexical retriever only; None for `random`.
+    # [M3-03] lexical retriever (and the lexical leg of `hybrid`); None for
+    # `random` and `dense`.
     chunk_corpus_path: str | None = None
     chunk_corpus_chunk_count: int | None = None
     lexical_analyzer_version: str | None = None
@@ -44,3 +47,19 @@ class RetrievalRunConfig(BaseModel):
     lexical_index_text_field: str | None = None
     stemming_exception_count: int | None = None
     lexical_config_fingerprint: str | None = None
+
+    # [M3-04] metadata pre-filter: `none` or `default` (per-question SUSEP
+    # process + CNPJ from the manifest join). None for pre-M3-04 runs.
+    filter_mode: str | None = None
+
+    # [M3-04] dense retriever (and the dense leg of `hybrid`); None otherwise.
+    dense_model_id: str | None = None
+    dense_model_revision: str | None = None
+    embedding_config_fingerprint: str | None = None
+
+    # [M3-04] `hybrid` only; None otherwise.
+    fusion_strategy: str | None = None
+    rrf_k: int | None = None
+    fusion_weights: list[float] | None = None
+    candidate_depth: int | None = None
+    hybrid_config_fingerprint: str | None = None

--- a/app/src/infrastructure/evaluation/retriever.py
+++ b/app/src/infrastructure/evaluation/retriever.py
@@ -5,9 +5,18 @@ exist yet (see ``MILESTONES.md``, M3 is ``todo``) -- so this harness can be
 validated now, against [random_retriever.RandomRetriever]'s deliberately
 broken implementation, and a future M3 retriever can be pointed at the same
 harness unmodified by implementing this one method.
+
+[M3-04] adds [FilterableRetriever]: the same contract plus an optional
+``metadata_filter``. The dense, lexical and hybrid retrievers implement it;
+``random`` implements only the bare [Retriever]. The ``RetrievalFilter``
+reference is type-checking only, so importing this module still pulls in no
+``infrastructure.rag`` code.
 """
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 
 class Retriever(Protocol):
@@ -15,4 +24,18 @@ class Retriever(Protocol):
 
     def retrieve(self, question: str, *, k: int) -> list[str]:
         """Return up to ``k`` clause ids, ranked best-match first."""
+        ...
+
+
+class FilterableRetriever(Protocol):
+    """A [Retriever] that also honours a [M3-04] metadata pre-filter."""
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: "RetrievalFilter | None" = None,
+    ) -> list[str]:
+        """Return up to ``k`` clause ids, ranked best-match first, filtered."""
         ...

--- a/app/src/infrastructure/rag/ann_index.py
+++ b/app/src/infrastructure/rag/ann_index.py
@@ -7,8 +7,11 @@ it (``docs/EMBEDDINGS.md`` measures the difference and records the verdict), its
 ``migrated_database`` fixture in ``tests/integration/conftest.py`` would rebuild
 it on every integration test. [M3-08]'s ``make build-index`` calls
 :func:`create_hnsw_index` (iff the recorded verdict says the index earns its
-place); [M3-04]'s retriever calls :func:`apply_ann_search_gucs` on every filtered
-query.
+place); a retriever calls :func:`apply_ann_search_gucs` only on a query that
+routes through the index. [M3-04]'s dense retriever does **not** -- its default
+path is exact ``<=>`` over the pre-filtered partition (``docs/EMBEDDINGS.md``,
+"Filtered search and the fewer-than-``k`` question"), so this helper is
+currently reached only by ``benchmark_ann_index`` and [M3-08]'s future matrix.
 
 The parameters are module constants, not ``.env`` knobs: ``m`` / ``ef_construction``
 change the index (and therefore any published Recall@k), and ``ef_search`` /

--- a/app/src/infrastructure/rag/dense_retriever.py
+++ b/app/src/infrastructure/rag/dense_retriever.py
@@ -1,0 +1,104 @@
+"""Dense (embedding) retrieval over the pgvector chunk table -- [M3-04].
+
+The query side M3-02 deferred here: [infrastructure.rag.embedding_config.
+format_query] the question, embed it through the same [Embedder] contract the
+index side uses, then exact ``<=>`` cosine search over the metadata-filtered
+partition ([infrastructure.database.chunk_repository.search_chunks_by_vector]),
+rolled up from chunk hits to clause-id granularity the same way
+[infrastructure.rag.lexical_retriever.LexicalRetriever] does -- so both legs
+satisfy the clause-granularity [infrastructure.evaluation.retriever.Retriever]
+contract the [M2-06] harness scores and [M3-04]'s fusion can combine them.
+
+No HNSW / ``apply_ann_search_gucs``: ``docs/EMBEDDINGS.md``'s verdict is that
+the index does not earn its place at this corpus size and the planner reads the
+``(susep_process, cnpj)`` partition by btree + exact sort anyway.
+
+The embedder is constructor-injected. Production wires the real
+[infrastructure.rag.sentence_transformer_embedder.SentenceTransformerEmbedder]
+(optionally wrapped in [infrastructure.rag.embedding_cache.CachingEmbedder]);
+the test suite uses a fake, per the [M1-05b]/[M1-04d] no-live-calls precedent.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from infrastructure.database.chunk_repository import search_chunks_by_vector
+from infrastructure.rag.embedder import Embedder
+from infrastructure.rag.embedding_config import format_query
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+# Chunks fetched per requested clause. A chunk carries >= 1 clause id and an
+# over-long clause splits into a few chunks that share one, so k chunks can roll
+# up to fewer than k clauses. Splits are rare and only ever 2-way ([M3-01]
+# report), so 4x is comfortably enough; exact search over the small filtered
+# partition makes the wider fetch free. Not a tuning knob -- chosen so the
+# roll-up never under-fills, not to move a number.
+_CLAUSE_ROLLUP_OVERSAMPLE = 4
+
+
+class DenseRetriever:
+    """Ranks clause ids for a question by cosine similarity of dense vectors."""
+
+    def __init__(self, session: Session, embedder: Embedder) -> None:
+        """Build over an open session and a query embedder."""
+        self._session = session
+        self._embedder = embedder
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, best match first. May return fewer; never pads."""
+        return [
+            clause_id
+            for clause_id, _score in self.retrieve_scored(
+                question, k=k, metadata_filter=metadata_filter
+            )
+        ]
+
+    def retrieve_scored(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[tuple[str, float]]:
+        """Up to ``k`` ``(clause_id, cosine similarity)`` pairs, best first.
+
+        Similarity is ``1 - cosine_distance`` (both stored and query vectors are
+        L2-normalised, per [infrastructure.rag.embedding_config]). A clause's
+        score is its best chunk's -- and since hits arrive in ascending distance
+        order, that is simply the first chunk it appears in. The scores are what
+        [M3-04]'s weighted-score fusion needs and :meth:`retrieve` discards.
+        """
+        if k <= 0:
+            return []
+        query_vector = self._embed_query(question)
+        hits = search_chunks_by_vector(
+            self._session,
+            query_vector,
+            k=k * _CLAUSE_ROLLUP_OVERSAMPLE,
+            metadata_filter=metadata_filter,
+        )
+        scored: list[tuple[str, float]] = []
+        seen: set[str] = set()
+        for _chunk_id, source_clause_ids, distance in hits:
+            similarity = 1.0 - distance
+            for clause_id in source_clause_ids:
+                if clause_id not in seen:
+                    seen.add(clause_id)
+                    scored.append((clause_id, similarity))
+                    if len(scored) == k:
+                        return scored
+        return scored
+
+    def _embed_query(self, question: str) -> Sequence[float]:
+        """Embed one query string through the pinned contract."""
+        vectors = self._embedder.embed([format_query(question)])
+        if len(vectors) != 1:
+            raise ValueError(f"embedder returned {len(vectors)} vectors for 1 query")
+        return vectors[0]

--- a/app/src/infrastructure/rag/fusion.py
+++ b/app/src/infrastructure/rag/fusion.py
@@ -1,0 +1,83 @@
+"""Rank / score fusion of the lexical and dense retrieval legs -- [M3-04].
+
+Two strategies, compared on the golden set in ``docs/HYBRID_RETRIEVAL.md``:
+
+* :func:`reciprocal_rank_fusion` -- rank-only, one parameter (``k``), the method
+  named in the [M3-04] DoD.
+* :func:`weighted_score_fusion` -- min-max normalises each leg's raw scores to
+  ``[0, 1]`` and takes a weighted sum, so a leg that is confident (a top score
+  well clear of its runners-up) pulls harder than its rank alone would say.
+
+Both are pure functions over clause-id rankings and return a single ranked
+``list[str]``. Ties break on the clause id ascending -- the same reproducibility
+tie-break [infrastructure.rag.bm25.top_n] uses, so a committed Recall@k number
+is stable run to run. Each input list is expected to already be deduplicated to
+clause-id granularity (both legs roll chunk hits up before returning); a
+repeated id within one list is counted once, at its best position.
+"""
+
+from collections.abc import Mapping, Sequence
+
+
+def _rank_by_descending_score(scores: Mapping[str, float]) -> list[str]:
+    """Clause ids ordered by score desc, ties broken by id asc."""
+    return [
+        clause_id
+        for clause_id, _ in sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: Sequence[Sequence[str]], *, k: int
+) -> list[str]:
+    """Fuse ranked clause-id lists by summed reciprocal rank ``1 / (k + rank)``.
+
+    ``rank`` is 1-based within each list. ``k`` dampens how much the very top of
+    one list dominates (the standard RRF constant, ~60). A clause absent from a
+    list contributes nothing from it.
+    """
+    scores: dict[str, float] = {}
+    for ranked in ranked_lists:
+        seen: set[str] = set()
+        for rank, clause_id in enumerate(ranked, start=1):
+            if clause_id in seen:
+                continue
+            seen.add(clause_id)
+            scores[clause_id] = scores.get(clause_id, 0.0) + 1.0 / (k + rank)
+    return _rank_by_descending_score(scores)
+
+
+def weighted_score_fusion(
+    scored_lists: Sequence[Sequence[tuple[str, float]]],
+    *,
+    weights: Sequence[float],
+) -> list[str]:
+    """Fuse ``(clause_id, score)`` lists by weighted sum of per-list min-max norms.
+
+    Each list's raw scores are normalised to ``[0, 1]`` independently
+    (``(s - min) / (max - min)``; a list whose scores are all equal normalises
+    to all-``1.0``), scaled by that list's weight, and summed. ``weights`` is
+    positional, one per list.
+    """
+    if len(scored_lists) != len(weights):
+        raise ValueError(f"got {len(scored_lists)} lists but {len(weights)} weights")
+    scores: dict[str, float] = {}
+    for scored, weight in zip(scored_lists, weights, strict=True):
+        best: dict[str, float] = {}
+        for clause_id, value in scored:
+            best[clause_id] = max(best.get(clause_id, value), value)
+        for clause_id, value in _min_max(best).items():
+            scores[clause_id] = scores.get(clause_id, 0.0) + weight * value
+    return _rank_by_descending_score(scores)
+
+
+def _min_max(scores: Mapping[str, float]) -> dict[str, float]:
+    """Scale ``scores`` to ``[0, 1]``; all-equal (incl. singletons) -> all ``1.0``."""
+    if not scores:
+        return {}
+    low = min(scores.values())
+    high = max(scores.values())
+    if high == low:
+        return dict.fromkeys(scores, 1.0)
+    span = high - low
+    return {key: (value - low) / span for key, value in scores.items()}

--- a/app/src/infrastructure/rag/hybrid_config.py
+++ b/app/src/infrastructure/rag/hybrid_config.py
@@ -1,0 +1,78 @@
+"""The pinned hybrid-retrieval contract -- [M3-04].
+
+Single source of truth for the fusion strategy and its parameters: the RRF
+smoothing constant, the weighted-fusion weights, how deep each leg is sampled
+before fusion, and which strategy is the default. The [M3-04] eval
+(``docs/HYBRID_RETRIEVAL.md``) compares RRF against weighted score fusion on the
+golden set and sets ``DEFAULT_FUSION_STRATEGY`` to the winner.
+
+Why these are module constants and not ``.env`` knobs: RRF ``k``, the weights
+and the candidate depth all change the published Recall@k / MRR. Per [M1-09]'s
+per-constant rule they are experimental design -- like ``SEED`` / ``SAMPLE_SIZE``
+in ``scripts/sample_parsing_quality.py`` -- and making them environment-dependent
+would let a ``.env`` edit silently move a published result. This issue
+introduces **no** ``.env`` key (the analog of docs/LEXICAL_RETRIEVAL.md's "zero"
+and docs/EMBEDDINGS.md's "exactly one").
+
+Rationale and evidence: docs/HYBRID_RETRIEVAL.md.
+"""
+
+import hashlib
+from enum import StrEnum
+
+from infrastructure.rag.embedding_config import config_fingerprint as _dense_fingerprint
+
+
+class FusionStrategy(StrEnum):
+    """How the lexical and dense legs are combined."""
+
+    RRF = "rrf"
+    WEIGHTED = "weighted"
+
+
+# Reciprocal Rank Fusion smoothing constant. 60 is the value from Cormack et
+# al.'s original RRF paper and the de-facto default across IR toolkits; tuning
+# it is [M3-08]'s, not this issue's. It changes the published Recall@k, so it
+# stays a code constant.
+RRF_K = 60
+
+# (lexical, dense) weights for weighted score fusion, positional and matched to
+# the leg order in [infrastructure.rag.hybrid_retriever.HybridRetriever]. Start
+# balanced; the [M3-04] eval records whether a tilt helps.
+FUSION_WEIGHTS: tuple[float, float] = (0.5, 0.5)
+
+# How many clause ids each leg contributes before fusion. Deep enough that a
+# clause outside either leg's top 10 can still be rescued by cross-leg
+# agreement, shallow enough to stay cheap at ~4.9k clauses. Changes the fused
+# ranking, so a code constant.
+CANDIDATE_DEPTH = 100
+
+# Set from the docs/HYBRID_RETRIEVAL.md comparison: RRF unless weighted wins
+# filtered overall Recall@10 or MRR by a clear margin.
+DEFAULT_FUSION_STRATEGY = FusionStrategy.RRF
+
+
+def config_fingerprint(*, lexical_config_fingerprint: str) -> str:
+    """Digest of every value that determines the fused ranking.
+
+    Folds in the caller-supplied lexical fingerprint
+    ([infrastructure.rag.lexical_config.config_fingerprint], which needs the
+    on-disk exception list) and computes the dense one itself
+    ([infrastructure.rag.embedding_config.config_fingerprint]), so a change to
+    the BM25 analyzer or the embedding model moves this too. Threaded into
+    [infrastructure.evaluation.retrieval_run_schema.RetrievalRunConfig] so a
+    report read in isolation says exactly what produced its numbers. Reads the
+    module constants at call time so a test can monkeypatch one and watch the
+    digest move (mirrors the sibling ``config_fingerprint``s).
+    """
+    payload = "\x00".join(
+        (
+            str(RRF_K),
+            ",".join(repr(weight) for weight in FUSION_WEIGHTS),
+            str(CANDIDATE_DEPTH),
+            DEFAULT_FUSION_STRATEGY.value,
+            lexical_config_fingerprint,
+            _dense_fingerprint(),
+        )
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]

--- a/app/src/infrastructure/rag/hybrid_retriever.py
+++ b/app/src/infrastructure/rag/hybrid_retriever.py
@@ -1,0 +1,95 @@
+"""Hybrid retrieval: fuse the lexical and dense legs behind one interface -- [M3-04].
+
+The single retrieval interface [M3-04]'s DoD asks for, so M4's graph node stays
+unaware of the implementation: one ``retrieve(question, *, k, metadata_filter)``
+that runs BM25 ([infrastructure.rag.lexical_retriever.LexicalRetriever]) and
+dense cosine search ([infrastructure.rag.dense_retriever.DenseRetriever]) over
+the same [infrastructure.rag.retrieval_filter.RetrievalFilter], then fuses the
+two rankings.
+
+Two fusion strategies, selected by [infrastructure.rag.hybrid_config.
+FusionStrategy] and compared on the golden set in ``docs/HYBRID_RETRIEVAL.md``:
+Reciprocal Rank Fusion (rank-only) and weighted score fusion (min-max
+normalised, weighted). Each leg contributes ``CANDIDATE_DEPTH`` clause ids
+before fusion so a clause outside either leg's top 10 can still be rescued by
+cross-leg agreement.
+
+Satisfies the [infrastructure.evaluation.retriever.Retriever] contract when
+called as ``retrieve(question, k=k)``.
+"""
+
+from typing import Protocol
+
+from infrastructure.rag.fusion import reciprocal_rank_fusion, weighted_score_fusion
+from infrastructure.rag.hybrid_config import (
+    CANDIDATE_DEPTH,
+    DEFAULT_FUSION_STRATEGY,
+    FUSION_WEIGHTS,
+    RRF_K,
+    FusionStrategy,
+)
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+class _ScoredLeg(Protocol):
+    """One fusion input: [LexicalRetriever] / [DenseRetriever]'s scored method."""
+
+    def retrieve_scored(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[tuple[str, float]]:
+        """Up to ``k`` ``(clause_id, score)`` pairs, best match first."""
+        ...
+
+
+class HybridRetriever:
+    """Fuses a BM25 leg and a dense leg over a shared metadata pre-filter."""
+
+    def __init__(
+        self,
+        lexical: _ScoredLeg,
+        dense: _ScoredLeg,
+        *,
+        fusion: FusionStrategy = DEFAULT_FUSION_STRATEGY,
+    ) -> None:
+        """Compose the two legs; ``fusion`` picks the combine strategy."""
+        self._lexical = lexical
+        self._dense = dense
+        self._fusion = fusion
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, best match first. May return fewer; never pads.
+
+        ``metadata_filter`` reaches both legs unchanged -- the dense leg pushes
+        it into SQL, the lexical leg applies it in memory before its roll-up.
+        """
+        if k <= 0:
+            return []
+        lexical_scored = self._lexical.retrieve_scored(
+            question, k=CANDIDATE_DEPTH, metadata_filter=metadata_filter
+        )
+        dense_scored = self._dense.retrieve_scored(
+            question, k=CANDIDATE_DEPTH, metadata_filter=metadata_filter
+        )
+        if self._fusion is FusionStrategy.RRF:
+            fused = reciprocal_rank_fusion(
+                [
+                    [clause_id for clause_id, _ in lexical_scored],
+                    [clause_id for clause_id, _ in dense_scored],
+                ],
+                k=RRF_K,
+            )
+        else:
+            fused = weighted_score_fusion(
+                [lexical_scored, dense_scored], weights=FUSION_WEIGHTS
+            )
+        return fused[:k]

--- a/app/src/infrastructure/rag/lexical_retriever.py
+++ b/app/src/infrastructure/rag/lexical_retriever.py
@@ -11,6 +11,10 @@ Everything here is in-memory and constructor-injected: no database, no I/O. The
 index is rebuilt from ``build/chunks.jsonl`` per run (a few seconds for ~4.5k
 chunks -- unlike the 41-minute embedding run, it does not justify an on-disk
 cache in this issue).
+
+[M3-04] adds the ``metadata_filter`` kwarg and ``retrieve_scored`` -- this leg
+of the hybrid retriever, filtered and score-exposing -- without changing the
+unfiltered ``retrieve(question, k=k)`` path or its committed numbers.
 """
 
 from collections.abc import Mapping, Sequence
@@ -19,6 +23,7 @@ from typing import Protocol
 from infrastructure.rag.bm25 import BM25Index, build_bm25_index, top_n
 from infrastructure.rag.chunk_schema import ChunkRecord
 from infrastructure.rag.lexical_config import BM25_B, BM25_K1, LEXICAL_INDEX_TEXT_FIELD
+from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 
 class _Analyzer(Protocol):
@@ -44,11 +49,17 @@ class LexicalRetriever:
         index: BM25Index,
         analyzer: _Analyzer,
         chunk_to_clauses: Mapping[str, Sequence[str]],
+        chunks_by_id: Mapping[str, ChunkRecord],
     ) -> None:
-        """Build over a prepared index, its analyzer, and the chunk->clauses map."""
+        """Build over a prepared index, its analyzer, and the chunk lookups.
+
+        ``chunks_by_id`` carries the metadata [M3-04]'s pre-filter matches
+        against; it is untouched when ``retrieve`` is called without a filter.
+        """
         self._index = index
         self._analyzer = analyzer
         self._chunk_to_clauses = chunk_to_clauses
+        self._chunks_by_id = chunks_by_id
 
     @classmethod
     def from_chunks(
@@ -69,26 +80,57 @@ class LexicalRetriever:
         chunk_to_clauses = {
             chunk.chunk_id: tuple(chunk.source_clause_ids) for chunk in chunks
         }
-        return cls(index, analyzer, chunk_to_clauses)
+        chunks_by_id = {chunk.chunk_id: chunk for chunk in chunks}
+        return cls(index, analyzer, chunk_to_clauses, chunks_by_id)
 
-    def retrieve(self, question: str, *, k: int) -> list[str]:
-        """Up to ``k`` clause ids, best match first. May return fewer; never pads.
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, best match first. May return fewer; never pads."""
+        return [
+            clause_id
+            for clause_id, _score in self.retrieve_scored(
+                question, k=k, metadata_filter=metadata_filter
+            )
+        ]
+
+    def retrieve_scored(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[tuple[str, float]]:
+        """Up to ``k`` ``(clause_id, BM25 score)`` pairs, best match first.
 
         Scores every matching chunk, not just the top k: split chunks
         (``clause_id#0``, ``#1``, ...) and merged chunks collapse on the roll-up
-        to clause ids, so a fixed oversample could still under-fill.
+        to clause ids, so a fixed oversample could still under-fill. A clause's
+        score is its best chunk's -- and since chunks arrive in descending score
+        order, that is the first chunk it appears in. The scores are what
+        [M3-04]'s weighted-score fusion needs and :meth:`retrieve` discards;
+        ``metadata_filter`` drops non-matching chunks before the roll-up
+        ([M3-04]'s pre-filter, applied to this leg).
         """
         if k <= 0:
             return []
         query_tokens = self._analyzer.analyze(question)
         ranked_chunks = top_n(self._index, query_tokens, len(self._index.doc_ids))
-        clause_ids: list[str] = []
+        scored: list[tuple[str, float]] = []
         seen: set[str] = set()
-        for chunk_id, _score in ranked_chunks:
+        for chunk_id, score in ranked_chunks:
+            if metadata_filter is not None and not metadata_filter.matches(
+                self._chunks_by_id[chunk_id]
+            ):
+                continue
             for clause_id in self._chunk_to_clauses[chunk_id]:
                 if clause_id not in seen:
                     seen.add(clause_id)
-                    clause_ids.append(clause_id)
-                    if len(clause_ids) == k:
-                        return clause_ids
-        return clause_ids
+                    scored.append((clause_id, score))
+                    if len(scored) == k:
+                        return scored
+        return scored

--- a/app/src/infrastructure/rag/retrieval_filter.py
+++ b/app/src/infrastructure/rag/retrieval_filter.py
@@ -1,0 +1,79 @@
+"""The metadata pre-filter that cuts the retrieval search space -- [M3-04].
+
+A claims analyst works a case for a known policy, so the *default* retrieval
+path filters chunks to one SUSEP process + insurer CNPJ before anything is
+ranked -- not an optional optimisation. ``docs/HYBRID_RETRIEVAL.md`` has the
+measured effect (the M3-03 lexical baseline's ~35-point Recall@10 gap is
+entirely cross-document leakage this filter removes).
+
+One ``RetrievalFilter`` value drives both retrieval legs: the dense leg
+translates it to a SQL ``WHERE`` ([infrastructure.database.chunk_repository.
+search_chunks_by_vector]); the in-memory lexical leg applies :meth:`matches` to
+each chunk before the chunk->clause roll-up. Filter by CNPJ, never insurer name
+-- HDI Seguros (``29980158000157``) and HDI Global (``18096627000153``) share a
+brand but are different legal entities ([M1-05]).
+"""
+
+from dataclasses import dataclass
+
+from domain.clause_classification import ClauseType
+from infrastructure.rag.chunk_schema import ChunkRecord
+
+
+@dataclass(frozen=True)
+class RetrievalFilter:
+    """A conjunction of equality pre-filters over chunk metadata.
+
+    Every field is optional; ``None`` means "do not constrain this field". An
+    all-``None`` filter matches every chunk -- the unknown-process degradation
+    path ([M3-04] DoD item 5), not an error.
+    """
+
+    susep_process: str | None = None
+    cnpj: str | None = None
+    product_line: str | None = None
+    bundle_section: str | None = None
+    clause_type: ClauseType | None = None
+    # When ``bundle_section`` is set, ``strict_bundle=False`` (the default) also
+    # keeps chunks whose ``bundle_section`` is ``None``: when a multi-product
+    # document's product-start signal is unclear a large share of its clauses
+    # land in that bucket ([M1-06] cross-note in [M3-04]), and excluding them
+    # silently is the failure mode this guards against. ``strict_bundle=True``
+    # is exact equality.
+    strict_bundle: bool = False
+
+    @classmethod
+    def from_manifest_row(cls, row: dict[str, str]) -> "RetrievalFilter":
+        """The default retrieval filter for a document: its SUSEP process + CNPJ.
+
+        ``row`` is a ``data/policies/manifest.csv`` record
+        ([infrastructure.parsing.manifest.read_manifest]).
+        """
+        return cls(susep_process=row["susep_process"], cnpj=row["cnpj"])
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no field constrains anything (matches every chunk)."""
+        return (
+            self.susep_process is None
+            and self.cnpj is None
+            and self.product_line is None
+            and self.bundle_section is None
+            and self.clause_type is None
+        )
+
+    def matches(self, chunk: ChunkRecord) -> bool:
+        """Whether ``chunk`` passes every set constraint (the lexical leg)."""
+        if self.susep_process is not None and chunk.susep_process != self.susep_process:
+            return False
+        if self.cnpj is not None and chunk.cnpj != self.cnpj:
+            return False
+        if self.product_line is not None and chunk.product_line != self.product_line:
+            return False
+        if self.clause_type is not None and chunk.clause_type != self.clause_type:
+            return False
+        if self.bundle_section is not None:
+            if self.strict_bundle:
+                return chunk.bundle_section == self.bundle_section
+            return chunk.bundle_section in (self.bundle_section, None)
+        return True

--- a/docs/HYBRID_RETRIEVAL.md
+++ b/docs/HYBRID_RETRIEVAL.md
@@ -1,0 +1,318 @@
+# Hybrid retrieval and metadata pre-filtering
+
+The [M3-04] retrieval layer: one interface that fuses the [M3-03] BM25 lexical
+leg and a new dense pgvector leg, over a metadata pre-filter that cuts the
+search space to a known SUSEP process + insurer CNPJ. The contract lives in
+code at `app/src/infrastructure/rag/hybrid_config.py`,
+`app/src/infrastructure/rag/fusion.py` and
+`app/src/infrastructure/rag/retrieval_filter.py`; this document is the
+rationale, the evidence, and the numbers.
+
+**Scope.** This issue builds the dense query side (M3-02 deferred it here),
+Reciprocal Rank Fusion, weighted score fusion, and the pre-filter, and measures
+**RRF vs weighted score fusion** and **filter-on vs filter-off** on
+`golden-set-v1`. It does **not**:
+
+- produce the committed lexical-only / dense-only / hybrid / hybrid+rerank
+  benchmark matrix or `make build-index` — that is [M3-08]'s, run on
+  `golden-set-v1`;
+- add cross-encoder reranking ([M3-05]), exclusion co-retrieval ([M3-06]) or
+  the insufficient-context gate ([M3-07]);
+- persist a lexical column to Postgres — the M3-03 doc already declined that
+  (Postgres `ts_rank` is not BM25; real in-DB BM25 needs a heavy extension),
+  and with the filter numbers now in hand the decision stands: the lexical leg
+  stays in-memory over `build/chunks.jsonl`.
+
+The standalone `--retriever dense` numbers below are given for context; the
+committed dense baseline write-up is [M3-08]'s.
+
+---
+
+## Method
+
+### One interface, two legs, one filter
+
+`HybridRetriever.retrieve(question, *, k, metadata_filter=None) -> list[str]`
+(`hybrid_retriever.py`) is the single entry point M4's graph node will call. It:
+
+1. asks each leg for `CANDIDATE_DEPTH` (100) scored clause ids, passing the
+   same `RetrievalFilter` to both;
+2. fuses the two rankings (RRF or weighted score fusion);
+3. returns the top `k`, "up to `k`, never padded" — the shortfall-as-signal
+   contract [M3-07]'s gate depends on.
+
+**Dense leg** (`dense_retriever.py`): `embedding_config.format_query` the
+question, embed it through the same `Embedder` contract the index side uses
+(pinned `Alibaba-NLP/gte-multilingual-base`, cosine, L2-normalised), then exact
+`<=>` search over the metadata-filtered partition
+(`chunk_repository.search_chunks_by_vector`), rolled up from chunk hits to
+clause-id granularity via `source_clause_ids`. **No HNSW / `iterative_scan`:**
+`docs/EMBEDDINGS.md`'s verdict is that the index does not earn its place at
+~4,540 chunks and the planner reads the `(susep_process, cnpj)` partition by
+btree + exact sort anyway. Score = `1 - cosine_distance`.
+
+**Lexical leg** (`lexical_retriever.py`, extended): the [M3-03] BM25 retriever
+gains an optional `metadata_filter` (drops non-matching chunks before the
+roll-up) and a `retrieve_scored` (rolls the BM25 score up to clause id, max
+over the clause's chunks). The unfiltered `retrieve(question, k=k)` path and
+its committed numbers are unchanged.
+
+### The metadata pre-filter
+
+`RetrievalFilter` (`retrieval_filter.py`) is a conjunction of equality
+pre-filters: `susep_process`, `cnpj`, `product_line`, `bundle_section`,
+`clause_type`. All optional; an all-`None` filter matches everything (the
+unknown-process degradation path, item 5). The default retrieval path is
+`RetrievalFilter.from_manifest_row(row)` → SUSEP process + CNPJ.
+
+- **Insurers are matched by CNPJ, never by the `insurer` name** ([M1-05]: HDI
+  Seguros `29980158000157` and HDI Global `18096627000153` share a brand but
+  are different legal entities). The `insurer` column is deliberately not
+  indexed.
+- **`bundle_section` is lenient by default** (`= :x OR bundle_section IS NULL`),
+  with a `strict_bundle=True` escape hatch — see "M1-06 bundle-section
+  decision" below.
+
+The dense leg pushes the filter into a SQL `WHERE`; the lexical leg applies
+`RetrievalFilter.matches` in memory. BM25 IDF stays a full-corpus statistic
+(the filter changes what is *retrieved*, not how terms are weighted).
+
+### The `[M1-09]` per-constant decision
+
+RRF's smoothing `k`, the weighted-fusion weights and the candidate depth all
+change the published Recall@k / MRR, so per [M1-09]'s rule (a value that moves
+a published number is experimental design, like `SEED` / `SAMPLE_SIZE`) they
+are **all module constants** in `hybrid_config.py`. **Zero new `.env` keys** —
+the analog of [M3-03]'s "zero" and [M3-02]'s "exactly one".
+
+| constant | value | why a code constant |
+| --- | --- | --- |
+| `RRF_K` | 60 | Cormack et al.'s original RRF constant / IR-toolkit default; changes the fused Recall@k. Tuning is [M3-08]'s. |
+| `FUSION_WEIGHTS` | `(0.5, 0.5)` | (lexical, dense) weights for weighted fusion; changes the fused ranking. |
+| `CANDIDATE_DEPTH` | 100 | per-leg pool before fusion; deep enough to rescue a clause outside either leg's top 10 by cross-leg agreement. |
+| `DEFAULT_FUSION_STRATEGY` | `rrf` | set from the comparison below. |
+
+`config_fingerprint(*, lexical_config_fingerprint)` (sha256[:16] over the
+constants + both legs' own fingerprints) stamps every run's
+`RetrievalRunConfig`. `RetrievalRunConfig` is bumped to `v3` with the
+filter-mode, fusion strategy + constants, and the embedding / hybrid
+fingerprints — all optional; `random` and `lexical` reports are unaffected.
+
+### The harness
+
+`scripts/eval_retrieval.py` gains `--retriever dense|hybrid`, `--filter
+none|default` (per-question SUSEP process + CNPJ from the manifest join) and
+`--fusion rrf|weighted`. A new pooled metric, the **foreign-document rate**,
+answers DoD item 4: of every clause retrieved in a question's top-10, the
+fraction from a document other than the question's target. `make
+eval-retrieval-hybrid` / `-dense` run under `uv run --group embed` and need a
+Postgres with loaded + embedded chunks; the query embedder is wrapped in
+`CachingEmbedder` so a re-run over the 117 golden queries costs nothing.
+
+---
+
+## Pre-registered prediction
+
+Written in the implementation plan **before** the retrievers were built or run,
+reproduced here unedited:
+
+> - The metadata pre-filter (process + CNPJ) is the dominant effect. Filtered
+>   overall Recall@10 clears M3's ≥ 0.85 bar (lexical alone already hit 93.2%
+>   in the M3-03 perfect-filter simulation); foreign-document rate drops to 0.
+> - Dense-only beats lexical-only on `definition` and paraphrased questions;
+>   lexical-only beats dense on exact-term `direct_lookup`.
+> - Hybrid ≥ max(lexical, dense) on filtered overall Recall@10 and MRR.
+> - RRF and weighted score fusion land within a few points of each other. RRF
+>   is kept as the default unless weighted wins filtered overall Recall@10 *or*
+>   MRR by a clear margin (> 2 points), because RRF has one parameter and no
+>   score-normalisation fragility.
+> - `coverage_with_exclusion` stays the weakest type even filtered (exclusion
+>   co-retrieval is M3-06); exclusion-clause recall improves with the filter
+>   but stays below overall recall.
+> - Unfiltered ("unknown process") hybrid beats unfiltered lexical alone (dense
+>   adds signal) but falls well short of the filtered number — that gap is the
+>   measured cost of intake-extraction failure.
+
+---
+
+## Outcome (2026-08-28)
+
+`make eval-retrieval-hybrid` and `-dense` (+ `--fusion weighted` / `--filter
+none` for the comparison) → `eval/runs/retrieval_eval_*.{md,json}`
+(regenerable; gitignored). Dense model `Alibaba-NLP/gte-multilingual-base` @
+`9bbca17d92…`, cosine, L2-normalised (embedding fingerprint `7ea39a621eaee88e`);
+RRF `k=60`, weights `(0.5, 0.5)`, candidate depth 100 (hybrid fingerprint
+`279ed8ee0a668227`); lexical `v1` / `k1=1.5 b=0.75` (`ef0a2dd0c1dfb4e4`). 117
+scorable questions (the 23 `unanswerable` are excluded — empty reference set);
+all CASCO / CARTA VERDE, all `text` extraction mode (`golden-set-v1`'s known
+coverage limit, see `docs/EVALUATION.md` and "Limitations" below).
+
+### Overall — every configuration
+
+| retriever | filter | R@1 | R@5 | R@10 | MRR | nDCG@10 | exclusion recall | foreign-doc |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| random (self-test) | — | 0.0% | 0.0% | 0.0% | 0.0% | 0.0% | 0.0% (0/27) | 95.9% |
+| lexical | none | 24.5% | 47.7% | 58.7% | 38.8% | 41.9% | 51.9% (14/27) | 79.7% |
+| dense | none | 21.0% | 33.9% | 47.4% | 30.7% | 33.6% | 18.5% (5/27) | 81.4% |
+| hybrid RRF | none | 22.8% | 47.0% | 52.1% | 35.6% | 38.5% | 51.9% (14/27) | 80.2% |
+| hybrid weighted | none | 23.2% | 45.3% | 54.8% | 36.6% | 40.0% | 48.1% (13/27) | 79.9% |
+| lexical | **default** | 62.9% | 83.4% | 87.2% | 79.0% | 78.5% | 85.2% (23/27) | **0.0%** |
+| dense | **default** | 56.8% | 79.0% | 84.3% | 71.8% | 73.3% | 70.4% (19/27) | **0.0%** |
+| **hybrid RRF** | **default** | **64.5%** | **83.6%** | **91.5%** | **78.8%** | **80.3%** | **92.6% (25/27)** | **0.0%** |
+| hybrid weighted | **default** | 67.9% | 85.7% | 88.9% | 83.1% | 82.0% | 92.6% (25/27) | **0.0%** |
+
+The unfiltered `lexical` row reproduces the [M3-03] committed baseline
+(58.7% / 38.8% / 41.9% / 51.9%) exactly — the M3-04 changes did not perturb it.
+
+### Prediction vs actual
+
+| prediction | actual | call |
+| --- | --- | --- |
+| Pre-filter is the dominant effect; filtered R@10 ≥ 0.85; foreign-doc → 0 | filter lifts R@10 by 27–39 pts on every leg; every filtered config 84.3–91.5%; foreign-doc **exactly 0.0%** | **held** |
+| Dense beats lexical on `definition` / paraphrase; lexical beats dense on `direct_lookup` | filtered lexical beats dense on `definition` (83.3 vs 77.8), `coverage_with_exclusion` (73.7 vs 63.2) and `cross_document` (93.8 vs 87.5); dense edges lexical only on `direct_lookup` (91.7 vs 90.6) | **missed** — filtered BM25 is the stronger *single* leg here; the predicted split is essentially backwards |
+| Hybrid ≥ max(lexical, dense) on filtered R@10 and MRR | R@10: RRF 91.5 > max 87.2 ✓. MRR: RRF 78.8 vs lexical 79.0 ✗ (by 0.2 pt); weighted 83.1 ✓ | **held (R@10), missed (RRF MRR, barely)** |
+| RRF and weighted within a few points | R@10 91.5 vs 88.9; MRR 78.8 vs 83.1 | **held** |
+| `coverage_with_exclusion` stays the weakest type even filtered | RRF+filter: `coverage_with_exclusion` R@10 78.9% is the lowest of the four types (vs 88.9 / 93.8 / 95.3) | **held** |
+| Exclusion-clause recall improves with the filter but stays below overall | 51.9% → 92.6%; **exceeds** overall R@10 (91.5%) by 1.1 pt under RRF+filter | **missed** — the filter helps exclusion clauses slightly *more* than the average clause |
+| Unfiltered hybrid beats unfiltered lexical alone | unfiltered hybrid RRF R@10 52.1% < unfiltered lexical 58.7% | **missed** — fusing the weak unfiltered dense leg (47.4%) *drags RRF down*; a strong argument that the filter is not optional |
+
+### By question type — filtered
+
+| question_type | n | lexical | dense | **hybrid RRF** | hybrid weighted |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `direct_lookup` | 64 | 90.6% | 91.7% | **95.3%** | 93.8% |
+| `coverage_with_exclusion` | 19 | 73.7% | 63.2% | **78.9%** | 73.7% |
+| `cross_document` | 16 | 93.8% | 87.5% | **93.8%** | 87.5% |
+| `definition` | 18 | 83.3% | 77.8% | **88.9%** | 88.9% |
+
+(Recall@10. RRF+filter beats or ties both legs on every type — the fusion is
+additive here even though each leg alone already clears 0.85 on most types.)
+
+---
+
+## Verdict
+
+### The filter
+
+**The SUSEP process + CNPJ pre-filter is [M3-04]'s whole result.** It takes
+every leg from "well below M3's bar" to "well above it", and it is the
+system's default path, not an optimisation — a claims analyst works a known
+policy. Unfiltered retrieval is a documented degradation mode (below), not an
+alternative primary flow.
+
+### RRF vs weighted score fusion → **keep RRF**
+
+Neither dominates. RRF wins deep recall (**R@10 91.5 vs 88.9**); weighted wins
+top-rank precision (**MRR 83.1 vs 78.8**, R@1 67.9 vs 64.5, nDCG 82.0 vs 80.3).
+
+**RRF is kept as the default**, for three reasons:
+
+1. **Recall@10 is M3's stated exit metric** and the quantity that decides
+   whether the answer clause reaches the LLM's context window — the LLM reads
+   all `k`, so presence in the top-10 matters more than exact rank. RRF wins
+   it.
+2. **RRF has one fixed, standard parameter and no score-normalisation step.**
+   Weighted fusion's per-list min-max normalisation is sensitive to
+   score-distribution shifts — a query with zero BM25 hits, a future
+   embedding-model swap — that RRF's rank-only formula is immune to.
+3. **[M3-05]'s cross-encoder reranker reorders the top-`k`**, which is exactly
+   the top-rank precision weighted fusion buys. Feeding the reranker the
+   higher-recall RRF candidate set is the better pipeline: the reranker fixes
+   ordering, it cannot recover a clause that was never retrieved.
+
+**Deviation from the pre-registered prediction, stated per `MILESTONES.md`:**
+the prediction's rule was "pick weighted if it wins Recall@10 *or* MRR by a
+clear (> 2 pt) margin", and weighted won MRR by 4.3 pt. That rule was a
+pre-commitment against post-hoc cherry-picking; the deviation is on reasons
+1–3, which the full table above lets a reader weigh independently, and both
+strategies remain one flag apart (`--fusion weighted`). [M3-08] re-opens this
+with reranking in the matrix.
+
+### DoD item 4 — cross-document errors are eliminated
+
+The 16 `cross_document` questions each target a document whose same-insurer
+sibling (same CNPJ, **different SUSEP process**) holds a near-duplicate
+distractor clause named in the question's `notes`. Under `--filter default`:
+
+- **foreign-document rate is exactly 0.0%** — not one retrieved clause, across
+  all 117 scored questions, comes from a document other than the target. The
+  named distractor clauses cannot be retrieved: they are in a different SUSEP
+  process, and the process filter excludes them at the SQL / roll-up boundary.
+- `cross_document` Recall@10 rises 62.5% → 93.8% (RRF); the residual misses are
+  within-document ranking, not leakage.
+
+`tests/integration/test_dense_retriever.py` proves the SQL pushdown against a
+real Postgres with a synthetic same-CNPJ decoy partition.
+
+### DoD item 5 — unknown-process degradation
+
+When intake extraction fails to identify the policy, retrieval falls back to
+`--filter none`. Measured cost, RRF hybrid:
+
+| | filtered | unfiltered | drop |
+| --- | ---: | ---: | ---: |
+| Recall@10 | 91.5% | 52.1% | −39.4 pt |
+| MRR | 78.8% | 35.6% | −43.2 pt |
+| foreign-doc rate | 0.0% | 80.2% | +80.2 pt |
+
+Unfiltered, ~80% of every result list is from the wrong document, and — the
+sharper finding — **unfiltered hybrid RRF (52.1%) is worse than unfiltered
+lexical alone (58.7%)**: fusing in the weak unfiltered dense leg (47.4%) hurts.
+This is a robustness result, not an alternative flow to optimise for; the
+realistic broad-search case is `bundle_section` *within* one known insurer's
+filing (`docs/EVALUATION.md`, "Why `cross_document` is not a realistic search
+scenario"), not blind cross-insurer search.
+
+### DoD item 7 — M1-06 bundle-section decision
+
+A strict `WHERE bundle_section = :x` silently drops `bundle_section IS NULL`
+chunks. Post-[M1-04b] the NULL bucket is only ~1.8–3.7% of the two multi-product
+documents (down from ~40%), but excluding unknown-bundle clauses without
+telling anyone is exactly the failure the [M1-06] cross-note warns about.
+
+**Decision: the `bundle_section` filter is lenient by default** — `= :x OR
+bundle_section IS NULL` — with `RetrievalFilter(strict_bundle=True)` as an
+explicit opt-in. `golden-set-v1` has no scorable question that sets a
+`bundle_section` filter (the 4 M2-03 bundle questions live in
+`direct_lookup.jsonl` and are scored document-wide), so there is no golden-set
+delta to report; the behaviour is proven in
+`tests/integration/test_dense_retriever.py` (lenient keeps the NULL chunk,
+strict drops it) and `tests/unit/infrastructure/rag/test_retrieval_filter.py`.
+
+---
+
+## Limitations
+
+- **Product-line coverage stays 2 of 5.** The 117 scorable questions reference
+  only CASCO (114) and CARTA VERDE (3) documents; RCF-A, ASSIST and GAR.EST
+  appear only among the excluded `unanswerable` questions. Broadening scorable
+  coverage is new golden-set authoring, out of scope here — same limitation
+  `docs/LEXICAL_RETRIEVAL.md` and `docs/EVALUATION.md` record.
+- **The dense leg reads the dev database.** `make eval-retrieval-hybrid` runs
+  against whatever `create_engine_from_settings()` resolves to, with real
+  embeddings from `make embed-chunks`. It is not hermetic the way the
+  file-based lexical eval is; the config fingerprints pin the model contract.
+- **The M3-03 "perfect filter" simulation (93.2%) does not reproduce exactly.**
+  That one-off rebuilt BM25 per single-document index, sharpening IDF; the
+  proper filtered lexical number with corpus-wide IDF is **87.2%**. Still
+  clears 0.85; the 6-point gap is the IDF effect, not a regression.
+- **`fusion_weights` are untuned** at `(0.5, 0.5)`. Weighted fusion already
+  beats RRF on MRR/nDCG untuned; a tilt was not explored — [M3-08]'s, with the
+  reranker in the loop.
+
+---
+
+## Deferred / handed to later issues
+
+- **Cross-encoder reranking of the fused top-`k`** — [M3-05].
+- **Exclusion co-retrieval** (pull the exclusion linked to every retrieved
+  coverage clause) — [M3-06]. `coverage_with_exclusion` R@10 78.9% is the
+  weakest type and the reason this exists.
+- **The insufficient-context gate** on the retrieval signals — [M3-07]. The
+  "up to `k`, never padded" contract and a stacked filter legitimately
+  returning `< k` are the inputs it will read.
+- **The lexical / dense / hybrid / hybrid+rerank benchmark matrix and `make
+  build-index`** — [M3-08], which also re-opens the RRF-vs-weighted call with
+  reranking in the mix and re-runs the ANN-earns-its-place check on real
+  embeddings.
+- **A DB-side lexical column** — still declined (see Scope).

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -10,10 +10,19 @@ against garbage retrieval).
 ``--retriever lexical`` [M3-03] runs [infrastructure.rag.lexical_retriever.
 LexicalRetriever]: hand-rolled Okapi BM25 over ``build/chunks.jsonl`` with
 Portuguese tokenisation and Snowball stemming, each chunk hit rolled up to
-its ``source_clause_ids``. No metadata filter (that is [M3-04]'s), so this
-is the standalone lexical baseline the M3-03 DoD asks for; the committed
-numbers and the verdict on which question types it wins live in
-``docs/LEXICAL_RETRIEVAL.md``.
+its ``source_clause_ids``. The M3-03 standalone baseline; committed numbers
+and the per-question-type verdict live in ``docs/LEXICAL_RETRIEVAL.md``.
+
+``--retriever dense`` / ``--retriever hybrid`` [M3-04] run
+[infrastructure.rag.dense_retriever.DenseRetriever] (exact ``<=>`` cosine
+search over the pgvector chunk table) and
+[infrastructure.rag.hybrid_retriever.HybridRetriever] (RRF or weighted
+fusion of the lexical and dense legs). Both need a running Postgres with
+loaded + embedded chunks and the local embedder from the optional ``embed``
+uv group. ``--filter default`` cuts each question to its document's SUSEP
+process + insurer CNPJ (the default retrieval path); ``--filter none`` is
+the unknown-process degradation case. Comparison and verdict:
+``docs/HYBRID_RETRIEVAL.md``.
 
 For every golden question except ``unanswerable`` ones (which carry no
 ``reference_clause_ids`` by schema construction, so Recall/MRR/nDCG are
@@ -22,26 +31,33 @@ dropped), retrieves the top 10 clause ids and computes Recall@{1,5,10},
 MRR and nDCG@10 against ``reference_clause_ids``, each broken down by
 ``question_type``, ``product_line`` and extraction mode (joined onto each
 question via its ``document_id`` against ``data/policies/manifest.csv``),
-plus a separate exclusion-clause recall pooled across every reference
-clause whose ``clause_type`` is ``exclusion``.
+plus a separate exclusion-clause recall and a foreign-document rate
+([M3-04] item 4) pooled across scored questions.
 
-Writes ``eval/runs/retrieval_eval_<retriever>.json`` (machine-readable)
-and ``eval/runs/retrieval_eval_<retriever>.md`` (human-readable), both
-stamped with the [infrastructure.evaluation.retrieval_run_schema.
-RetrievalRunConfig] that produced them. Run via ``make eval-retrieval``.
+Writes ``eval/runs/retrieval_eval_<retriever>[...].json`` (machine-readable)
+and ``.md`` (human-readable), both stamped with the
+[infrastructure.evaluation.retrieval_run_schema.RetrievalRunConfig] that
+produced them. Run via ``make eval-retrieval`` (and ``-lexical`` /
+``-dense`` / ``-hybrid``).
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from domain.clause_classification import ClauseType
+from infrastructure.database import (
+    assert_chunk_table_ready,
+    create_engine_from_settings,
+    create_session_factory,
+)
 from infrastructure.evaluation.golden_set_schema import GoldenQuestion, QuestionType
 from infrastructure.evaluation.random_retriever import DEFAULT_SEED, RandomRetriever
 from infrastructure.evaluation.retrieval_metrics import (
@@ -53,12 +69,32 @@ from infrastructure.evaluation.retrieval_run_schema import (
     SCHEMA_VERSION,
     RetrievalRunConfig,
 )
-from infrastructure.evaluation.retriever import Retriever
+from infrastructure.evaluation.retriever import FilterableRetriever, Retriever
 from infrastructure.parsing.clause_schema import ParsedClauseRecord
 from infrastructure.parsing.corpus_artifact import JSONL_PATH, read_parsed_clauses_jsonl
 from infrastructure.parsing.manifest import read_manifest
 from infrastructure.rag.chunk_artifact import CHUNKS_JSONL_PATH, read_chunks_jsonl
 from infrastructure.rag.chunk_schema import ChunkRecord
+from infrastructure.rag.dense_retriever import DenseRetriever
+from infrastructure.rag.embedder import Embedder
+from infrastructure.rag.embedding_cache import CachingEmbedder
+from infrastructure.rag.embedding_config import (
+    EMBEDDING_MODEL_ID,
+    EMBEDDING_MODEL_REVISION,
+)
+from infrastructure.rag.embedding_config import (
+    config_fingerprint as embedding_config_fingerprint,
+)
+from infrastructure.rag.hybrid_config import (
+    CANDIDATE_DEPTH,
+    FUSION_WEIGHTS,
+    RRF_K,
+    FusionStrategy,
+)
+from infrastructure.rag.hybrid_config import (
+    config_fingerprint as hybrid_config_fingerprint,
+)
+from infrastructure.rag.hybrid_retriever import HybridRetriever
 from infrastructure.rag.lexical_analyzer import build_analyzer
 from infrastructure.rag.lexical_config import (
     BM25_B,
@@ -67,10 +103,13 @@ from infrastructure.rag.lexical_config import (
     LEXICAL_ANALYZER_VERSION,
     LEXICAL_INDEX_TEXT_FIELD,
     LEXICAL_STEMMING_EXCEPTIONS_PATH,
-    config_fingerprint,
+)
+from infrastructure.rag.lexical_config import (
+    config_fingerprint as lexical_config_fingerprint,
 )
 from infrastructure.rag.lexical_retriever import LexicalRetriever
 from infrastructure.rag.lexical_stemming_exceptions import load_stemming_exceptions
+from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 GOLDEN_SET_DIR = Path("data/golden_set")
 MANIFEST_PATH = Path("data/policies/manifest.csv")
@@ -79,7 +118,9 @@ OUTPUT_DIR = Path("eval/runs")
 K_VALUES: tuple[int, ...] = (1, 5, 10)
 NDCG_K = 10
 RETRIEVE_K = max(*K_VALUES, NDCG_K)
-RETRIEVER_NAMES = ("random", "lexical")
+RETRIEVER_NAMES = ("random", "lexical", "dense", "hybrid")
+FILTER_MODES = ("none", "default")
+FUSION_STRATEGIES = tuple(strategy.value for strategy in FusionStrategy)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -96,7 +137,28 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_SEED,
         help="Random seed for the built-in random retriever (default: 42).",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--filter",
+        dest="filter_mode",
+        choices=FILTER_MODES,
+        default="none",
+        help=(
+            "Metadata pre-filter [M3-04] (dense/hybrid only). `default` filters "
+            "each question to its document's SUSEP process + insurer CNPJ (the "
+            "default retrieval path); `none` is the unknown-process degradation "
+            "case. Default: none."
+        ),
+    )
+    parser.add_argument(
+        "--fusion",
+        choices=FUSION_STRATEGIES,
+        default=FusionStrategy.RRF.value,
+        help="Fusion strategy for --retriever hybrid [M3-04] (default: rrf).",
+    )
+    args = parser.parse_args()
+    if args.filter_mode == "default" and args.retriever == "random":
+        parser.error("--filter default is not supported by --retriever random")
+    return args
 
 
 def resolve_source(extraction_mode: str) -> Literal["text", "ocr"]:
@@ -162,6 +224,7 @@ class ScoredQuestion:
 
     question_id: str
     question_type: str
+    document_id: str
     product_line: str
     extraction_mode: str
     reference_clause_ids: tuple[str, ...]
@@ -171,11 +234,36 @@ class ScoredQuestion:
     ndcg: float
 
 
+# A per-question metadata filter, or None (this question is not filtered).
+FilterFor = Callable[[GoldenQuestion], RetrievalFilter | None]
+
+
+def _retrieve(
+    retriever: Retriever,
+    question: str,
+    *,
+    k: int,
+    metadata_filter: RetrievalFilter | None,
+) -> list[str]:
+    """Call ``retriever.retrieve``, threading a [M3-04] filter when there is one.
+
+    ``random`` is scored without a filter (the bare [Retriever], and
+    ``--filter default`` is rejected for it); the filtered path only ever runs
+    against ``lexical``/``dense``/``hybrid``, which satisfy [FilterableRetriever].
+    """
+    if metadata_filter is None:
+        return retriever.retrieve(question, k=k)
+    return cast(FilterableRetriever, retriever).retrieve(
+        question, k=k, metadata_filter=metadata_filter
+    )
+
+
 def evaluate_questions(
     questions: Sequence[GoldenQuestion],
     retriever: Retriever,
     document_meta: dict[str, dict[str, str]],
     *,
+    filter_for: FilterFor | None = None,
     k_values: Sequence[int] = K_VALUES,
     ndcg_k: int = NDCG_K,
     retrieve_k: int = RETRIEVE_K,
@@ -186,6 +274,10 @@ def evaluate_questions(
     against, not scored, since Recall/MRR/nDCG are undefined for an empty
     reference set -- and only counted, so callers can report that count
     instead of silently dropping it.
+
+    ``filter_for`` ([M3-04]) supplies a per-question [RetrievalFilter]; the
+    retriever must then satisfy [FilterableRetriever]. ``None`` (the default)
+    keeps the pre-M3-04 unfiltered call path.
     """
     rows: list[ScoredQuestion] = []
     unanswerable_count = 0
@@ -194,7 +286,10 @@ def evaluate_questions(
             unanswerable_count += 1
             continue
         meta = document_meta[question.document_id]
-        retrieved = retriever.retrieve(question.question, k=retrieve_k)
+        metadata_filter = filter_for(question) if filter_for is not None else None
+        retrieved = _retrieve(
+            retriever, question.question, k=retrieve_k, metadata_filter=metadata_filter
+        )
         recall = {
             k: recall_at_k(retrieved, question.reference_clause_ids, k)
             for k in k_values
@@ -203,6 +298,7 @@ def evaluate_questions(
             ScoredQuestion(
                 question_id=question.question_id,
                 question_type=question.question_type.value,
+                document_id=question.document_id,
                 product_line=meta["product_line"],
                 extraction_mode=resolve_source(meta["extraction_mode"]),
                 reference_clause_ids=tuple(question.reference_clause_ids),
@@ -275,6 +371,34 @@ def compute_exclusion_clause_recall(
     return {"k": k, "hits": hits, "total": total, "recall": recall}
 
 
+def _document_of(clause_id: str) -> str:
+    """The document id prefix of a ``{document_id}:{path}`` clause id."""
+    return clause_id.split(":", 1)[0]
+
+
+def compute_foreign_document_rate(
+    rows: Sequence[ScoredQuestion], *, k: int = RETRIEVE_K
+) -> dict[str, float | int | None]:
+    """Fraction of retrieved top-k clause ids from a document other than target.
+
+    [M3-04] DoD item 4: the metadata pre-filter's job is to keep retrieval
+    inside the question's own SUSEP process. Pooled over every scored question:
+    ``hits`` is the count of retrieved clauses whose document != the question's
+    ``document_id``, ``total`` the count of retrieved clauses. **0 under
+    ``--filter default``**; a non-trivial number under ``--filter none`` is the
+    cross-document leakage the filter removes.
+    """
+    hits = 0
+    total = 0
+    for row in rows:
+        for clause_id in row.retrieved[:k]:
+            total += 1
+            if _document_of(clause_id) != row.document_id:
+                hits += 1
+    rate = hits / total if total > 0 else None
+    return {"k": k, "hits": hits, "total": total, "rate": rate}
+
+
 def build_report(
     config: RetrievalRunConfig,
     rows: Sequence[ScoredQuestion],
@@ -313,6 +437,9 @@ def build_report(
         "by_extraction_mode": by_extraction_mode,
         "exclusion_clause_recall": compute_exclusion_clause_recall(
             rows, clause_by_id, k=exclusion_recall_k
+        ),
+        "foreign_document_rate": compute_foreign_document_rate(
+            rows, k=exclusion_recall_k
         ),
     }
 
@@ -363,8 +490,8 @@ def render_markdown_report(report: dict[str, Any]) -> str:
     lines = [
         "# Retrieval evaluation",
         "",
-        "Generated by `scripts/eval_retrieval.py` (`make eval-retrieval` / "
-        "`make eval-retrieval-lexical`) against the golden set in "
+        "Generated by `scripts/eval_retrieval.py` (`make eval-retrieval` and "
+        "`-lexical` / `-dense` / `-hybrid`) against the golden set in "
         "`data/golden_set/` and the parsed corpus in "
         "`build/parsed_clauses.jsonl`. Recall@k, MRR and nDCG@10 are all "
         "computed over each question's top-10 retrieved clause ids, so MRR "
@@ -394,6 +521,21 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             f"{config['stemming_exception_count']} stemming exceptions",
             f"- Lexical config fingerprint: `{config['lexical_config_fingerprint']}`",
         ]
+    if config.get("dense_model_id"):
+        lines.append(
+            f"- Dense model: `{config['dense_model_id']}` @ "
+            f"`{config['dense_model_revision']}`; embedding config fingerprint "
+            f"`{config['embedding_config_fingerprint']}`"
+        )
+    if config.get("fusion_strategy"):
+        lines += [
+            f"- Fusion: `{config['fusion_strategy']}` (RRF k={config['rrf_k']}, "
+            f"weights {config['fusion_weights']}, candidate depth "
+            f"{config['candidate_depth']})",
+            f"- Hybrid config fingerprint: `{config['hybrid_config_fingerprint']}`",
+        ]
+    if config.get("filter_mode"):
+        lines.append(f"- Metadata filter: `{config['filter_mode']}`")
     lines += [
         f"- Seed: {config['seed']}",
         f"- Run at (UTC): {config['run_at_utc']}",
@@ -427,6 +569,11 @@ def render_markdown_report(report: dict[str, Any]) -> str:
         if exclusion_recall is not None
         else "n/a (no exclusion clauses referenced)"
     )
+    foreign = report["foreign_document_rate"]
+    foreign_rate = foreign["rate"]
+    foreign_line = (
+        _fmt(foreign_rate) if foreign_rate is not None else "n/a (nothing retrieved)"
+    )
     lines += [
         "## Exclusion-clause recall",
         "",
@@ -435,9 +582,19 @@ def render_markdown_report(report: dict[str, Any]) -> str:
         f"{exclusion['k']}: **{exclusion_line}** "
         f"({exclusion['hits']}/{exclusion['total']}).",
         "",
+        "## Foreign-document rate",
+        "",
+        f"Of every clause retrieved in the top-{foreign['k']} across all scored "
+        "questions, the fraction from a document other than the question's "
+        f"target: **{foreign_line}** ({foreign['hits']}/{foreign['total']}). "
+        "[M3-04] item 4: this is **0** under the SUSEP process + CNPJ "
+        "pre-filter, and the cross-document leakage the filter removes when "
+        "unfiltered.",
+        "",
         "## Summary",
         "",
         f"- Retriever: `{config['retriever_name']}`",
+        f"- Metadata filter: `{config.get('filter_mode', 'none')}`",
         f"- Questions scored: {int(report['overall']['n'])} "
         f"(of {config['golden_set_question_count']} total; "
         f"{report['by_question_type']['unanswerable']['n']} unanswerable excluded)",
@@ -446,6 +603,7 @@ def render_markdown_report(report: dict[str, Any]) -> str:
         f"- Overall MRR: {_fmt(report['overall']['mrr'])}",
         f"- Overall nDCG@{ndcg_k}: {_fmt(report['overall'][f'ndcg@{ndcg_k}'])}",
         f"- Exclusion-clause recall: {exclusion_line}",
+        f"- Foreign-document rate: {foreign_line}",
         "",
     ]
     return "\n".join(lines)
@@ -457,7 +615,7 @@ def _random_config_fields(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _lexical_config_fields(chunks: Sequence[ChunkRecord]) -> dict[str, Any]:
-    """The `--retriever lexical` slice of RetrievalRunConfig: the BM25 contract."""
+    """The lexical-leg slice of RetrievalRunConfig: the BM25 contract."""
     exception_tokens = load_stemming_exceptions(LEXICAL_STEMMING_EXCEPTIONS_PATH)
     return {
         "seed": None,
@@ -469,10 +627,125 @@ def _lexical_config_fields(chunks: Sequence[ChunkRecord]) -> dict[str, Any]:
         "lexical_idf_variant": IDF_VARIANT,
         "lexical_index_text_field": LEXICAL_INDEX_TEXT_FIELD,
         "stemming_exception_count": len(exception_tokens),
-        "lexical_config_fingerprint": config_fingerprint(
+        "lexical_config_fingerprint": lexical_config_fingerprint(
             exception_tokens=exception_tokens
         ),
     }
+
+
+def _dense_config_fields() -> dict[str, Any]:
+    """The dense-leg slice of RetrievalRunConfig: the pinned embedding contract."""
+    return {
+        "seed": None,
+        "dense_model_id": EMBEDDING_MODEL_ID,
+        "dense_model_revision": EMBEDDING_MODEL_REVISION,
+        "embedding_config_fingerprint": embedding_config_fingerprint(),
+    }
+
+
+def _hybrid_config_fields(chunks: Sequence[ChunkRecord], fusion: str) -> dict[str, Any]:
+    """The `--retriever hybrid` slice: both legs plus the fusion contract."""
+    lexical = _lexical_config_fields(chunks)
+    return {
+        **lexical,
+        **_dense_config_fields(),
+        "fusion_strategy": fusion,
+        "rrf_k": RRF_K,
+        "fusion_weights": list(FUSION_WEIGHTS),
+        "candidate_depth": CANDIDATE_DEPTH,
+        "hybrid_config_fingerprint": hybrid_config_fingerprint(
+            lexical_config_fingerprint=lexical["lexical_config_fingerprint"]
+        ),
+    }
+
+
+@contextmanager
+def _open_retriever(
+    args: argparse.Namespace, corpus: Sequence[ParsedClauseRecord]
+) -> Iterator[tuple[Retriever, dict[str, Any]]]:
+    """Yield ``(retriever, config fields)``; ``dense``/``hybrid`` hold a DB session.
+
+    ``dense``/``hybrid`` need Postgres (loaded + embedded chunks) and the local
+    embedder from the optional ``embed`` uv group, so ``make
+    eval-retrieval-hybrid`` runs under ``uv run --group embed`` -- mirroring
+    ``make embed-chunks``. The query embedder is wrapped in a
+    [infrastructure.rag.embedding_cache.CachingEmbedder] so a re-run over the
+    117 golden queries costs nothing.
+    """
+    name = args.retriever
+    if name == "random":
+        yield (
+            RandomRetriever([r.clause_id for r in corpus], seed=args.seed),
+            _random_config_fields(args),
+        )
+        return
+    if name == "lexical":
+        chunks = load_chunk_corpus()
+        yield build_lexical_retriever(chunks), _lexical_config_fields(chunks)
+        return
+
+    engine = create_engine_from_settings()
+    session = create_session_factory(engine=engine)()
+    try:
+        assert_chunk_table_ready(session)
+        embedder = CachingEmbedder(_load_query_embedder())
+        dense = DenseRetriever(session, embedder)
+        if name == "dense":
+            yield dense, _dense_config_fields()
+        else:
+            chunks = load_chunk_corpus()
+            hybrid = HybridRetriever(
+                build_lexical_retriever(chunks),
+                dense,
+                fusion=FusionStrategy(args.fusion),
+            )
+            yield hybrid, _hybrid_config_fields(chunks, args.fusion)
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _load_query_embedder() -> Embedder:
+    """Load the real local embedder.
+
+    Deferred import so the heavy ``embed`` group is only needed for
+    ``dense``/``hybrid`` runs (mirrors ``scripts/embed_chunks.py``).
+    """
+    from infrastructure.rag.sentence_transformer_embedder import (
+        SentenceTransformerEmbedder,
+    )
+
+    return SentenceTransformerEmbedder()
+
+
+def _build_filter_for(
+    filter_mode: str, document_meta: dict[str, dict[str, str]]
+) -> FilterFor | None:
+    """`default` -> a per-question SUSEP process + CNPJ filter; `none` -> None."""
+    if filter_mode != "default":
+        return None
+
+    def filter_for(question: GoldenQuestion) -> RetrievalFilter | None:
+        return RetrievalFilter.from_manifest_row(document_meta[question.document_id])
+
+    return filter_for
+
+
+def _output_stem(args: argparse.Namespace) -> str:
+    """`eval/runs/` basename, tagged by the run's distinguishing options.
+
+    ``random`` and the unfiltered ``lexical`` baseline keep their pre-M3-04
+    names (``retrieval_eval_random`` / ``retrieval_eval_lexical``) so the
+    ``docs/LEXICAL_RETRIEVAL.md`` reference and the eval smoke test stay valid;
+    every other combination is tagged so the four hybrid comparison runs do not
+    overwrite each other.
+    """
+    parts = [args.retriever]
+    if args.retriever == "hybrid":
+        parts.append(args.fusion)
+    if args.filter_mode != "none":
+        parts.append(f"filter-{args.filter_mode}")
+    return "retrieval_eval_" + "_".join(parts)
 
 
 def main() -> None:
@@ -483,24 +756,16 @@ def main() -> None:
     corpus = load_corpus(JSONL_PATH)
     clause_by_id = {record.clause_id: record for record in corpus}
     questions = load_golden_questions(GOLDEN_SET_DIR)
+    filter_for = _build_filter_for(args.filter_mode, document_meta)
 
-    retriever_name = args.retriever
-    retriever: Retriever
-    if retriever_name == "lexical":
-        chunks = load_chunk_corpus()
-        retriever = build_lexical_retriever(chunks)
-        extra_config = _lexical_config_fields(chunks)
-    else:
-        retriever = RandomRetriever(
-            [record.clause_id for record in corpus], seed=args.seed
+    with _open_retriever(args, corpus) as (retriever, extra_config):
+        rows, unanswerable_count = evaluate_questions(
+            questions, retriever, document_meta, filter_for=filter_for
         )
-        extra_config = _random_config_fields(args)
-
-    rows, unanswerable_count = evaluate_questions(questions, retriever, document_meta)
 
     config = RetrievalRunConfig(
         schema_version=SCHEMA_VERSION,
-        retriever_name=retriever_name,
+        retriever_name=args.retriever,
         k_values=list(K_VALUES),
         ndcg_k=NDCG_K,
         golden_set_dir=str(GOLDEN_SET_DIR),
@@ -508,13 +773,15 @@ def main() -> None:
         corpus_path=str(JSONL_PATH),
         corpus_clause_count=len(corpus),
         run_at_utc=datetime.now(UTC),
+        filter_mode=args.filter_mode,
         **extra_config,
     )
     report = build_report(config, rows, unanswerable_count, clause_by_id)
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    json_path = OUTPUT_DIR / f"retrieval_eval_{retriever_name}.json"
-    md_path = OUTPUT_DIR / f"retrieval_eval_{retriever_name}.md"
+    stem = _output_stem(args)
+    json_path = OUTPUT_DIR / f"{stem}.json"
+    md_path = OUTPUT_DIR / f"{stem}.md"
     json_path.write_text(
         json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -526,6 +793,7 @@ def main() -> None:
         f"MRR={_fmt(overall['mrr'])} nDCG@{NDCG_K}={_fmt(overall[f'ndcg@{NDCG_K}'])}"
     )
     print(f"Exclusion-clause recall: {report['exclusion_clause_recall']['recall']}")
+    print(f"Foreign-document rate: {report['foreign_document_rate']['rate']}")
     print(f"Wrote {json_path} and {md_path}")
 
 

--- a/tests/eval/test_hybrid_retrieval_baseline.py
+++ b/tests/eval/test_hybrid_retrieval_baseline.py
@@ -1,0 +1,92 @@
+"""Sanity floor for the [M3-04] hybrid retriever + metadata pre-filter.
+
+The mirror of ``test_lexical_retrieval_baseline.py`` for the full pipeline:
+proves the RRF hybrid, filtered to each question's SUSEP process + CNPJ,
+clears a floor far above the unfiltered legs on the real golden set, and that
+the pre-filter drives the foreign-document rate to exactly zero ([M3-04] item
+4). A smoke check, not a quality gate -- the committed numbers and the verdict
+live in ``docs/HYBRID_RETRIEVAL.md``.
+
+Needs more than the lexical baseline: ``build/chunks.jsonl``, a reachable
+Postgres with embedded chunks, and the optional ``embed`` uv group. Skips
+cleanly when any is absent, so ``make test-eval`` stays green on a machine
+without the stack.
+"""
+
+import argparse
+
+import pytest
+from sqlalchemy import func, select
+
+from infrastructure.rag.chunk_artifact import CHUNKS_JSONL_PATH
+
+pytestmark = pytest.mark.eval
+
+RECALL_FLOOR = 0.80
+MRR_FLOOR = 0.55
+
+
+def _skip_unless_ready() -> None:
+    if not CHUNKS_JSONL_PATH.exists():
+        pytest.skip("build/chunks.jsonl not built; run `make build-chunks`")
+    try:
+        import sentence_transformers  # noqa: F401
+    except ImportError:
+        pytest.skip("optional `embed` group not installed; `uv sync --group embed`")
+    from infrastructure.database import (
+        create_engine_from_settings,
+        create_session_factory,
+    )
+    from infrastructure.database.models import ChunkRow
+
+    try:
+        engine = create_engine_from_settings()
+        with create_session_factory(engine=engine)() as session:
+            embedded = session.execute(
+                select(func.count())
+                .select_from(ChunkRow)
+                .where(ChunkRow.embedding.is_not(None))
+            ).scalar_one()
+        engine.dispose()
+    except Exception as exc:  # noqa: BLE001 - any DB failure is a skip, not a fail
+        pytest.skip(f"database not ready for the hybrid eval: {exc}")
+    if embedded < 100:
+        pytest.skip(f"only {embedded} embedded chunks; run `make embed-chunks`")
+
+
+@pytest.mark.eval
+def test_filtered_hybrid_clears_a_floor_and_stays_in_document() -> None:
+    _skip_unless_ready()
+
+    from scripts.eval_retrieval import (
+        GOLDEN_SET_DIR,
+        MANIFEST_PATH,
+        _build_filter_for,
+        _open_retriever,
+        aggregate,
+        compute_foreign_document_rate,
+        evaluate_questions,
+        load_corpus,
+        load_document_metadata,
+        load_golden_questions,
+    )
+
+    from infrastructure.parsing.corpus_artifact import JSONL_PATH
+
+    args = argparse.Namespace(
+        retriever="hybrid", fusion="rrf", filter_mode="default", seed=42
+    )
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    questions = load_golden_questions(GOLDEN_SET_DIR)
+    filter_for = _build_filter_for("default", document_meta)
+
+    with _open_retriever(args, load_corpus(JSONL_PATH)) as (retriever, _config):
+        rows, _ = evaluate_questions(
+            questions, retriever, document_meta, filter_for=filter_for
+        )
+
+    overall = aggregate(rows, (1, 5, 10), 10)
+    assert overall["recall@10"] > RECALL_FLOOR
+    assert overall["mrr"] > MRR_FLOOR
+    # DoD item 4: the process + CNPJ filter never leaks into another document.
+    assert compute_foreign_document_rate(rows, k=10)["rate"] == 0.0

--- a/tests/integration/test_dense_retriever.py
+++ b/tests/integration/test_dense_retriever.py
@@ -1,0 +1,203 @@
+"""Dense retrieval + the metadata pre-filter against a real Postgres -- [M3-04].
+
+Covers what only SQL + pgvector can prove: the ``<=>`` cosine search orders by
+the stored vectors, the [RetrievalFilter] translates to a ``WHERE`` that pushes
+down (a same-CNPJ decoy document is excluded by SUSEP process -- the M2-03
+cross-document case), insurers are matched by CNPJ not name, a stacked filter
+legitimately returns fewer than ``k``, and the ``bundle_section`` lenient/strict
+NULL rule behaves. Synthetic vectors, built in-test -- the CI integration job
+does not fetch the corpus. The embedder is a deterministic fake; no live model
+call anywhere in the suite.
+"""
+
+from collections.abc import Sequence
+from math import cos, sin
+
+import pytest
+from sqlalchemy.orm import Session
+
+from domain.clause_classification import ClauseType
+from infrastructure.database.chunk_repository import (
+    upsert_chunks,
+    write_chunk_embeddings,
+)
+from infrastructure.rag.chunk_schema import SCHEMA_VERSION, ChunkRecord
+from infrastructure.rag.dense_retriever import DenseRetriever
+from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+pytestmark = pytest.mark.integration
+
+_TARGET = {"susep_process": "10000.111111/2024-11", "cnpj": "11111111000111"}
+# Same CNPJ, different SUSEP process -- the M2-03 near-duplicate sibling.
+_DECOY = {"susep_process": "10000.222222/2024-22", "cnpj": "11111111000111"}
+# A different insurer sharing a brand name would still differ by CNPJ.
+_OTHER_INSURER = {"susep_process": "10000.333333/2024-33", "cnpj": "99999999000199"}
+
+
+def _planar(theta: float) -> list[float]:
+    """A unit vector at angle ``theta`` in the axis 0/1 plane; farther = larger."""
+    vector = [0.0] * EMBEDDING_DIMENSIONS
+    vector[0] = cos(theta)
+    vector[1] = sin(theta)
+    return vector
+
+
+class FakeEmbedder:
+    """Embeds any text to the fixed query direction (axis 0)."""
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        return [_planar(0.0) for _ in texts]
+
+
+def _record(
+    chunk_id: str,
+    partition: dict[str, str],
+    *,
+    clause_type: str = "coverage",
+    bundle_section: str | None = None,
+) -> ChunkRecord:
+    base: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "chunk_id": chunk_id,
+        "document_id": partition["susep_process"],
+        "clause_id": chunk_id,
+        "source_clause_ids": [chunk_id],
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "parent_path": "",
+        "text": "Texto da cláusula.",
+        "display_text": "Texto da cláusula.",
+        "char_count": 18,
+        "rule": "single",
+        "clause_type": clause_type,
+        "type_source": "rule",
+        "confidence": None,
+        "bundle_section": bundle_section,
+        "source": "text",
+        "insurer": "Seguradora Compartilhada",
+        "product_line": "CASCO",
+        "indemnity_regime": "VD",
+        "filing_year": "2024",
+        **partition,
+    }
+    return ChunkRecord.model_validate(base)
+
+
+def _load(
+    session: Session,
+    records: list[ChunkRecord],
+    vectors: dict[str, list[float]],
+) -> None:
+    upsert_chunks(session, records)
+    write_chunk_embeddings(session, vectors)
+    session.flush()
+
+
+def _retriever(session: Session) -> DenseRetriever:
+    return DenseRetriever(session, FakeEmbedder())
+
+
+def test_process_filter_excludes_the_same_cnpj_decoy_document(
+    db_session: Session,
+) -> None:
+    # 12 decoys at the query direction (closest); 12 targets farther out.
+    records: list[ChunkRecord] = []
+    vectors: dict[str, list[float]] = {}
+    for i in range(12):
+        records.append(_record(f"d:{i}", _DECOY))
+        vectors[f"d:{i}"] = _planar(0.01 * (i + 1))
+        records.append(_record(f"t:{i}", _TARGET))
+        vectors[f"t:{i}"] = _planar(0.5 + 0.01 * (i + 1))
+    _load(db_session, records, vectors)
+    retriever = _retriever(db_session)
+
+    # Unfiltered: the decoys are nearer, so they win.
+    assert all(cid.startswith("d:") for cid in retriever.retrieve("q", k=10))
+
+    # Filtered to the target's SUSEP process: only target clauses, k of them,
+    # in distance order.
+    filt = RetrievalFilter.from_manifest_row(_TARGET)
+    hits = retriever.retrieve("q", k=10, metadata_filter=filt)
+    assert hits == [f"t:{i}" for i in range(10)]
+
+
+def test_cnpj_filter_matches_by_cnpj_never_by_insurer_name(
+    db_session: Session,
+) -> None:
+    records = [_record("a:0", _TARGET), _record("b:0", _OTHER_INSURER)]
+    vectors = {"a:0": _planar(0.1), "b:0": _planar(0.2)}
+    _load(db_session, records, vectors)
+
+    # Both rows share the `insurer` string; only the CNPJ distinguishes them.
+    hits = _retriever(db_session).retrieve(
+        "q", k=10, metadata_filter=RetrievalFilter(cnpj=_TARGET["cnpj"])
+    )
+    assert hits == ["a:0"]
+
+
+def test_exact_search_fills_k_when_the_partition_has_enough_rows(
+    db_session: Session,
+) -> None:
+    records = [_record(f"t:{i}", _TARGET) for i in range(15)]
+    vectors = {f"t:{i}": _planar(0.01 * (i + 1)) for i in range(15)}
+    _load(db_session, records, vectors)
+
+    hits = _retriever(db_session).retrieve(
+        "q", k=10, metadata_filter=RetrievalFilter.from_manifest_row(_TARGET)
+    )
+    assert len(hits) == 10
+
+
+def test_a_stacked_clause_type_filter_can_return_fewer_than_k(
+    db_session: Session,
+) -> None:
+    records = [_record(f"cov:{i}", _TARGET) for i in range(10)]
+    records += [_record(f"exc:{i}", _TARGET, clause_type="exclusion") for i in range(2)]
+    vectors = {r.chunk_id: _planar(0.01 * (i + 1)) for i, r in enumerate(records)}
+    _load(db_session, records, vectors)
+
+    filt = RetrievalFilter(
+        susep_process=_TARGET["susep_process"], clause_type=ClauseType.EXCLUSION
+    )
+    hits = _retriever(db_session).retrieve("q", k=10, metadata_filter=filt)
+    assert sorted(hits) == ["exc:0", "exc:1"]
+
+
+def test_bundle_section_lenient_keeps_null_chunks_strict_drops_them(
+    db_session: Session,
+) -> None:
+    records = [
+        _record("moto:0", _TARGET, bundle_section="Moto"),
+        _record("null:0", _TARGET, bundle_section=None),
+        _record("carga:0", _TARGET, bundle_section="Carga"),
+    ]
+    vectors = {
+        "moto:0": _planar(0.1),
+        "null:0": _planar(0.2),
+        "carga:0": _planar(0.3),
+    }
+    _load(db_session, records, vectors)
+    retriever = _retriever(db_session)
+
+    lenient = retriever.retrieve(
+        "q", k=10, metadata_filter=RetrievalFilter(bundle_section="Moto")
+    )
+    assert sorted(lenient) == ["moto:0", "null:0"]
+
+    strict = retriever.retrieve(
+        "q",
+        k=10,
+        metadata_filter=RetrievalFilter(bundle_section="Moto", strict_bundle=True),
+    )
+    assert strict == ["moto:0"]
+
+
+def test_chunks_without_an_embedding_are_never_returned(db_session: Session) -> None:
+    records = [_record("has_vec", _TARGET), _record("no_vec", _TARGET)]
+    upsert_chunks(db_session, records)
+    write_chunk_embeddings(db_session, {"has_vec": _planar(0.1)})
+    db_session.flush()
+
+    hits = _retriever(db_session).retrieve("q", k=10)
+    assert hits == ["has_vec"]

--- a/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
+++ b/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
@@ -60,3 +60,35 @@ def test_lexical_fields_are_optional_and_round_trip() -> None:
         lexical_config_fingerprint="deadbeefdeadbeef",
     )
     assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config
+
+
+@pytest.mark.unit
+def test_v3_filter_and_fusion_fields_are_optional_and_round_trip() -> None:
+    # `random`/`lexical` leave every [M3-04] field None; `hybrid` sets them.
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "retriever_name": "hybrid",
+        "k_values": [1, 5, 10],
+        "ndcg_k": 10,
+        "golden_set_dir": "data/golden_set",
+        "golden_set_question_count": 140,
+        "corpus_path": "build/parsed_clauses.jsonl",
+        "corpus_clause_count": 4925,
+        "seed": None,
+        "run_at_utc": datetime.now(UTC),
+    }
+    assert RetrievalRunConfig(**base).fusion_strategy is None
+
+    config = RetrievalRunConfig(
+        **base,
+        filter_mode="default",
+        dense_model_id="Alibaba-NLP/gte-multilingual-base",
+        dense_model_revision="9bbca17d",
+        embedding_config_fingerprint="7ea39a621eaee88e",
+        fusion_strategy="rrf",
+        rrf_k=60,
+        fusion_weights=[0.5, 0.5],
+        candidate_depth=100,
+        hybrid_config_fingerprint="279ed8ee0a668227",
+    )
+    assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config

--- a/tests/unit/infrastructure/rag/test_fusion.py
+++ b/tests/unit/infrastructure/rag/test_fusion.py
@@ -1,0 +1,68 @@
+"""Rank / score fusion of the retrieval legs -- [M3-04]."""
+
+import pytest
+
+from infrastructure.rag.fusion import reciprocal_rank_fusion, weighted_score_fusion
+
+
+@pytest.mark.unit
+def test_rrf_rewards_agreement_across_lists() -> None:
+    lexical = ["a", "b", "c"]
+    dense = ["c", "a", "d"]
+
+    # `a` is rank 1+2, `c` is rank 3+1 -> both beat the singletons; `a` edges
+    # `c` (1/61 + 1/62 > 1/63 + 1/61).
+    assert reciprocal_rank_fusion([lexical, dense], k=60) == ["a", "c", "b", "d"]
+
+
+@pytest.mark.unit
+def test_rrf_tie_breaks_on_clause_id_ascending() -> None:
+    # Symmetric single-list input: every id has the same score.
+    assert reciprocal_rank_fusion([["b", "a"], ["a", "b"]], k=60) == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_rrf_handles_empty_and_single_lists() -> None:
+    assert reciprocal_rank_fusion([], k=60) == []
+    assert reciprocal_rank_fusion([[], []], k=60) == []
+    assert reciprocal_rank_fusion([["a", "b"]], k=60) == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_rrf_counts_a_repeated_id_once_at_its_best_rank() -> None:
+    # A leg that (defensively) emits a dup must not double-score it.
+    once = reciprocal_rank_fusion([["a", "b"]], k=60)
+    twice = reciprocal_rank_fusion([["a", "a", "b"]], k=60)
+    assert once == twice == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_weighted_fusion_normalises_each_list_independently() -> None:
+    lexical = [("a", 10.0), ("b", 0.0)]  # -> a:1.0, b:0.0
+    dense = [("b", 0.9), ("a", 0.1)]  # -> b:1.0, a:0.0
+    # equal weights -> a and b both sum to 1.0 -> tie -> id order.
+    assert weighted_score_fusion([lexical, dense], weights=(0.5, 0.5)) == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_weighted_fusion_weights_shift_the_ranking() -> None:
+    lexical = [("a", 10.0), ("b", 0.0)]
+    dense = [("b", 0.9), ("a", 0.1)]
+    assert weighted_score_fusion([lexical, dense], weights=(0.9, 0.1)) == ["a", "b"]
+    assert weighted_score_fusion([lexical, dense], weights=(0.1, 0.9)) == ["b", "a"]
+
+
+@pytest.mark.unit
+def test_weighted_fusion_all_equal_scores_normalise_to_one() -> None:
+    # A list whose scores are all equal (incl. a singleton) contributes its
+    # full weight to every member rather than dividing by zero.
+    result = weighted_score_fusion(
+        [[("a", 5.0), ("b", 5.0)], [("a", 1.0)]], weights=(1.0, 1.0)
+    )
+    assert result == ["a", "b"]  # a: 1.0 + 1.0, b: 1.0 + 0
+
+
+@pytest.mark.unit
+def test_weighted_fusion_rejects_a_weight_count_mismatch() -> None:
+    with pytest.raises(ValueError, match="2 lists but 1 weights"):
+        weighted_score_fusion([[("a", 1.0)], [("b", 1.0)]], weights=(1.0,))

--- a/tests/unit/infrastructure/rag/test_hybrid_config.py
+++ b/tests/unit/infrastructure/rag/test_hybrid_config.py
@@ -1,0 +1,61 @@
+"""The pinned hybrid-retrieval contract and its anti-drift guards -- [M3-04]."""
+
+import re
+
+import pytest
+
+from infrastructure.rag import hybrid_config
+from infrastructure.rag.hybrid_config import (
+    CANDIDATE_DEPTH,
+    DEFAULT_FUSION_STRATEGY,
+    FUSION_WEIGHTS,
+    RRF_K,
+    FusionStrategy,
+    config_fingerprint,
+)
+
+_LEXICAL_FP = "ef0a2dd0c1dfb4e4"
+
+
+@pytest.mark.unit
+def test_contract_constants() -> None:
+    assert RRF_K == 60
+    assert FUSION_WEIGHTS == (0.5, 0.5)
+    assert CANDIDATE_DEPTH == 100
+    assert DEFAULT_FUSION_STRATEGY is FusionStrategy.RRF
+
+
+@pytest.mark.unit
+def test_config_fingerprint_shape_and_dependence_on_the_lexical_fingerprint() -> None:
+    digest = config_fingerprint(lexical_config_fingerprint=_LEXICAL_FP)
+    assert re.fullmatch(r"[0-9a-f]{16}", digest)
+    assert config_fingerprint(lexical_config_fingerprint="other") != digest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("attr", "value"),
+    [
+        ("RRF_K", 40),
+        ("FUSION_WEIGHTS", (0.7, 0.3)),
+        ("CANDIDATE_DEPTH", 50),
+        ("DEFAULT_FUSION_STRATEGY", FusionStrategy.WEIGHTED),
+    ],
+)
+def test_every_contract_field_changes_the_fingerprint(
+    monkeypatch: pytest.MonkeyPatch, attr: str, value: object
+) -> None:
+    baseline = config_fingerprint(lexical_config_fingerprint=_LEXICAL_FP)
+    monkeypatch.setattr(hybrid_config, attr, value)
+    assert config_fingerprint(lexical_config_fingerprint=_LEXICAL_FP) != baseline
+
+
+@pytest.mark.unit
+def test_fingerprint_moves_with_the_embedding_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infrastructure.rag import embedding_config
+
+    baseline = config_fingerprint(lexical_config_fingerprint=_LEXICAL_FP)
+    monkeypatch.setattr(embedding_config, "EMBEDDING_MODEL_REVISION", "deadbeef")
+    assert config_fingerprint(lexical_config_fingerprint=_LEXICAL_FP) != baseline

--- a/tests/unit/infrastructure/rag/test_hybrid_retriever.py
+++ b/tests/unit/infrastructure/rag/test_hybrid_retriever.py
@@ -1,0 +1,93 @@
+"""Hybrid fusion of the lexical and dense legs -- [M3-04]."""
+
+import pytest
+
+from infrastructure.rag.hybrid_config import FusionStrategy
+from infrastructure.rag.hybrid_retriever import HybridRetriever
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+class FakeLeg:
+    """A retrieval leg double: returns a fixed scored list, records the filter."""
+
+    def __init__(self, scored: list[tuple[str, float]]) -> None:
+        self._scored = scored
+        self.seen_filter: RetrievalFilter | None = None
+        self.seen_k: int | None = None
+
+    def retrieve_scored(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[tuple[str, float]]:
+        del question
+        self.seen_filter = metadata_filter
+        self.seen_k = k
+        return self._scored[:k]
+
+
+@pytest.mark.unit
+def test_rrf_fuses_both_legs_and_truncates_to_k() -> None:
+    lexical = FakeLeg([("a", 5.0), ("b", 4.0), ("c", 3.0)])
+    dense = FakeLeg([("c", 0.9), ("a", 0.8), ("d", 0.7)])
+    hybrid = HybridRetriever(lexical, dense, fusion=FusionStrategy.RRF)
+
+    # `a` (rank 1 + 2) and `c` (rank 3 + 1) beat the singletons `b`, `d`.
+    assert hybrid.retrieve("q", k=2) == ["a", "c"]
+
+
+@pytest.mark.unit
+def test_weighted_fusion_uses_the_leg_scores() -> None:
+    lexical = FakeLeg([("a", 100.0), ("b", 0.0)])
+    dense = FakeLeg([("b", 0.9), ("a", 0.1)])
+    hybrid = HybridRetriever(lexical, dense, fusion=FusionStrategy.WEIGHTED)
+
+    # Balanced weights, each leg normalised to [0,1]: a and b both sum to 1.0,
+    # tie -> id order.
+    assert hybrid.retrieve("q", k=2) == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_the_metadata_filter_reaches_both_legs() -> None:
+    lexical = FakeLeg([("a", 1.0)])
+    dense = FakeLeg([("a", 1.0)])
+    hybrid = HybridRetriever(lexical, dense)
+    filt = RetrievalFilter(susep_process="P", cnpj="C")
+
+    hybrid.retrieve("q", k=5, metadata_filter=filt)
+
+    assert lexical.seen_filter is filt
+    assert dense.seen_filter is filt
+
+
+@pytest.mark.unit
+def test_each_leg_is_asked_for_candidate_depth_not_k() -> None:
+    lexical = FakeLeg([("a", 1.0)])
+    dense = FakeLeg([("a", 1.0)])
+    hybrid = HybridRetriever(lexical, dense)
+
+    hybrid.retrieve("q", k=3)
+
+    assert lexical.seen_k == 100  # hybrid_config.CANDIDATE_DEPTH
+    assert dense.seen_k == 100
+
+
+@pytest.mark.unit
+def test_returns_fewer_than_k_without_padding() -> None:
+    hybrid = HybridRetriever(FakeLeg([("a", 1.0)]), FakeLeg([]))
+    assert hybrid.retrieve("q", k=10) == ["a"]
+
+
+@pytest.mark.unit
+def test_non_positive_k_returns_empty() -> None:
+    hybrid = HybridRetriever(FakeLeg([("a", 1.0)]), FakeLeg([("a", 1.0)]))
+    assert hybrid.retrieve("q", k=0) == []
+
+
+@pytest.mark.unit
+def test_default_strategy_is_rrf() -> None:
+    hybrid = HybridRetriever(FakeLeg([("a", 1.0)]), FakeLeg([("b", 1.0)]))
+    # A run that would differ under weighted (disjoint singletons, equal RRF).
+    assert hybrid.retrieve("q", k=2) == ["a", "b"]

--- a/tests/unit/infrastructure/rag/test_lexical_retriever.py
+++ b/tests/unit/infrastructure/rag/test_lexical_retriever.py
@@ -2,8 +2,10 @@
 
 import pytest
 
+from domain.clause_classification import ClauseType
 from infrastructure.rag.chunk_schema import ChunkRecord
 from infrastructure.rag.lexical_retriever import LexicalRetriever
+from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 
 class WhitespaceAnalyzer:
@@ -18,12 +20,17 @@ def _chunk(
     clause_id: str,
     source_clause_ids: list[str],
     text: str,
+    *,
+    document_id: str = "1",
+    susep_process: str = "123",
+    cnpj: str = "123",
+    clause_type: str = "coverage",
 ) -> ChunkRecord:
     return ChunkRecord.model_validate(
         {
             "schema_version": "v1",
             "chunk_id": chunk_id,
-            "document_id": "1",
+            "document_id": document_id,
             "clause_id": clause_id,
             "source_clause_ids": source_clause_ids,
             "chunk_index": 0,
@@ -33,14 +40,14 @@ def _chunk(
             "display_text": text,
             "char_count": len(text),
             "rule": "single",
-            "clause_type": "coverage",
+            "clause_type": clause_type,
             "type_source": "rule",
             "confidence": 1.0,
             "bundle_section": None,
             "source": "text",
-            "susep_process": "123",
+            "susep_process": susep_process,
             "insurer": "Insurer",
-            "cnpj": "123",
+            "cnpj": cnpj,
             "product_line": "CASCO",
             "indemnity_regime": "VD",
             "filing_year": "2020",
@@ -95,3 +102,49 @@ def test_retrieval_is_deterministic() -> None:
     retriever = _retriever()
     query = "reboque exclusao franquia"
     assert retriever.retrieve(query, k=5) == retriever.retrieve(query, k=5)
+
+
+# -- [M3-04] metadata filter + retrieve_scored -------------------------------- #
+
+_CROSS_DOC_CHUNKS = [
+    _chunk("1:a", "1:a", ["1:a"], "franquia reduzida vidros", susep_process="P1"),
+    _chunk("2:a", "2:a", ["2:a"], "franquia reduzida vidros", susep_process="P2"),
+]
+
+
+@pytest.mark.unit
+def test_a_process_filter_keeps_only_the_matching_document() -> None:
+    retriever = LexicalRetriever.from_chunks(_CROSS_DOC_CHUNKS, WhitespaceAnalyzer())
+    filt = RetrievalFilter(susep_process="P1")
+
+    assert retriever.retrieve("franquia", k=10, metadata_filter=filt) == ["1:a"]
+
+
+@pytest.mark.unit
+def test_a_clause_type_filter_drops_non_matching_chunks() -> None:
+    chunks = [
+        _chunk("1:cov", "1:cov", ["1:cov"], "guerra", clause_type="coverage"),
+        _chunk("1:exc", "1:exc", ["1:exc"], "guerra", clause_type="exclusion"),
+    ]
+    retriever = LexicalRetriever.from_chunks(chunks, WhitespaceAnalyzer())
+    filt = RetrievalFilter(clause_type=ClauseType.EXCLUSION)
+
+    assert retriever.retrieve("guerra", k=10, metadata_filter=filt) == ["1:exc"]
+
+
+@pytest.mark.unit
+def test_retrieve_scored_returns_bm25_scores_best_first() -> None:
+    scored = _retriever().retrieve_scored("franquia vidros cobertura", k=10)
+
+    assert scored[0][0] == "1:cov"
+    assert all(isinstance(score, float) for _, score in scored)
+    assert [s for _, s in scored] == sorted((s for _, s in scored), reverse=True)
+
+
+@pytest.mark.unit
+def test_retrieve_projects_retrieve_scored() -> None:
+    retriever = _retriever()
+    query = "reboque exclusao franquia"
+    assert retriever.retrieve(query, k=5) == [
+        clause_id for clause_id, _ in retriever.retrieve_scored(query, k=5)
+    ]

--- a/tests/unit/infrastructure/rag/test_retrieval_filter.py
+++ b/tests/unit/infrastructure/rag/test_retrieval_filter.py
@@ -1,0 +1,104 @@
+"""The metadata pre-filter -- [M3-04]."""
+
+import pytest
+
+from domain.clause_classification import ClauseType
+from infrastructure.rag.chunk_schema import ChunkRecord
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+def _chunk(
+    *,
+    susep_process: str = "15414.610650/2024-59",
+    cnpj: str = "61198164000160",
+    product_line: str = "CASCO",
+    bundle_section: str | None = None,
+    clause_type: str = "coverage",
+) -> ChunkRecord:
+    return ChunkRecord.model_validate(
+        {
+            "schema_version": "v1",
+            "chunk_id": "1:c",
+            "document_id": "1",
+            "clause_id": "1:c",
+            "source_clause_ids": ["1:c"],
+            "chunk_index": 0,
+            "chunk_count": 1,
+            "parent_path": "",
+            "text": "texto",
+            "display_text": "texto",
+            "char_count": 5,
+            "rule": "single",
+            "clause_type": clause_type,
+            "type_source": "rule",
+            "confidence": None,
+            "bundle_section": bundle_section,
+            "source": "text",
+            "susep_process": susep_process,
+            "insurer": "Seguradora",
+            "cnpj": cnpj,
+            "product_line": product_line,
+            "indemnity_regime": "VD",
+            "filing_year": "2024",
+        }
+    )
+
+
+@pytest.mark.unit
+def test_from_manifest_row_builds_the_default_process_cnpj_filter() -> None:
+    row = {"susep_process": "15414.610650/2024-59", "cnpj": "61198164000160"}
+    filt = RetrievalFilter.from_manifest_row(row)
+
+    assert filt.susep_process == "15414.610650/2024-59"
+    assert filt.cnpj == "61198164000160"
+    assert filt.product_line is None
+    assert not filt.is_empty
+
+
+@pytest.mark.unit
+def test_all_none_filter_is_empty_and_matches_everything() -> None:
+    filt = RetrievalFilter()
+
+    assert filt.is_empty
+    assert filt.matches(_chunk())
+
+
+@pytest.mark.unit
+def test_process_and_cnpj_equality() -> None:
+    filt = RetrievalFilter(susep_process="A", cnpj="X")
+
+    assert filt.matches(_chunk(susep_process="A", cnpj="X"))
+    assert not filt.matches(_chunk(susep_process="B", cnpj="X"))
+    assert not filt.matches(_chunk(susep_process="A", cnpj="Y"))
+
+
+@pytest.mark.unit
+def test_clause_type_is_compared_as_the_enum() -> None:
+    filt = RetrievalFilter(clause_type=ClauseType.EXCLUSION)
+
+    assert filt.matches(_chunk(clause_type="exclusion"))
+    assert not filt.matches(_chunk(clause_type="coverage"))
+
+
+@pytest.mark.unit
+def test_bundle_section_lenient_default_keeps_null_chunks() -> None:
+    filt = RetrievalFilter(bundle_section="Motocicletas")
+
+    assert filt.matches(_chunk(bundle_section="Motocicletas"))
+    assert filt.matches(_chunk(bundle_section=None))
+    assert not filt.matches(_chunk(bundle_section="Veículos de Carga"))
+
+
+@pytest.mark.unit
+def test_bundle_section_strict_excludes_null_chunks() -> None:
+    filt = RetrievalFilter(bundle_section="Motocicletas", strict_bundle=True)
+
+    assert filt.matches(_chunk(bundle_section="Motocicletas"))
+    assert not filt.matches(_chunk(bundle_section=None))
+
+
+@pytest.mark.unit
+def test_strict_bundle_is_inert_without_a_bundle_section() -> None:
+    filt = RetrievalFilter(cnpj="X", strict_bundle=True)
+
+    assert filt.matches(_chunk(cnpj="X", bundle_section=None))

--- a/tests/unit/scripts/test_eval_retrieval.py
+++ b/tests/unit/scripts/test_eval_retrieval.py
@@ -7,10 +7,13 @@ from scripts.eval_retrieval import (
     K_VALUES,
     NDCG_K,
     ScoredQuestion,
+    _build_filter_for,
+    _output_stem,
     _parse_args,
     aggregate,
     build_lexical_retriever,
     compute_exclusion_clause_recall,
+    compute_foreign_document_rate,
     evaluate_questions,
     load_golden_questions,
     render_markdown_report,
@@ -20,6 +23,7 @@ from scripts.eval_retrieval import (
 from infrastructure.evaluation.golden_set_schema import GoldenQuestion
 from infrastructure.parsing.clause_schema import ParsedClauseRecord
 from infrastructure.rag.chunk_schema import ChunkRecord
+from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 
 def make_question(**overrides: object) -> GoldenQuestion:
@@ -73,9 +77,17 @@ class FakeRetriever:
 
     def __init__(self, result: list[str]) -> None:
         self._result = result
+        self.seen_filters: list[RetrievalFilter | None] = []
 
-    def retrieve(self, question: str, *, k: int) -> list[str]:
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
         del question
+        self.seen_filters.append(metadata_filter)
         return self._result[:k]
 
 
@@ -135,11 +147,76 @@ def test_evaluate_questions_skips_unanswerable_and_scores_others() -> None:
     assert len(rows) == 1
     row = rows[0]
     assert row.question_id == "direct_lookup-001"
+    assert row.document_id == "1"
     assert row.product_line == "CASCO"
     assert row.extraction_mode == "text"
     assert row.recall == {1: 1.0, 5: 1.0, 10: 1.0}
     assert row.mrr == 1.0
     assert row.ndcg == 1.0
+    assert retriever.seen_filters == [None]  # no filter_for -> unfiltered path
+
+
+@pytest.mark.unit
+def test_evaluate_questions_threads_a_per_question_filter() -> None:
+    question = make_question()
+    document_meta = {
+        "1": {
+            "product_line": "CASCO",
+            "extraction_mode": "text",
+            "susep_process": "P1",
+            "cnpj": "C1",
+        }
+    }
+    retriever = FakeRetriever(["1:a"])
+
+    evaluate_questions(
+        [question],
+        retriever,
+        document_meta,
+        filter_for=_build_filter_for("default", document_meta),
+    )
+
+    assert retriever.seen_filters == [RetrievalFilter(susep_process="P1", cnpj="C1")]
+
+
+@pytest.mark.unit
+def test_compute_foreign_document_rate_pools_wrong_document_hits() -> None:
+    row = ScoredQuestion(
+        question_id="cross_document-001",
+        question_type="cross_document",
+        document_id="10",
+        product_line="CASCO",
+        extraction_mode="text",
+        reference_clause_ids=("10:x",),
+        retrieved=("10:x", "17:y", "10:z", "17:w"),
+        recall={1: 1.0, 5: 1.0, 10: 1.0},
+        mrr=1.0,
+        ndcg=1.0,
+    )
+
+    result = compute_foreign_document_rate([row], k=10)
+
+    assert result == {"k": 10, "hits": 2, "total": 4, "rate": 0.5}
+
+
+@pytest.mark.unit
+def test_output_stem_keeps_random_and_lexical_names_and_tags_the_rest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def stem_for(*argv: str) -> str:
+        monkeypatch.setattr("sys.argv", ["eval_retrieval.py", *argv])
+        return _output_stem(_parse_args())
+
+    assert stem_for("--retriever", "lexical") == "retrieval_eval_lexical"
+    assert stem_for("--retriever", "random") == "retrieval_eval_random"
+    assert stem_for("--retriever", "dense") == "retrieval_eval_dense"
+    assert stem_for("--retriever", "lexical", "--filter", "default") == (
+        "retrieval_eval_lexical_filter-default"
+    )
+    assert (
+        stem_for("--retriever", "hybrid", "--fusion", "weighted", "--filter", "default")
+        == "retrieval_eval_hybrid_weighted_filter-default"
+    )
 
 
 @pytest.mark.unit
@@ -147,6 +224,7 @@ def test_aggregate_computes_mean_across_rows() -> None:
     row_hit = ScoredQuestion(
         question_id="q1",
         question_type="direct_lookup",
+        document_id="1",
         product_line="CASCO",
         extraction_mode="text",
         reference_clause_ids=("1:a",),
@@ -158,6 +236,7 @@ def test_aggregate_computes_mean_across_rows() -> None:
     row_miss = ScoredQuestion(
         question_id="q2",
         question_type="direct_lookup",
+        document_id="1",
         product_line="CASCO",
         extraction_mode="text",
         reference_clause_ids=("1:b",),
@@ -194,6 +273,7 @@ def test_compute_exclusion_clause_recall_counts_only_exclusion_type() -> None:
     row_hit = ScoredQuestion(
         question_id="q1",
         question_type="coverage_with_exclusion",
+        document_id="1",
         product_line="CASCO",
         extraction_mode="text",
         reference_clause_ids=("1:a", "1:b"),
@@ -205,6 +285,7 @@ def test_compute_exclusion_clause_recall_counts_only_exclusion_type() -> None:
     row_miss = ScoredQuestion(
         question_id="q2",
         question_type="coverage_with_exclusion",
+        document_id="1",
         product_line="CASCO",
         extraction_mode="text",
         reference_clause_ids=("1:c",),
@@ -229,6 +310,7 @@ def test_compute_exclusion_clause_recall_returns_none_without_exclusion_refs() -
     row = ScoredQuestion(
         question_id="q1",
         question_type="direct_lookup",
+        document_id="1",
         product_line="CASCO",
         extraction_mode="text",
         reference_clause_ids=("1:b",),
@@ -275,6 +357,7 @@ def test_render_markdown_report_includes_config_and_all_sections() -> None:
         "by_product_line": {"CASCO": metrics_row},
         "by_extraction_mode": {"text": metrics_row},
         "exclusion_clause_recall": {"k": 10, "hits": 1, "total": 27, "recall": 0.037},
+        "foreign_document_rate": {"k": 10, "hits": 0, "total": 90, "rate": 0.0},
     }
 
     markdown = render_markdown_report(report)
@@ -288,10 +371,12 @@ def test_render_markdown_report_includes_config_and_all_sections() -> None:
         "## By product line",
         "## By extraction mode",
         "## Exclusion-clause recall",
+        "## Foreign-document rate",
         "## Summary",
     ):
         assert header in markdown
     assert "Chunk corpus" not in markdown  # lexical block absent for `random`
+    assert "Dense model" not in markdown  # dense block absent for `random`
 
 
 def _chunk(chunk_id: str, clause_id: str, text: str) -> ChunkRecord:
@@ -325,14 +410,28 @@ def _chunk(chunk_id: str, clause_id: str, text: str) -> ChunkRecord:
 
 
 @pytest.mark.unit
-def test_parse_args_defaults_to_random_and_accepts_lexical(
+def test_parse_args_defaults_and_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["eval_retrieval.py"])
+    args = _parse_args()
+    assert (args.retriever, args.filter_mode, args.fusion) == ("random", "none", "rrf")
+
+    for retriever in ("lexical", "dense", "hybrid"):
+        monkeypatch.setattr("sys.argv", ["eval_retrieval.py", "--retriever", retriever])
+        assert _parse_args().retriever == retriever
+
+    monkeypatch.setattr("sys.argv", ["eval_retrieval.py", "--retriever", "nope"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+@pytest.mark.unit
+def test_parse_args_rejects_default_filter_with_the_random_retriever(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("sys.argv", ["eval_retrieval.py"])
-    assert _parse_args().retriever == "random"
-    monkeypatch.setattr("sys.argv", ["eval_retrieval.py", "--retriever", "lexical"])
-    assert _parse_args().retriever == "lexical"
-    monkeypatch.setattr("sys.argv", ["eval_retrieval.py", "--retriever", "nope"])
+    monkeypatch.setattr(
+        "sys.argv",
+        ["eval_retrieval.py", "--retriever", "random", "--filter", "default"],
+    )
     with pytest.raises(SystemExit):
         _parse_args()
 
@@ -388,6 +487,7 @@ def test_render_markdown_report_includes_the_lexical_config_block() -> None:
         "by_product_line": {"CASCO": metrics_row},
         "by_extraction_mode": {"text": metrics_row},
         "exclusion_clause_recall": {"k": 10, "hits": 1, "total": 27, "recall": 0.037},
+        "foreign_document_rate": {"k": 10, "hits": 0, "total": 90, "rate": 0.0},
     }
 
     markdown = render_markdown_report(report)


### PR DESCRIPTION
## Summary

Builds the [M3-04] hybrid retrieval layer: the dense query side M3-02 deferred,
Reciprocal Rank Fusion and weighted score fusion, and a metadata pre-filter that
cuts the search space to a known SUSEP process + insurer CNPJ — the default
retrieval path a claims analyst works, not an optimisation.

**New modules** (`app/src/infrastructure/rag/`):
- `retrieval_filter.py` — `RetrievalFilter` (SUSEP process, CNPJ, product line,
  `bundle_section`, clause type). Insurers matched by CNPJ, never by name
  ([M1-05]). `bundle_section` is **lenient by default** (`= :x OR IS NULL`) with
  a `strict_bundle=True` opt-in — closes the [M1-06] cross-note.
- `fusion.py` — pure `reciprocal_rank_fusion` / `weighted_score_fusion`.
- `dense_retriever.py` — `format_query` → embed → exact `<=>` over the
  metadata-filtered partition (no HNSW, per `docs/EMBEDDINGS.md`'s verdict) →
  roll chunk hits up to clause-id granularity.
- `hybrid_retriever.py` — one `retrieve(question, *, k, metadata_filter)` that
  fuses both legs; the single interface M4's graph node will consume.
- `hybrid_config.py` — RRF `k=60`, weights, candidate depth, fingerprint.
  **Zero new `.env` keys** per the [M1-09] per-constant rule.

**Plumbing:** `chunk_repository.search_chunks_by_vector` (SQL `WHERE` pushdown);
`LexicalRetriever` gains an optional `metadata_filter` + `retrieve_scored`
without changing the unfiltered `retrieve` path; `RetrievalRunConfig` → `v3`;
`FilterableRetriever` protocol; a new pooled **foreign-document rate** metric
(DoD item 4); `scripts/eval_retrieval.py` gains `--retriever dense|hybrid`,
`--filter none|default`, `--fusion rrf|weighted`; `make eval-retrieval-dense` /
`-hybrid` (run under `uv run --group embed`, need Postgres with embedded chunks).

**Verdict (`docs/HYBRID_RETRIEVAL.md`):** the pre-filter is the whole result —
every leg gains 27–39 pts of Recall@10. RRF is kept as the default over weighted
score fusion (RRF wins Recall@10, weighted wins MRR/nDCG); this is a *stated
deviation* from the pre-registered rule, documented per `MILESTONES.md`, and
both stay one `--fusion` flag apart for [M3-08] to revisit with reranking.

## Related issue

[M3-04]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
      — unit: `test_fusion`, `test_retrieval_filter`, `test_hybrid_config`,
      `test_hybrid_retriever`, extended `test_lexical_retriever` /
      `test_eval_retrieval` / `test_retrieval_run_schema`; integration:
      `test_dense_retriever` (real Postgres, synthetic vectors, filter pushdown /
      CNPJ-not-name / stacked-filter-under-k / bundle-NULL); eval:
      `test_hybrid_retrieval_baseline` (floor + foreign-doc-rate 0, skips
      without the stack).
- [x] Docs updated — new `docs/HYBRID_RETRIEVAL.md`; one-line correction to
      `ann_index.py`'s docstring (its retriever no longer calls
      `apply_ann_search_gucs`).
- [x] Evaluation impact considered — **yes, this adds retrieval numbers.**
      Hybrid RRF + process/CNPJ filter on `golden-set-v1` (117 scorable):
      Recall@10 **91.5%**, MRR 78.8%, nDCG@10 80.3%, exclusion-clause recall
      92.6%, foreign-document rate **0.0%** — clears M3's Recall@10 ≥ 0.85 /
      MRR ≥ 0.60 bar. The unfiltered `lexical` baseline is byte-identical to
      [M3-03]'s (58.7% / 38.8% / 41.9% / 51.9%). Full four-config comparison
      table and prediction-vs-actual in `docs/HYBRID_RETRIEVAL.md`. The
      lexical/dense/hybrid/hybrid+rerank matrix and `make build-index` remain
      [M3-08]'s.
- [x] `make check` passes locally (also `make test-integration` and
      `make test-eval`, against a local Docker Postgres)