### PR TITLE
feat(rag): rerank the hybrid top-k with a Portuguese cross-encoder, t…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,12 @@ LLM_CLASSIFICATION_MAX_WORKERS=
 # human-facing name and is cross-checked against that pin by a test. See
 # docs/EMBEDDINGS.md for the choice and its evidence.
 EMBEDDING_MODEL=Alibaba-NLP/gte-multilingual-base
-RERANKER_MODEL=
+
+# Cross-encoder reranker [M3-05]. Pinned to an exact Hub revision in code
+# (app/src/infrastructure/rag/reranker_config.py); this key is the human-facing
+# name and is cross-checked against that pin by a test. See docs/RERANKING.md
+# for the choice and its evidence.
+RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base
 
 # Chunks embedded per batch by `make embed-chunks` (default: 64). Pure
 # throughput / memory knob -- no effect on the stored vectors (the embedding

--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,9 @@ data/cache/boundary_escalation_pages/
 # Embedding cache, keyed by a hash of (embedding-contract fingerprint, input text)
 data/cache/embeddings/
 
+# Reranker cache, keyed by a hash of (reranker-contract fingerprint, query, passage)
+data/cache/reranker/
+
 # Embeddings and vector index artifacts — rebuilt via `make build-index`
 data/index/
 *.faiss

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -292,6 +292,24 @@ from the coverage clause it cancels.
 - `make build-index` rebuilds the full index from `data/policies/raw/` on a
   clean machine.
 
+**[M3-05] outcome (2026-08-29).** Cross-encoder reranking
+(`Alibaba-NLP/gte-multilingual-reranker-base`) of the [M3-04] hybrid RRF top-10,
+filtered to each question's SUSEP process + CNPJ.
+`RERANK_CANDIDATE_DEPTH` is set to **10** — the shallowest point — from the
+`make tune-reranking` sweep (`docs/RERANKING.md`): reranking the hybrid top-10
+lifts overall MRR 78.8 → 80.6, R@1 64.5 → 65.8, R@5 83.6 → 86.9 and nDCG@10
+80.3 → 82.0, with R@10 unchanged at 91.5% and exclusion-clause recall unchanged
+at 92.6% (25/27); every deeper depth trades the top-rank gain away, and depth
+≥ 30 pushes exclusion clauses out of the top-10 (the DoD's named regression) and
+drops R@10 below the no-rerank baseline. Both M3 exit values still clear their
+bars. Three of five pre-registered predictions missed and are published rather
+than absorbed, per this file's protocol: the metric lift is real but ~half the
+predicted magnitude; the curve peaks at the shallowest depth, not at k ≈ 30–50;
+and CPU reranking latency (~9.7 s/query p50 at depth 10 on a Ryzen 5 5600H) is
+~50–100× the "tens to low-hundreds of ms" predicted — which makes the CPU
+cross-encoder a batch-eval / GPU-serving tool, not a live-path component. The
+four-configuration benchmark matrix and `make build-index` remain [M3-08].
+
 ## M4 — Agent graph
 
 Assemble the LangGraph state graph: intake with a conditional clarification

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank tune-reranking review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -49,6 +49,8 @@ help:
 	@echo "  eval-retrieval-lexical - M3-03: score the BM25 lexical retriever (Portuguese tokenisation + Snowball stemming over build/chunks.jsonl, no metadata filter) on the golden set; writes eval/runs/retrieval_eval_lexical.{md,json}"
 	@echo "  eval-retrieval-dense - M3-04: score the dense pgvector retriever with the SUSEP-process+CNPJ pre-filter (needs a running Postgres with loaded+embedded chunks; runs the optional embed uv group); writes eval/runs/retrieval_eval_dense_filter-default.{md,json}"
 	@echo "  eval-retrieval-hybrid - M3-04: score the hybrid (RRF fusion of lexical+dense) retriever with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement as eval-retrieval-dense; pass --fusion weighted / --filter none on the script for the comparison); writes eval/runs/retrieval_eval_hybrid_*.{md,json}. Comparison and verdict: docs/HYBRID_RETRIEVAL.md"
+	@echo "  eval-retrieval-rerank - M3-05: score hybrid RRF + cross-encoder rerank with the SUSEP-process+CNPJ pre-filter at the chosen candidate depth (same Postgres + embed-group requirement); writes eval/runs/retrieval_eval_hybrid_rrf_rerank_filter-default.{md,json}. Verdict: docs/RERANKING.md"
+	@echo "  tune-reranking    - M3-05: sweep the reranker candidate depth on the golden set and record the metrics + latency curve (same Postgres + embed-group requirement); writes eval/runs/rerank_tuning.{md,json}. Curve and chosen depth: docs/RERANKING.md"
 	@echo "  review-golden-set-sample - Independent second-reviewer pass over a stratified golden-set-v1 sample (--dry-run prints the sample composition, no model calls); writes data/golden_set/review/review_v1.jsonl and eval/runs/golden_set_review_v1.{md,json}"
 
 install:
@@ -200,6 +202,12 @@ eval-retrieval-dense:
 
 eval-retrieval-hybrid:
 	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default
+
+eval-retrieval-rerank:
+	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default --rerank
+
+tune-reranking:
+	PYTHONPATH=app/src uv run --group embed python -m scripts.tune_reranking
 
 review-golden-set-sample:
 	PYTHONPATH=app/src uv run python scripts/review_golden_set_sample.py

--- a/app/src/infrastructure/evaluation/retrieval_run_schema.py
+++ b/app/src/infrastructure/evaluation/retrieval_run_schema.py
@@ -11,15 +11,17 @@ a frozen schema, since its shape is expected to grow with new breakdowns.
 ``v2`` [M3-03]: the lexical retriever adds the chunk-corpus identity and its
 BM25/analyzer contract. ``v3`` [M3-04]: the dense and hybrid retrievers add the
 metadata-filter mode, the fusion strategy and its constants, and the embedding /
-hybrid config fingerprints. Every added field is optional -- ``random`` and
-``lexical`` leave the new ones ``None``.
+hybrid config fingerprints. ``v4`` [M3-05]: the ``--rerank`` path adds the
+cross-encoder model id/revision, the candidate depth and the reranker config
+fingerprint. Every added field is optional -- a run without that leg leaves the
+new ones ``None``.
 """
 
 from datetime import datetime
 
 from pydantic import BaseModel
 
-SCHEMA_VERSION = "v3"
+SCHEMA_VERSION = "v4"
 
 
 class RetrievalRunConfig(BaseModel):
@@ -63,3 +65,11 @@ class RetrievalRunConfig(BaseModel):
     fusion_weights: list[float] | None = None
     candidate_depth: int | None = None
     hybrid_config_fingerprint: str | None = None
+
+    # [M3-05] `--rerank` only; None otherwise. `rerank_candidate_depth` is how
+    # many of the base retriever's candidates the cross-encoder re-scored before
+    # the top-k cut.
+    reranker_model_id: str | None = None
+    reranker_model_revision: str | None = None
+    rerank_candidate_depth: int | None = None
+    reranker_config_fingerprint: str | None = None

--- a/app/src/infrastructure/rag/cross_encoder_reranker.py
+++ b/app/src/infrastructure/rag/cross_encoder_reranker.py
@@ -1,0 +1,98 @@
+"""The real, local :class:`~infrastructure.rag.reranker.Reranker` -- [M3-05].
+
+Loads the pinned ``Alibaba-NLP/gte-multilingual-reranker-base`` (see
+[infrastructure.rag.reranker_config]) with ``sentence-transformers``'
+``CrossEncoder`` and scores ``(query, passage)`` pairs in-process: no API, no
+rate limit, no per-token charge.
+
+``sentence-transformers`` (and its ``torch`` / ``transformers`` dependencies) is
+the optional ``embed`` dependency group, deliberately kept out of ``uv sync``
+and CI -- the same group the embedder uses, and it already ships ``CrossEncoder``
+(no new dependency). Import this module freely: the heavy import is deferred to
+``CrossEncoderReranker.__init__``; only constructing one needs the group
+installed (``make eval-retrieval-rerank`` / ``make tune-reranking`` run
+``uv run --group embed``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from infrastructure.rag.reranker_config import (
+    RERANKER_MAX_INPUT_TOKENS,
+    RERANKER_MODEL_ID,
+    RERANKER_MODEL_REVISION,
+    RERANKER_TRUST_REMOTE_CODE,
+)
+
+# Pairs scored per forward batch. A pure throughput / memory lever -- no effect
+# on the scores or their order (padding is attention-masked), so (per [M1-09]) it
+# is a plain module constant, not a `.env` knob and not part of
+# ``reranker_config.config_fingerprint()``. Held at 1, not a library-typical
+# 32/64: a batch pads to its longest member, and one 8192-token clause (the input
+# cap) already fills the activation budget of a 4 GB dev GPU; a batch of 64 of
+# them needs >12 GB, past a 14 GB CPU box too. Per-pair cost is dominated by the
+# model forward, so 1 costs little (GPU: ~45 ms/pair; CPU is slow either way) and
+# bounds the peak on any hardware. M4 sets its own value for its serving box.
+# See docs/RERANKING.md.
+RERANK_BATCH_SIZE = 1
+
+
+class CrossEncoderReranker:
+    """Score query/passage pairs with the pinned cross-encoder, loaded once."""
+
+    def __init__(
+        self,
+        *,
+        batch_size: int = RERANK_BATCH_SIZE,
+        max_length: int = RERANKER_MAX_INPUT_TOKENS,
+        device: str | None = None,
+    ) -> None:
+        """Load the pinned model at its pinned revision.
+
+        ``device`` is passed straight to ``sentence-transformers`` -- ``None``
+        auto-selects (CUDA if available, else CPU); pass ``"cpu"`` to force it.
+        """
+        try:
+            from sentence_transformers import CrossEncoder
+        except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+            raise ModuleNotFoundError(
+                "sentence-transformers is not installed. It is the optional "
+                "`embed` dependency group: run `make eval-retrieval-rerank` "
+                "(which uses `uv run --group embed`) or `uv sync --group embed` "
+                "first."
+            ) from exc
+
+        self._batch_size = batch_size
+        self._model = CrossEncoder(
+            RERANKER_MODEL_ID,
+            revision=RERANKER_MODEL_REVISION,
+            trust_remote_code=RERANKER_TRUST_REMOTE_CODE,
+            max_length=max_length,
+            device=device,
+        )
+
+    @property
+    def device(self) -> str:
+        """The torch device the model ended up on, e.g. ``"cpu"`` / ``"cuda:0"``."""
+        for attr in ("device", "_target_device"):
+            value = getattr(self._model, attr, None)
+            if value is not None:
+                return str(value)
+        return "unknown"
+
+    def rerank(self, query: str, passages: Sequence[str]) -> list[float]:
+        """Return one relevance score per passage, in input order.
+
+        Higher is more relevant. Only the ordering is consumed downstream
+        ([infrastructure.rag.reranking_retriever.RerankingRetriever]).
+        """
+        if not passages:
+            return []
+        scores = self._model.predict(
+            [(query, passage) for passage in passages],
+            batch_size=self._batch_size,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+        )
+        return [float(score) for score in scores]

--- a/app/src/infrastructure/rag/reranker.py
+++ b/app/src/infrastructure/rag/reranker.py
@@ -1,0 +1,30 @@
+"""The cross-encoder interface the [M3-05] reranking stage depends on.
+
+A local Protocol, mirroring [infrastructure.rag.embedder.Embedder] and
+[infrastructure.evaluation.retriever.Retriever]: reranking is pure
+infrastructure (a model runtime that scores a query against a passage), so
+there is no application use case to hang an ``application/ports/`` port off.
+
+The real implementation is
+[infrastructure.rag.cross_encoder_reranker.CrossEncoderReranker]
+(``sentence-transformers`` loading the pinned
+[infrastructure.rag.reranker_config] model, from the optional ``embed``
+dependency group). The test suite drives the reranking retriever with a fake,
+per the [M1-05b]/[M1-04d] no-live-calls precedent.
+"""
+
+from collections.abc import Sequence
+from typing import Protocol
+
+
+class Reranker(Protocol):
+    """Anything that scores a query against each of several passages."""
+
+    def rerank(self, query: str, passages: Sequence[str]) -> list[float]:
+        """Return one relevance score per passage, in input order.
+
+        Higher means more relevant. The scale is model-defined and only its
+        ordering is used -- [infrastructure.rag.reranking_retriever.
+        RerankingRetriever] sorts by it and discards the values.
+        """
+        ...

--- a/app/src/infrastructure/rag/reranker_cache.py
+++ b/app/src/infrastructure/rag/reranker_cache.py
@@ -1,0 +1,99 @@
+"""Content-addressed, on-disk cache wrapping a Reranker -- [M3-05].
+
+The ``make tune-reranking`` candidate-depth sweep re-scores heavily overlapping
+``(query, clause)`` pairs across depths, and a re-run over the 117 golden
+queries should cost nothing. This wraps any
+[infrastructure.rag.reranker.Reranker] with a cache keyed by a hash of
+(reranker-contract fingerprint, query, passage): a rerun skips every pair
+already scored, across separate runs.
+
+The key deliberately covers more than the pair.
+[infrastructure.rag.reranker_config.config_fingerprint] folds the model id,
+revision, input cap and candidate depth into the key, so a cache built under one
+reranker configuration can never silently serve its scores to another -- the
+same guard [infrastructure.rag.embedding_cache.CachingEmbedder] applies.
+
+Location and format follow the repo convention
+(``data/cache/embeddings/cache.jsonl``,
+``data/cache/llm_classification/cache.jsonl``): one gitignored JSON Lines file,
+appended on every miss.
+"""
+
+import hashlib
+import json
+import threading
+from collections.abc import Sequence
+from pathlib import Path
+
+from infrastructure.rag.reranker import Reranker
+from infrastructure.rag.reranker_config import config_fingerprint
+
+RERANKER_CACHE_PATH = Path("data/cache/reranker/cache.jsonl")
+
+
+class CachingReranker:
+    """A [Reranker] that persists ``(query, passage) -> score`` to a JSONL file."""
+
+    def __init__(
+        self, inner: Reranker, *, cache_path: Path = RERANKER_CACHE_PATH
+    ) -> None:
+        """Wrap ``inner``, caching its scores under ``cache_path``."""
+        self._inner = inner
+        self._fingerprint = config_fingerprint()
+        self._cache_path = cache_path
+        self._lock = threading.Lock()
+        self._cache: dict[str, float] = self._load()
+        # Per-instance tallies over every pair passed to :meth:`rerank`, so a
+        # sweep can report cold-vs-warm behaviour (cold: hits == 0). ``hits +
+        # misses`` always equals the number of pairs seen.
+        self.hits = 0
+        self.misses = 0
+
+    def _key(self, query: str, passage: str) -> str:
+        payload = f"{self._fingerprint}\x00{query}\x00{passage}".encode()
+        return hashlib.sha256(payload).hexdigest()[:32]
+
+    def _load(self) -> dict[str, float]:
+        if not self._cache_path.exists():
+            return {}
+        cache: dict[str, float] = {}
+        with self._cache_path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                cache[record["key"]] = record["score"]
+        return cache
+
+    def _persist(self, entries: dict[str, float]) -> None:
+        self._cache.update(entries)
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._cache_path.open("a", encoding="utf-8") as f:
+            for key, score in entries.items():
+                f.write(json.dumps({"key": key, "score": score}) + "\n")
+            f.flush()
+
+    def rerank(self, query: str, passages: Sequence[str]) -> list[float]:
+        """Return one score per passage, scoring only pairs not already cached."""
+        keys = [self._key(query, passage) for passage in passages]
+        with self._lock:
+            resolved = {key: self._cache[key] for key in keys if key in self._cache}
+
+        cached_keys = set(resolved)
+        self.hits += sum(1 for key in keys if key in cached_keys)
+        self.misses += sum(1 for key in keys if key not in cached_keys)
+
+        pending: dict[str, str] = {}  # key -> passage, duplicates collapsed
+        for passage, key in zip(passages, keys, strict=True):
+            if key not in resolved and key not in pending:
+                pending[key] = passage
+
+        if pending:
+            scores = self._inner.rerank(query, list(pending.values()))
+            fresh = dict(zip(pending, scores, strict=True))
+            with self._lock:
+                self._persist(fresh)
+            resolved.update(fresh)
+
+        return [resolved[key] for key in keys]

--- a/app/src/infrastructure/rag/reranker_config.py
+++ b/app/src/infrastructure/rag/reranker_config.py
@@ -1,0 +1,92 @@
+"""The pinned cross-encoder-reranker contract -- [M3-05].
+
+Single source of truth for the reranker model, its revision, its input-length
+cap and how deep the fused candidate list is re-scored. The eval harness (query
+side) and M4's graph node both reach the reranker through this module, so the
+model a golden-set number was measured under and the model M4 runs cannot drift
+apart. Recorded here, as code, not in a comment.
+
+Why these are module constants and not `.env` knobs: the model id, revision,
+input cap and candidate depth together determine the exact ranking behind a
+published MRR / Recall@10 number. Per [M1-09]'s per-constant rule they are
+experimental design -- like ``SEED`` / ``SAMPLE_SIZE`` in
+``scripts/sample_parsing_quality.py`` -- and making them environment-dependent
+would let a `.env` edit silently move a published result. ``RERANKER_MODEL``
+stays in `.env` as the human-facing name and is cross-checked against
+``RERANKER_MODEL_ID`` by a test, exactly as ``EMBEDDING_MODEL`` is against
+``EMBEDDING_MODEL_ID``. This issue introduces **no** new `.env` key -- the
+analog of ``docs/LEXICAL_RETRIEVAL.md``'s "zero" and
+``docs/HYBRID_RETRIEVAL.md``'s "zero".
+
+Rationale and evidence: docs/RERANKING.md.
+"""
+
+import hashlib
+
+# Alibaba-NLP/gte-multilingual-reranker-base -- the reranking half of the same
+# mGTE work as the pinned embedder (Alibaba-NLP/gte-multilingual-base). The
+# paper docs/EMBEDDINGS.md already cites ("...Text Representation *and Reranking*
+# Models for Multilingual Text", arXiv 2407.19669) is this model's paper;
+# Portuguese is an explicit target language, not incidental. Same 8192-token
+# window, same architecture family. See docs/RERANKING.md.
+RERANKER_MODEL_ID = "Alibaba-NLP/gte-multilingual-reranker-base"
+
+# Pinned by Hub commit -- NOT the floating ``main`` alias -- so a provider-side
+# re-upload cannot silently change the weights behind an already-published
+# number. Commit last modified 2025-07-05; re-confirm before bumping.
+#
+# Same caveat as the embedder (embedding_config.py): the ``trust_remote_code``
+# modelling code is loaded from ``Alibaba-NLP/new-impl`` at *its* ``main``, not
+# this revision -- HF's ``repo--module`` auto_map form does not pin it. The
+# ``embed`` group's ``transformers`` pin (the 4.4x line) is what stabilises that
+# RoPE code path; the reranker's config.json declares the same
+# ``transformers_version 4.39.1`` as the embedder's.
+RERANKER_MODEL_REVISION = "8215cf04918ba6f7b6a62bb44238ce2953d8831c"
+
+# Model card / config.json: 8192-token context window. Passed to the
+# cross-encoder as ``max_length`` so a long clause is truncated deterministically
+# rather than by the tokenizer's silent default.
+RERANKER_MAX_INPUT_TOKENS = 8192
+
+# gte-multilingual-reranker-base ships the same custom ``New*`` architecture as
+# the embedder (auto_map -> ``Alibaba-NLP/new-impl``), so it must be loaded with
+# ``trust_remote_code=True``. Safe because the weights are fetched at the pinned
+# revision above. Security-sensitive -- a code constant, never `.env`-flippable,
+# per the ``EMBEDDING_TRUST_REMOTE_CODE`` precedent.
+RERANKER_TRUST_REMOTE_CODE = True
+
+# How many of the fused hybrid candidates the cross-encoder re-scores before the
+# final top-k cut. Set to 10 -- the shallowest point -- from the ``make
+# tune-reranking`` curve in docs/RERANKING.md: reranking the hybrid top-10 lifts
+# R@1 / R@5 / MRR / nDCG with R@10 unchanged and exclusion-clause recall held at
+# 92.6%, while every deeper depth trades that top-rank gain away and depth >= 30
+# pushes exclusion clauses out of the kept context (the M3-05 DoD's named
+# regression) and drops R@10 below the no-rerank baseline. A code constant: it
+# changes the reranked ranking the golden-set numbers are measured on.
+RERANK_CANDIDATE_DEPTH = 10
+
+
+def config_fingerprint() -> str:
+    """Digest of every contract value that determines the reranked order.
+
+    [infrastructure.rag.reranker_cache.CachingReranker] prepends this to its
+    per-(query, passage) key, so a cached score can never be served under a
+    different model id, revision, input cap or candidate depth than the one it
+    was computed under. Threaded into the eval run's
+    [infrastructure.evaluation.retrieval_run_schema.RetrievalRunConfig] so a
+    report read in isolation says exactly what produced its numbers.
+
+    Reads the module constants at call time (not import time) so a test can
+    monkeypatch one and see the fingerprint move -- mirrors the sibling
+    ``config_fingerprint``s in ``embedding_config`` / ``lexical_config`` /
+    ``hybrid_config``.
+    """
+    payload = "\x00".join(
+        (
+            RERANKER_MODEL_ID,
+            RERANKER_MODEL_REVISION,
+            str(RERANKER_MAX_INPUT_TOKENS),
+            str(RERANK_CANDIDATE_DEPTH),
+        )
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]

--- a/app/src/infrastructure/rag/reranking_retriever.py
+++ b/app/src/infrastructure/rag/reranking_retriever.py
@@ -1,0 +1,87 @@
+"""Cross-encoder reranking of a base retriever's candidates -- [M3-05].
+
+Wraps any filtered retriever (in practice
+[infrastructure.rag.hybrid_retriever.HybridRetriever], per
+``docs/HYBRID_RETRIEVAL.md``'s reasoning that the higher-recall RRF candidate
+set is the right thing to feed a reranker) behind the **same**
+``retrieve(question, *, k, metadata_filter)`` interface, so M4's graph node and
+the [M2-06] eval harness stay unaware of it.
+
+Flow: ask the base retriever for ``candidate_depth`` clause ids over the given
+filter, look up each candidate's passage text, score every ``(question,
+passage)`` pair with the [infrastructure.rag.reranker.Reranker], then return the
+``k`` highest-scoring clause ids. Equal scores keep the base retriever's order
+(a stable sort), so the output is deterministic. The reranker can only reorder
+the candidate set -- it never introduces a clause the base retriever did not
+return, and it never pads.
+"""
+
+from collections.abc import Mapping
+from typing import Protocol
+
+from infrastructure.rag.reranker import Reranker
+from infrastructure.rag.reranker_config import RERANK_CANDIDATE_DEPTH
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+class _FilterableBase(Protocol):
+    """The base retriever contract: a filtered, clause-id-ranking ``retrieve``.
+
+    Structurally [infrastructure.evaluation.retriever.FilterableRetriever];
+    re-declared here so ``infrastructure.rag`` imports nothing from
+    ``infrastructure.evaluation`` (the same split ``hybrid_retriever._ScoredLeg``
+    keeps).
+    """
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, ranked best-match first, filtered."""
+        ...
+
+
+class RerankingRetriever:
+    """Reorders a base retriever's top candidates with a cross-encoder."""
+
+    def __init__(
+        self,
+        base: _FilterableBase,
+        reranker: Reranker,
+        clause_text: Mapping[str, str],
+        *,
+        candidate_depth: int = RERANK_CANDIDATE_DEPTH,
+    ) -> None:
+        """Compose the base retriever, the reranker, and the clause-id -> text map.
+
+        ``clause_text`` supplies the passage each candidate clause id is scored
+        as; a candidate missing from it is scored as the empty string (it sinks
+        to the bottom rather than raising).
+        """
+        self._base = base
+        self._reranker = reranker
+        self._clause_text = clause_text
+        self._candidate_depth = candidate_depth
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, reranked best match first. May return fewer."""
+        if k <= 0:
+            return []
+        candidates = self._base.retrieve(
+            question, k=self._candidate_depth, metadata_filter=metadata_filter
+        )
+        if not candidates:
+            return []
+        passages = [self._clause_text.get(clause_id, "") for clause_id in candidates]
+        scores = self._reranker.rerank(question, passages)
+        order = sorted(range(len(candidates)), key=lambda i: scores[i], reverse=True)
+        return [candidates[i] for i in order][:k]

--- a/docs/RERANKING.md
+++ b/docs/RERANKING.md
@@ -1,0 +1,324 @@
+# Cross-encoder reranking
+
+The [M3-05] reranking stage: a model that reads the query and each candidate
+clause *together* re-scores the fused hybrid candidate set, so the answer clause
+is lifted toward rank 1. The contract lives in code at
+`app/src/infrastructure/rag/reranker_config.py`; this document is the rationale,
+the evidence, and the numbers.
+
+**Scope.** This issue builds the reranker, wires it behind the existing
+`retrieve(question, *, k, metadata_filter)` interface, and tunes its **candidate
+depth** on `golden-set-v1` — with the reranker sitting on the [M3-04] hybrid RRF
++ SUSEP-process + CNPJ config, which `docs/HYBRID_RETRIEVAL.md` already fixed as
+the base. It does **not**:
+
+- produce the committed lexical-only / dense-only / hybrid / hybrid+rerank
+  benchmark matrix or `make build-index` — that is [M3-08]'s, which also
+  re-opens the RRF-vs-weighted fusion call with the reranker in the loop;
+- re-tune BM25 `k1`/`b` or the RRF constant — those stay the pinned
+  `docs/LEXICAL_RETRIEVAL.md` / `docs/HYBRID_RETRIEVAL.md` values ([M3-08]'s);
+- add exclusion co-retrieval ([M3-06]) or the insufficient-context gate
+  ([M3-07]).
+
+---
+
+## Method
+
+### The pipeline
+
+`RerankingRetriever` (`reranking_retriever.py`) wraps the hybrid retriever behind
+the **same** `retrieve(question, *, k, metadata_filter=None) -> list[str]` M4's
+graph node will call:
+
+1. ask the base retriever (hybrid RRF, `--filter default`) for
+   `RERANK_CANDIDATE_DEPTH` clause ids over the question's SUSEP process + CNPJ;
+2. look up each candidate's passage text;
+3. score every `(question, passage)` pair with the cross-encoder;
+4. return the `k` highest-scoring clause ids. Equal scores keep the base
+   retriever's (fused) order — a stable sort — so the output is deterministic.
+
+The reranker can only **reorder** the candidate set: it never introduces a
+clause the base retriever did not return, and it never pads. This is the reason
+`docs/HYBRID_RETRIEVAL.md` kept RRF (higher Recall@10) over weighted fusion
+(higher MRR): "the reranker fixes ordering, it cannot recover a clause that was
+never retrieved", so feeding it the higher-recall candidate set is the better
+pipeline. (The Outcome below shows the reranker lifts RRF's MRR from 78.8 to
+80.6 — real, but short of the 83.1 weighted fusion had. [M3-08] re-runs the
+RRF-vs-weighted call with the reranker in the loop; M3-05 fixes the depth on the
+`docs/HYBRID_RETRIEVAL.md` base.)
+
+### The model — `Alibaba-NLP/gte-multilingual-reranker-base`
+
+The reranking half of the same mGTE work as the pinned embedder
+(`Alibaba-NLP/gte-multilingual-base`). The paper `docs/EMBEDDINGS.md` already
+cites — *"mGTE: Generalized Long-Context Text Representation and Reranking
+Models for Multilingual Text Retrieval"* (arXiv 2407.19669) — **is this model's
+paper**; Portuguese is one of its explicit target languages, evaluated in MLDR,
+not incidental.
+
+| property | value | source |
+| --- | --- | --- |
+| parameters | ~306M | model card |
+| context window | 8192 tokens | `config.json` `max_position_embeddings` |
+| output | single relevance score (`num_labels = 1`) | `config.json` |
+| architecture | `NewForSequenceClassification`, `trust_remote_code` via `Alibaba-NLP/new-impl` | `config.json` `auto_map` — the **same** custom code path as the embedder |
+| revision pinned | `8215cf04918ba6f7b6a62bb44238ce2953d8831c` (2025-07-05) | `reranker_config.RERANKER_MODEL_REVISION` |
+
+**Why this over `BAAI/bge-reranker-v2-m3`** (the other credible multilingual
+option): one family, one paper, one evidence story with the embedder; and the
+`embed` group's `transformers>=4.39,<4.46` / `sentence-transformers>=3.0,<3.5`
+pins **already exist** for exactly this `Alibaba-NLP/new-impl` RoPE code path
+(`config.json` declares `transformers_version 4.39.1`, same as the embedder), so
+the reranker adds **no dependency and no new pin**. `sentence-transformers`
+3.4.1 already ships `CrossEncoder`.
+
+The local placeholder `RERANKER_MODEL=BAAI/bge-reranker-base` (which predated
+this issue) was **not** viable: `bge-reranker-base` is English/Chinese only.
+
+### Passage representation
+
+The reranker scores `(question, passage)` where `passage` is built from the
+**chunk corpus** (`build/chunks.jsonl`): for each candidate clause id, the
+breadcrumb-prefixed `ChunkRecord.text` of its chunks, rejoined in `chunk_index`
+order (`eval_retrieval.build_clause_text_map`). This is the same field BM25
+indexes and the embedder embeds, so all three legs judge the candidate on the
+same representation — the reasoning `docs/LEXICAL_RETRIEVAL.md` gives for
+indexing `text` not `display_text` (the exact term is often only in an ancestor
+heading).
+
+### Caching and device
+
+`CachingReranker` (`reranker_cache.py`) mirrors `CachingEmbedder`: a gitignored
+`data/cache/reranker/cache.jsonl`, keyed by
+`sha256(config_fingerprint · query · passage)`, so a re-run of
+`make eval-retrieval-rerank` over the 117 golden queries costs nothing. The
+fingerprint folds the model id, revision, input cap and candidate depth, so a
+cache built under one configuration can never serve another.
+
+**Device split.** The cross-encoder's scores are fp32 and device-independent, so
+every Recall / MRR / nDCG / exclusion number is identical on CPU and GPU. The
+*scoring* pass therefore runs on the dev GPU when one is present (`_load_reranker`
+defaults to auto; `_load_query_embedder` is lazy and every golden query vector is
+already cached, so the card is free) — ~10× faster than CPU. The **latency**
+number the trade-off below turns on is still a **CPU** number by design: there is
+no GPU serving infra, a reranker in an interactive path is the realistic
+deployment, and CPU is reproducible on any machine. `make tune-reranking`
+measures it on a separate `device="cpu"` reranker, as a probe over
+`LATENCY_PROBE_QUESTIONS` questions at each candidate depth.
+
+### The `[M1-09]` per-constant decision
+
+Every value this issue introduces changes the reranked order (and so the
+published MRR / Recall@10), so per [M1-09]'s rule they are **all module
+constants** in `reranker_config.py`, folded into `config_fingerprint()`.
+**Zero new `.env` keys** — the analog of `docs/LEXICAL_RETRIEVAL.md`'s "zero"
+and `docs/HYBRID_RETRIEVAL.md`'s "zero".
+
+| constant | value | why a code constant |
+| --- | --- | --- |
+| `RERANKER_MODEL_ID` | `Alibaba-NLP/gte-multilingual-reranker-base` | determines the scores; `RERANKER_MODEL` in `.env` is the human-facing name, cross-checked against this by a test — the `EMBEDDING_MODEL` arrangement |
+| `RERANKER_MODEL_REVISION` | pinned Hub commit | a re-upload must not change a published number |
+| `RERANKER_MAX_INPUT_TOKENS` | 8192 | truncation length changes what the model sees for a long clause |
+| `RERANKER_TRUST_REMOTE_CODE` | `True` | security-sensitive — never `.env`-flippable, per `EMBEDDING_TRUST_REMOTE_CODE` |
+| `RERANK_CANDIDATE_DEPTH` | `10` (set from the sweep below) | changes the reranked ranking the golden-set numbers are measured on |
+| `RERANK_BATCH_SIZE` (`cross_encoder_reranker.py`) | 1 | pure throughput / memory lever, no effect on scores (padding is attention-masked) — **not** in the fingerprint (the `EMBEDDING_BATCH_SIZE` analog, minus the `.env` promotion since no operator has asked for it). Held at 1: a batch pads to its longest member, and one 8192-token clause already fills the activation budget of the 4 GB dev GPU the scoring pass uses (batch 4 CUDA-OOMs; batch 64 needs >12 GB, past the 14 GB CPU box too). Per-pair cost is the model forward, so 1 barely changes throughput (~45 ms/pair on the GPU) and bounds the peak on any hardware. The reported CPU latency is therefore a batch-1 number — the conservative direction; a batched interactive reranker would do better. M4 picks its own value for its serving hardware. |
+
+### The harness
+
+`scripts/eval_retrieval.py` gains a `--rerank` flag (rejected only with
+`--retriever random`); `RetrievalRunConfig` is bumped to `v4` with the reranker
+model id/revision, candidate depth and config fingerprint (all optional).
+`make eval-retrieval-rerank` runs `--retriever hybrid --filter default --rerank`
+and writes `eval/runs/retrieval_eval_hybrid_rrf_rerank_filter-default.{md,json}`.
+`make tune-reranking` (`scripts/tune_reranking.py`) sweeps the candidate depth
+and writes `eval/runs/rerank_tuning.{md,json}`. Both run under
+`uv run --group embed` and need Postgres with loaded + embedded chunks.
+
+---
+
+## Pre-registered prediction
+
+Written in the implementation plan **before** the reranker was run, reproduced
+here unedited:
+
+> - Reranking lifts MRR and R@1 on the filtered hybrid config (the top-rank
+>   precision weighted fusion bought: MRR toward ~83%+, R@1 toward ~68%+) and
+>   nDCG@10 with them.
+> - Recall@10 moves little at shallow candidate depth (k≈10–20: pure reorder)
+>   and can gain a point or two at deeper k as the cross-encoder rescues a
+>   relevant clause the fusion ranked 11–30; it does not drop below the 91.5%
+>   baseline at the chosen k.
+> - Exclusion-clause recall does not fall below 92.6% (25/27) at the chosen
+>   `(k, n)` — the DoD's named regression does not occur; `coverage_with_exclusion`
+>   stays the weakest question type (exclusion co-retrieval is [M3-06]).
+> - The curve has a knee: metrics rise from k=10 to ~k=30–50 then flatten while
+>   latency keeps climbing roughly linearly in k. Chosen k at the knee.
+> - Added latency is tens to low-hundreds of ms/query on CPU at the chosen k —
+>   material for a future interactive path, negligible for the batch eval.
+
+---
+
+## Outcome (2026-08-29)
+
+`make tune-reranking` (the candidate-depth sweep and the CPU latency probe) and
+`make eval-retrieval-rerank` (the full breakdown at the chosen depth) →
+`eval/runs/rerank_tuning.{md,json}` and
+`eval/runs/retrieval_eval_hybrid_rrf_rerank_filter-default.{md,json}`
+(regenerable; gitignored). Reranker `Alibaba-NLP/gte-multilingual-reranker-base`
+@ `8215cf04…` (config fingerprint `777c0503f1073d52`) on the [M3-04] hybrid RRF +
+SUSEP-process + CNPJ base (`279ed8ee0a668227`). 117 scorable questions (the 23
+`unanswerable` are excluded — empty reference set); all CASCO / CARTA VERDE, all
+`text` extraction. Scoring ran on an RTX 3050 (the scores are device-independent);
+the latency column is a CPU probe on a Ryzen 5 5600H.
+
+### Curve — candidate depth sweep
+
+The `n` dimension (final context cut) is the Recall@1 / @5 / @10 columns:
+n = 1 / 5 / 10.
+
+| candidate depth | R@1 | R@5 | R@10 | MRR | nDCG@10 | exclusion recall | CPU rerank ms/query (p50 / mean) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| hybrid RRF (no rerank) | 64.5% | 83.6% | 91.5% | 78.8% | 80.3% | 92.6% (25/27) | — |
+| **10** ← chosen | 65.8% | 86.9% | 91.5% | 80.6% | 82.0% | 92.6% (25/27) | 9 750 / 11 000 |
+| 20 | 64.1% | 86.1% | 92.3% | 79.1% | 81.1% | 92.6% (25/27) | 19 200 / 22 500 |
+| 30 | 64.1% | 85.7% | 91.6% | 78.8% | 80.5% | 85.2% (23/27) | 29 000 / 34 100 |
+| 50 | 63.2% | 84.9% | 90.7% | 78.2% | 79.8% | 85.2% (23/27) | 38 900 / 47 100 |
+
+The curve has **no rising limb** — every metric peaks at depth 10 and declines
+monotonically after. Depth 10 is a pure reorder of the hybrid top-10 (R@10 cannot
+move, and doesn't). Depth 20 is the only depth that lifts R@10, by 0.8 pt (one
+question), at the cost of 1.5 pt MRR. From depth 30 the cross-encoder starts
+promoting deep, plausible-but-wrong candidates: R@10 falls **below** the no-rerank
+baseline (90.7% at depth 50) and **exclusion-clause recall drops to 85.2%
+(23/27)** — two exclusion clauses pushed out of the top-10, the DoD's named
+regression.
+
+### At the chosen depth (10) — by question type
+
+(→ is no-rerank → +rerank at depth 10, both on the `--filter default` base.)
+
+| question_type | n | R@1 | R@5 | R@10 | MRR | nDCG@10 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `direct_lookup` | 64 | 69.5 → **74.2** | 89.5 → **93.2** | 95.3 → 95.3 | 80.7 → **85.1** | 83.9 → **87.2** |
+| `definition` | 18 | 77.8 → 77.8 | 83.3 → 83.3 | 88.9 → 88.9 | 80.4 → **81.5** | 82.4 → **83.3** |
+| `cross_document` | 16 | 75.0 → **68.8** | 87.5 → **93.8** | 93.8 → 93.8 | 82.1 → **80.2** | 85.0 → **83.7** |
+| `coverage_with_exclusion` | 19 | 26.3 → **23.7** | 60.5 → **63.2** | 78.9 → 78.9 | 68.2 → **64.8** | 62.1 → 61.8 |
+| overall | 117 | 64.5 → **65.8** | 83.6 → **86.9** | 91.5 → 91.5 | 78.8 → **80.6** | 80.3 → **82.0** |
+
+The lift is concentrated in `direct_lookup` (55% of the scored set): +4.7 pt R@1,
++3.7 pt R@5, +4.4 pt MRR — exactly where reading the query and the clause together
+disambiguates an exact-term match. `definition` gains slightly. `cross_document`
+and `coverage_with_exclusion` give back a little top-rank precision: the
+cross-encoder scores a fluent coverage clause above the terse exclusion that
+limits it, and can demote the right clause on a question that spans two
+documents. But **exclusion-*clause* recall** — the DoD metric, "is the exclusion
+retrieved in the top-10 at all" — is **unchanged at 92.6% (25/27)**: the same two
+clauses miss as in the baseline, none new.
+
+### Prediction vs actual
+
+| prediction | actual | call |
+| --- | --- | --- |
+| Reranking lifts MRR and R@1 (MRR → ~83%+, R@1 → ~68%+) and nDCG@10 | MRR 78.8 → 80.6, R@1 64.5 → 65.8, nDCG 80.3 → 82.0 — direction right, ~half the predicted magnitude | **partly missed** — the lift is real but does not recover the MRR 83.1 weighted fusion bought |
+| R@10 moves little at shallow depth, gains a point or two at deeper k, does not drop below 91.5% at the chosen k | depth 10: R@10 = 91.5% exactly (pure reorder); at deeper k it *drops* (90.7% at depth 50), it does not gain | **missed** — the "gains at deeper k" half is backwards; "not below baseline at the chosen k" held (chose depth 10) |
+| Exclusion-clause recall ≥ 92.6% at the chosen (k,n); the regression does not occur; `coverage_with_exclusion` stays weakest | depth 10: 92.6% (25/27), unchanged — regression does not occur. It *does* occur at depth ≥ 30 (85.2%). `coverage_with_exclusion` stays weakest (78.9% R@10) | **held** at the chosen depth — and the sweep shows where it breaks |
+| Curve has a knee: metrics rise from k=10 to ~k=30–50 then flatten; chosen k at the knee | metrics do not rise — they peak at k=10 and fall after | **missed** — chose k=10, for the opposite reason to the one predicted |
+| Added latency is tens to low-hundreds of ms/query on CPU at the chosen k | ~9 750 ms/query (p50) at depth 10 on the Ryzen 5 5600H | **missed, badly** — ~50–100× the prediction; see Latency trade-off |
+
+---
+
+## Latency trade-off
+
+At the chosen depth 10, batch 1, `RERANKER_MAX_INPUT_TOKENS` = 8192:
+
+> **+~9 750 ms/query (p50; mean ~11 000, p95 ~34 000) on CPU (Ryzen 5 5600H)
+> buys +1.8 pt MRR / +1.3 pt R@1 / +3.3 pt R@5 / +1.7 pt nDCG@10 / ±0 pt R@10 /
+> ±0 pt exclusion-clause recall.**
+
+The **metric** side of the trade is worth taking: a ~2 pt MRR / ~3 pt R@5 lift,
+and at eval time it is nearly free — the scoring pass runs on the RTX 3050 at
+~45 ms/pair (~2 min for the whole golden set), and the
+`data/cache/reranker/cache.jsonl` (keyed by `config_fingerprint · query ·
+passage`) makes every re-run after the first a dict lookup.
+
+The **latency** side rules the CPU cross-encoder out as a live component: ~10 s
+added to every claim (p50; ~34 s at p95, climbing to ~39 s p50 at depth 50) is
+not an interactive path. Per `docs/EMBEDDINGS.md`'s "does it earn its place"
+framing:
+
+- **Batch evaluation** (the [M3-08] matrix, golden-set re-measurement): the
+  reranker earns its place — GPU scoring, cached re-runs.
+- **M4's live graph / M5's API**: the CPU reranker as written does **not**. The
+  levers, all M4's to pull, sit behind the one `RerankingRetriever` interface:
+  run the ~306 M cross-encoder on a GPU (the RTX 3050's 4 GB holds it alone — the
+  eval already does this for scoring), drop `RERANK_CANDIDATE_DEPTH` further, make
+  reranking optional, or swap a smaller / quantized / API reranker. `_load_reranker`
+  pins CPU for the **eval harness only**; its docstring says M4 picks its device.
+
+---
+
+## Verdict
+
+**Keep reranking, at `RERANK_CANDIDATE_DEPTH = 10`.** Reordering the hybrid RRF
+top-10 with the cross-encoder lifts overall MRR 78.8 → 80.6, R@1 64.5 → 65.8, R@5
+83.6 → 86.9 and nDCG@10 80.3 → 82.0, with R@10 unchanged at 91.5% and
+exclusion-clause recall unchanged at 92.6% (25/27). Both M3 exit values
+(`MILESTONES.md`: R@10 ≥ 0.85, MRR ≥ 0.60) still clear their bars. The gain is
+concentrated in `direct_lookup`; `cross_document` and `coverage_with_exclusion`
+give back a little top-rank precision but their R@10 and the exclusion-clause
+metric are untouched.
+
+**DoD item 4 — reranking must not push exclusion clauses out of the final
+context.** At depth 10: confirmed — exclusion-clause recall 92.6% (25/27) before
+and after, the same two misses. The sweep shows the regression is real at
+depth ≥ 30 (85.2%, 23/27): the cross-encoder ranks a fluent coverage clause above
+the terse exclusion. That is a second, independent reason the chosen depth is
+shallow.
+
+**Why not depth 20** (the only depth that lifts R@10, by 0.8 pt): 0.8 pt is one
+question, and it costs 1.5 pt MRR and 1.7 pt R@1. Reranking's job is top-rank
+precision; depth 10 delivers it with no R@10 cost. [M3-08] re-opens the depth
+(and the RRF-vs-weighted call) with the full matrix and the reranker in the loop.
+
+**Deviation from the pre-registered prediction, stated per `MILESTONES.md`.**
+Three of the five bullets missed: the metric lift is real but ~half the predicted
+magnitude; the curve has no rising limb (metrics peak at the shallowest depth,
+not at k ≈ 30–50), so "chose k at the knee" holds only trivially; and the CPU
+latency is ~50–100× the "tens to low-hundreds of ms" predicted, which makes the
+CPU cross-encoder a batch-eval / GPU-serving tool, not a live-path component. The
+predictions are left unedited above; the curve and the by-type table are the
+evidence. A dated `[M3-05]` note is added to `MILESTONES.md`'s M3 section.
+
+---
+
+## Limitations
+
+- **Product-line coverage stays 2 of 5.** The 117 scorable questions reference
+  only CASCO (114) and CARTA VERDE (3); RCF-A, ASSIST and GAR.EST appear only
+  among the excluded `unanswerable` questions — the same `golden-set-v1` limit
+  `docs/LEXICAL_RETRIEVAL.md`, `docs/HYBRID_RETRIEVAL.md` and
+  `docs/EVALUATION.md` record.
+- **The `n` (final context) dimension is tuned against the top-10 harness.** The
+  Recall@1/@5/@10 columns give the n = 1/5/10 view, but M4's real context budget
+  — how many reranked clauses actually reach the assessment LLM — is M4's call
+  with its own constraints; `RERANK_CANDIDATE_DEPTH` is the knob M3-05 fixes.
+- **The dense leg reads the dev database** and the models load locally; not
+  hermetic the way the file-based lexical eval is. The config fingerprints pin
+  the contract.
+- **Latency is a CPU, batch-1 number** on one machine (Ryzen 5 5600H). It is the
+  conservative number for the interactive-path question — a batched or GPU
+  reranker does better — not a throughput ceiling. The metrics are
+  device-independent.
+
+---
+
+## Deferred / handed to later issues
+
+- **The lexical / dense / hybrid / hybrid+rerank benchmark matrix and
+  `make build-index`** — [M3-08], which also re-opens the RRF-vs-weighted fusion
+  call now that the reranker exists.
+- **Exclusion co-retrieval** (pull the exclusion linked to every retrieved
+  coverage clause) — [M3-06]. `coverage_with_exclusion` is the weakest question
+  type and reranking does not fix it — it can only reorder what retrieval found.
+- **The insufficient-context gate** on the retrieval signals — [M3-07].
+- **BM25 `k1`/`b` and RRF `k` tuning with the reranker in the loop** — [M3-08].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,17 @@ dev = [
     "ruff>=0.16.0",
 ]
 
-# Real local embedder for `make embed-chunks` only (sentence-transformers pulls
-# torch + transformers). Deliberately excluded from [tool.uv] default-groups, so
-# `uv sync` and CI stay torch-free; opt in with `uv run --group embed` (the
-# Makefile does) or `uv sync --group embed`.
+# Real local embedder (`make embed-chunks`) and cross-encoder reranker
+# (`make eval-retrieval-rerank` / `make tune-reranking`) -- sentence-transformers
+# pulls torch + transformers and already ships `CrossEncoder`, so the reranker
+# [M3-05] adds no dependency. Deliberately excluded from [tool.uv]
+# default-groups, so `uv sync` and CI stay torch-free; opt in with
+# `uv run --group embed` (the Makefile does) or `uv sync --group embed`.
 #
-# transformers is held in the 4.4x line: gte-multilingual-base's config.json
-# declares transformers_version 4.39.1, and its `trust_remote_code` RoPE
-# modelling code (Alibaba-NLP/new-impl) raises IndexError on transformers >=5 /
+# transformers is held in the 4.4x line: gte-multilingual-base and
+# gte-multilingual-reranker-base both declare transformers_version 4.39.1 in
+# config.json, and their shared `trust_remote_code` RoPE modelling code
+# (Alibaba-NLP/new-impl) raises IndexError on transformers >=5 /
 # sentence-transformers >=4. Pinned to a tested-compatible window; the lockfile
 # is the exact pin.
 embed = [

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -24,6 +24,15 @@ process + insurer CNPJ (the default retrieval path); ``--filter none`` is
 the unknown-process degradation case. Comparison and verdict:
 ``docs/HYBRID_RETRIEVAL.md``.
 
+``--rerank`` [M3-05] wraps the chosen retriever in
+[infrastructure.rag.reranking_retriever.RerankingRetriever]: it fetches
+[infrastructure.rag.reranker_config.RERANK_CANDIDATE_DEPTH] candidates from the
+base retriever, re-scores every ``(question, clause text)`` pair with the pinned
+cross-encoder (``Alibaba-NLP/gte-multilingual-reranker-base``, also from the
+``embed`` group), and returns the reordered top-k. Needs the chunk corpus for
+the clause-text lookup. Curve, chosen operating point and latency trade-off:
+``docs/RERANKING.md``.
+
 For every golden question except ``unanswerable`` ones (which carry no
 ``reference_clause_ids`` by schema construction, so Recall/MRR/nDCG are
 undefined for them -- their count is still reported, not silently
@@ -109,6 +118,17 @@ from infrastructure.rag.lexical_config import (
 )
 from infrastructure.rag.lexical_retriever import LexicalRetriever
 from infrastructure.rag.lexical_stemming_exceptions import load_stemming_exceptions
+from infrastructure.rag.reranker import Reranker
+from infrastructure.rag.reranker_cache import CachingReranker
+from infrastructure.rag.reranker_config import (
+    RERANK_CANDIDATE_DEPTH,
+    RERANKER_MODEL_ID,
+    RERANKER_MODEL_REVISION,
+)
+from infrastructure.rag.reranker_config import (
+    config_fingerprint as reranker_config_fingerprint,
+)
+from infrastructure.rag.reranking_retriever import RerankingRetriever
 from infrastructure.rag.retrieval_filter import RetrievalFilter
 
 GOLDEN_SET_DIR = Path("data/golden_set")
@@ -155,9 +175,20 @@ def _parse_args() -> argparse.Namespace:
         default=FusionStrategy.RRF.value,
         help="Fusion strategy for --retriever hybrid [M3-04] (default: rrf).",
     )
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help=(
+            "Rerank the base retriever's top candidates with the [M3-05] "
+            "cross-encoder (lexical/dense/hybrid only; needs the `embed` uv "
+            "group and the chunk corpus)."
+        ),
+    )
     args = parser.parse_args()
     if args.filter_mode == "default" and args.retriever == "random":
         parser.error("--filter default is not supported by --retriever random")
+    if args.rerank and args.retriever == "random":
+        parser.error("--rerank is not supported by --retriever random")
     return args
 
 
@@ -216,6 +247,26 @@ def load_chunk_corpus(jsonl_path: Path = CHUNKS_PATH) -> list[ChunkRecord]:
 def build_lexical_retriever(chunks: Sequence[ChunkRecord]) -> LexicalRetriever:
     """Build the [M3-03] BM25 lexical retriever from the chunk corpus."""
     return LexicalRetriever.from_chunks(list(chunks), build_analyzer())
+
+
+def build_clause_text_map(chunks: Sequence[ChunkRecord]) -> dict[str, str]:
+    """``clause_id`` -> the breadcrumb-prefixed chunk text the [M3-05] reranker scores.
+
+    Uses ``ChunkRecord.text`` -- the same field BM25 indexes and the embedder
+    embeds -- so all three legs judge the candidate on the same representation
+    (the reasoning ``docs/LEXICAL_RETRIEVAL.md`` gives for indexing ``text`` not
+    ``display_text``). A clause split across several chunks is rejoined in
+    ``chunk_index`` order; a short clause merged into a neighbour's chunk gets
+    that chunk's text via ``source_clause_ids``.
+    """
+    pieces: dict[str, list[tuple[int, str]]] = {}
+    for chunk in chunks:
+        for clause_id in chunk.source_clause_ids:
+            pieces.setdefault(clause_id, []).append((chunk.chunk_index, chunk.text))
+    return {
+        clause_id: "\n\n".join(text for _, text in sorted(parts))
+        for clause_id, parts in pieces.items()
+    }
 
 
 @dataclass(frozen=True)
@@ -534,6 +585,13 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             f"{config['candidate_depth']})",
             f"- Hybrid config fingerprint: `{config['hybrid_config_fingerprint']}`",
         ]
+    if config.get("reranker_model_id"):
+        lines += [
+            f"- Reranker: `{config['reranker_model_id']}` @ "
+            f"`{config['reranker_model_revision']}`; candidate depth "
+            f"{config['rerank_candidate_depth']}",
+            f"- Reranker config fingerprint: `{config['reranker_config_fingerprint']}`",
+        ]
     if config.get("filter_mode"):
         lines.append(f"- Metadata filter: `{config['filter_mode']}`")
     lines += [
@@ -659,18 +717,49 @@ def _hybrid_config_fields(chunks: Sequence[ChunkRecord], fusion: str) -> dict[st
     }
 
 
+def _rerank_config_fields() -> dict[str, Any]:
+    """The `--rerank` slice of RetrievalRunConfig: the pinned cross-encoder contract."""
+    return {
+        "reranker_model_id": RERANKER_MODEL_ID,
+        "reranker_model_revision": RERANKER_MODEL_REVISION,
+        "rerank_candidate_depth": RERANK_CANDIDATE_DEPTH,
+        "reranker_config_fingerprint": reranker_config_fingerprint(),
+    }
+
+
+def _apply_rerank(
+    args: argparse.Namespace,
+    base: FilterableRetriever,
+    chunks: Sequence[ChunkRecord],
+    extra_config: dict[str, Any],
+) -> tuple[Retriever, dict[str, Any]]:
+    """Wrap ``base`` in a [M3-05] RerankingRetriever when ``--rerank`` is set.
+
+    ``chunks`` supplies the clause-text lookup; it is loaded by the caller only
+    on the ``--rerank`` path for ``dense`` (lexical/hybrid already have it).
+    ``base`` is always a filterable retriever here -- ``random`` (the one
+    non-filterable retriever) rejects ``--rerank`` in ``_parse_args``.
+    """
+    if not args.rerank:
+        return base, extra_config
+    reranker = CachingReranker(_load_reranker())
+    wrapped = RerankingRetriever(base, reranker, build_clause_text_map(chunks))
+    return wrapped, {**extra_config, **_rerank_config_fields()}
+
+
 @contextmanager
 def _open_retriever(
     args: argparse.Namespace, corpus: Sequence[ParsedClauseRecord]
 ) -> Iterator[tuple[Retriever, dict[str, Any]]]:
     """Yield ``(retriever, config fields)``; ``dense``/``hybrid`` hold a DB session.
 
-    ``dense``/``hybrid`` need Postgres (loaded + embedded chunks) and the local
-    embedder from the optional ``embed`` uv group, so ``make
-    eval-retrieval-hybrid`` runs under ``uv run --group embed`` -- mirroring
-    ``make embed-chunks``. The query embedder is wrapped in a
-    [infrastructure.rag.embedding_cache.CachingEmbedder] so a re-run over the
-    117 golden queries costs nothing.
+    ``dense``/``hybrid`` (and any ``--rerank`` run) need Postgres (loaded +
+    embedded chunks) and the local models from the optional ``embed`` uv group,
+    so ``make eval-retrieval-hybrid`` / ``-rerank`` run under ``uv run --group
+    embed`` -- mirroring ``make embed-chunks``. The query embedder is wrapped in
+    a [infrastructure.rag.embedding_cache.CachingEmbedder] and the reranker in a
+    [infrastructure.rag.reranker_cache.CachingReranker] so a re-run over the 117
+    golden queries costs nothing.
     """
     name = args.retriever
     if name == "random":
@@ -681,7 +770,8 @@ def _open_retriever(
         return
     if name == "lexical":
         chunks = load_chunk_corpus()
-        yield build_lexical_retriever(chunks), _lexical_config_fields(chunks)
+        lexical = build_lexical_retriever(chunks)
+        yield _apply_rerank(args, lexical, chunks, _lexical_config_fields(chunks))
         return
 
     engine = create_engine_from_settings()
@@ -691,7 +781,8 @@ def _open_retriever(
         embedder = CachingEmbedder(_load_query_embedder())
         dense = DenseRetriever(session, embedder)
         if name == "dense":
-            yield dense, _dense_config_fields()
+            chunks = load_chunk_corpus() if args.rerank else []
+            yield _apply_rerank(args, dense, chunks, _dense_config_fields())
         else:
             chunks = load_chunk_corpus()
             hybrid = HybridRetriever(
@@ -699,23 +790,66 @@ def _open_retriever(
                 dense,
                 fusion=FusionStrategy(args.fusion),
             )
-            yield hybrid, _hybrid_config_fields(chunks, args.fusion)
+            yield _apply_rerank(
+                args, hybrid, chunks, _hybrid_config_fields(chunks, args.fusion)
+            )
     finally:
         session.close()
         engine.dispose()
 
 
+class _LazyEmbedder:
+    """A query [Embedder] that builds the real model only on a cache miss.
+
+    [M3-05]: every ``golden-set-v1`` query vector is normally already in the
+    [infrastructure.rag.embedding_cache.CachingEmbedder] file from a prior
+    ``dense`` / ``hybrid`` run, so a run that wraps this in a ``CachingEmbedder``
+    never calls ``embed`` -- and eagerly loading ``SentenceTransformerEmbedder``
+    anyway pins ~1 GB of the small dev GPU that the ``--rerank`` cross-encoder now
+    wants. On an actual miss it constructs the real embedder once (same model,
+    same vectors) and delegates from then on.
+    """
+
+    def __init__(self) -> None:
+        self._real: Embedder | None = None
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        if self._real is None:
+            from infrastructure.rag.sentence_transformer_embedder import (
+                SentenceTransformerEmbedder,
+            )
+
+            self._real = SentenceTransformerEmbedder()
+        return self._real.embed(texts)
+
+
 def _load_query_embedder() -> Embedder:
-    """Load the real local embedder.
+    """A lazily-constructed real embedder (see [_LazyEmbedder]).
 
     Deferred import so the heavy ``embed`` group is only needed for
     ``dense``/``hybrid`` runs (mirrors ``scripts/embed_chunks.py``).
     """
-    from infrastructure.rag.sentence_transformer_embedder import (
-        SentenceTransformerEmbedder,
-    )
+    return _LazyEmbedder()
 
-    return SentenceTransformerEmbedder()
+
+def _load_reranker(*, device: str | None = None) -> Reranker:
+    """Load the real local cross-encoder ([M3-05]).
+
+    ``device`` passes straight to ``sentence-transformers`` (``None`` auto-selects
+    CUDA when present, else CPU). Deferred import so the heavy ``embed`` group is
+    only needed on a ``--rerank`` run (mirrors ``_load_query_embedder``). The
+    cross-encoder's *scores* -- and so every Recall / MRR / nDCG / exclusion
+    number -- are device-independent, so ``make eval-retrieval-rerank`` takes the
+    default (the dev GPU when present: ~10x faster, and ``_load_query_embedder``
+    is lazy now so the card is free).
+    The *latency* the ``docs/RERANKING.md`` trade-off turns on is a CPU number by
+    design -- a reranker in an interactive path, no GPU serving infra -- so
+    ``scripts/tune_reranking.py`` measures that on a ``device="cpu"`` instance.
+    M4 constructs its own reranker for its serving hardware.
+    """
+    from infrastructure.rag.cross_encoder_reranker import CrossEncoderReranker
+
+    return CrossEncoderReranker(device=device)
 
 
 def _build_filter_for(
@@ -743,6 +877,8 @@ def _output_stem(args: argparse.Namespace) -> str:
     parts = [args.retriever]
     if args.retriever == "hybrid":
         parts.append(args.fusion)
+    if args.rerank:
+        parts.append("rerank")
     if args.filter_mode != "none":
         parts.append(f"filter-{args.filter_mode}")
     return "retrieval_eval_" + "_".join(parts)

--- a/scripts/tune_reranking.py
+++ b/scripts/tune_reranking.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Sweep the [M3-05] cross-encoder reranker's candidate depth -- record the curve.
+
+The M3-05 DoD asks to "tune retrieval k and rerank n on the golden set; record
+the curve, not just the chosen point", and to "measure the added latency and
+state the trade-off explicitly". This does both for the one knob that moves what
+the golden-set metrics see: ``RERANK_CANDIDATE_DEPTH`` -- how many of the fused
+hybrid candidates the cross-encoder re-scores before the top-k cut.
+
+**Metrics** (Recall@{1,5,10} / MRR / nDCG@10 / exclusion-clause recall, over all
+117 scorable ``golden-set-v1`` questions under the ``--filter default``
+SUSEP-process + CNPJ pre-filter) come from a single rerank pass at the deepest
+depth: ``fused[:30]`` is a prefix of ``fused[:50]``, so every shallower depth's
+ranking is that prefix re-sorted by the same scores -- the cross-encoder runs
+once per question, not once per (question, depth). That pass runs on the GPU
+when one is present; the scores (and so every metric) are device-independent.
+
+**Latency** is measured separately, on a ``device="cpu"`` reranker, as a probe
+over ``LATENCY_PROBE_QUESTIONS`` questions at each depth. CPU is the number the
+``docs/RERANKING.md`` trade-off turns on -- a reranker in an interactive path,
+no GPU serving infra. The query embedder is lazy (every golden query vector is
+already cached), so it never competes with the reranker for the dev GPU.
+
+The **rerank-n** dimension (final context size) is read straight off the
+Recall@1 / @5 / @10 columns of each row -- n = 1 / 5 / 10 -- so there is no
+separate n sweep here; ``docs/RERANKING.md`` states this.
+
+Needs a running Postgres with loaded + embedded chunks and the optional ``embed``
+uv group (same as ``make eval-retrieval-hybrid``). Run via ``make
+tune-reranking``. Writes ``eval/runs/rerank_tuning.{md,json}`` (gitignored); the
+committed curve and the chosen depth live in ``docs/RERANKING.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import statistics
+import time
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from infrastructure.database import (
+    assert_chunk_table_ready,
+    create_engine_from_settings,
+    create_session_factory,
+)
+from infrastructure.evaluation.golden_set_schema import GoldenQuestion, QuestionType
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import JSONL_PATH
+from infrastructure.rag.dense_retriever import DenseRetriever
+from infrastructure.rag.embedding_cache import CachingEmbedder
+from infrastructure.rag.hybrid_retriever import HybridRetriever
+from infrastructure.rag.reranker import Reranker
+from infrastructure.rag.reranker_config import (
+    RERANK_CANDIDATE_DEPTH,
+    RERANKER_MODEL_ID,
+    RERANKER_MODEL_REVISION,
+)
+from infrastructure.rag.reranker_config import (
+    config_fingerprint as reranker_config_fingerprint,
+)
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+from scripts.eval_retrieval import (
+    GOLDEN_SET_DIR,
+    K_VALUES,
+    MANIFEST_PATH,
+    NDCG_K,
+    _build_filter_for,
+    _hybrid_config_fields,
+    _load_query_embedder,
+    _load_reranker,
+    aggregate,
+    build_clause_text_map,
+    build_lexical_retriever,
+    compute_exclusion_clause_recall,
+    evaluate_questions,
+    load_chunk_corpus,
+    load_corpus,
+    load_document_metadata,
+    load_golden_questions,
+)
+
+SCHEMA_VERSION = "v1"
+OUTPUT_DIR = Path("eval/runs")
+JSON_PATH = OUTPUT_DIR / "rerank_tuning.json"
+MD_PATH = OUTPUT_DIR / "rerank_tuning.md"
+
+# The candidate-depth grid. 10 is a pure reorder of the top-10 (Recall@10 cannot
+# move); the deeper points test whether the cross-encoder rescues a relevant
+# clause the fusion ranked 11..N, and at what latency. Capped at 50: a
+# process+CNPJ-filtered partition on `golden-set-v1` rarely holds more than that
+# many candidates, so a deeper sweep would only repeat the depth-50 row.
+RERANK_CANDIDATE_DEPTHS: tuple[int, ...] = (10, 20, 30, 50)
+
+# How many questions the latency probe re-times at each shallower depth. The
+# deepest depth's latency is the full main pass (n = every scorable question);
+# the shallower rows only need a stable p50/mean, so a small sample keeps the
+# extra CPU cost modest.
+LATENCY_PROBE_QUESTIONS = 20
+
+
+def _percentile(sorted_values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile, same formula as ``scripts/benchmark_ann_index.py``."""
+    index = min(int(len(sorted_values) * fraction), len(sorted_values) - 1)
+    return sorted_values[index]
+
+
+def summarise_latency(samples_ms: list[float]) -> dict[str, float]:
+    """Summarise per-query rerank latency samples (milliseconds)."""
+    if not samples_ms:
+        return {"n": 0, "p50": 0.0, "p95": 0.0, "mean": 0.0}
+    ordered = sorted(samples_ms)
+    return {
+        "n": len(ordered),
+        "p50": round(_percentile(ordered, 0.50), 1),
+        "p95": round(_percentile(ordered, 0.95), 1),
+        "mean": round(statistics.fmean(ordered), 1),
+    }
+
+
+class _ReplayRetriever:
+    """Returns a precomputed reranked clause-id list per question text, cut to k."""
+
+    def __init__(self, by_question: Mapping[str, list[str]]) -> None:
+        self._by_question = by_question
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        del metadata_filter
+        return self._by_question[question][:k]
+
+
+def _rerank_order(candidates: Sequence[str], scores: Sequence[float]) -> list[str]:
+    """The candidate ids sorted by score desc; equal scores keep candidate order."""
+    order = sorted(range(len(candidates)), key=lambda i: scores[i], reverse=True)
+    return [candidates[i] for i in order]
+
+
+def _score_rows(
+    retriever: Any,
+    questions: Sequence[GoldenQuestion],
+    document_meta: dict[str, dict[str, str]],
+    clause_by_id: dict[str, ParsedClauseRecord],
+) -> dict[str, Any]:
+    """Run one retriever over the filtered golden set; return its metric row."""
+    filter_for = _build_filter_for("default", document_meta)
+    rows, _ = evaluate_questions(
+        questions, retriever, document_meta, filter_for=filter_for
+    )
+    overall = aggregate(rows, K_VALUES, NDCG_K)
+    exclusion = compute_exclusion_clause_recall(rows, clause_by_id, k=max(K_VALUES))
+    return {
+        "recall@1": overall["recall@1"],
+        "recall@5": overall["recall@5"],
+        "recall@10": overall["recall@10"],
+        "mrr": overall["mrr"],
+        f"ndcg@{NDCG_K}": overall[f"ndcg@{NDCG_K}"],
+        "exclusion_recall": exclusion["recall"],
+        "exclusion_hits": exclusion["hits"],
+        "exclusion_total": exclusion["total"],
+        "n": int(overall["n"]),
+    }
+
+
+class RerankTuningConfig(BaseModel):
+    """The reproducibility stamp for one ``make tune-reranking`` run."""
+
+    schema_version: str
+    run_at_utc: datetime
+    golden_set_dir: str
+    golden_set_question_count: int
+    corpus_path: str
+    corpus_clause_count: int
+    chunk_corpus_chunk_count: int
+    candidate_depths: list[int]
+    max_depth: int
+    latency_probe_questions: int
+    chosen_candidate_depth: int
+    reranker_model_id: str
+    reranker_model_revision: str
+    reranker_config_fingerprint: str
+    embedding_config_fingerprint: str
+    lexical_config_fingerprint: str
+    hybrid_config_fingerprint: str
+    scoring_device: str
+    reranker_device: str
+    platform: str
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    """Render the sweep as Markdown (numbers copied into docs/RERANKING.md)."""
+    config = report["config"]
+    lines = [
+        "# Reranker candidate-depth sweep",
+        "",
+        "Generated by `scripts/tune_reranking.py` (`make tune-reranking`) against "
+        "the golden set in `data/golden_set/` under the `--filter default` "
+        "SUSEP-process + CNPJ pre-filter. Regenerable; the committed curve and "
+        "the chosen depth live in `docs/RERANKING.md`.",
+        "",
+        "## Run configuration",
+        "",
+        f"- Golden set: `{config['golden_set_dir']}` "
+        f"({config['golden_set_question_count']} questions)",
+        f"- Corpus: `{config['corpus_path']}` "
+        f"({config['corpus_clause_count']} clauses); "
+        f"{config['chunk_corpus_chunk_count']} chunks",
+        f"- Reranker: `{config['reranker_model_id']}` @ "
+        f"`{config['reranker_model_revision']}` "
+        f"(fingerprint `{config['reranker_config_fingerprint']}`)",
+        f"- Hybrid RRF fingerprint: `{config['hybrid_config_fingerprint']}`; "
+        f"embedding `{config['embedding_config_fingerprint']}`; "
+        f"lexical `{config['lexical_config_fingerprint']}`",
+        f"- Reranker device: `{config['scoring_device']}` (scoring) / "
+        f"`{config['reranker_device']}` (latency probe); "
+        f"platform: {config['platform']}",
+        f"- Metrics: all {config['golden_set_question_count']} golden questions, "
+        f"one rerank pass at depth {config['max_depth']} (shallower depths are "
+        f"that prefix re-sorted -- scores are device-independent). Latency: a "
+        f"separate CPU probe over {config['latency_probe_questions']} questions "
+        f"per depth.",
+        f"- Candidate depths swept: {config['candidate_depths']}; "
+        f"chosen (in `reranker_config.py`): "
+        f"**{config['chosen_candidate_depth']}**",
+        f"- Run at (UTC): {config['run_at_utc']}",
+        "",
+        "## Curve",
+        "",
+        "The `n` dimension (final context cut) is the Recall@1 / @5 / @10 "
+        "columns: n = 1 / 5 / 10.",
+        "",
+        "| candidate depth | Recall@1 | Recall@5 | Recall@10 | MRR | "
+        f"nDCG@{NDCG_K} | exclusion recall | CPU rerank ms/query "
+        "(p50 / p95 / mean) |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in report["rows"]:
+        latency = row["latency_ms"]
+        if row["candidate_depth"] is None:
+            depth_label = "hybrid RRF (no rerank)"
+            latency_cell = "—"
+        else:
+            depth_label = str(row["candidate_depth"])
+            latency_cell = (
+                f"{latency['p50']:.1f} / {latency['p95']:.1f} / {latency['mean']:.1f}"
+            )
+        exclusion = row["exclusion_recall"]
+        exclusion_cell = (
+            f"{exclusion:.1%} ({row['exclusion_hits']}/{row['exclusion_total']})"
+            if exclusion is not None
+            else "n/a"
+        )
+        lines.append(
+            f"| {depth_label} "
+            f"| {row['recall@1']:.1%} | {row['recall@5']:.1%} "
+            f"| {row['recall@10']:.1%} | {row['mrr']:.1%} "
+            f"| {row[f'ndcg@{NDCG_K}']:.1%} | {exclusion_cell} | {latency_cell} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _scorable(questions: Sequence[GoldenQuestion]) -> list[GoldenQuestion]:
+    return [q for q in questions if q.question_type is not QuestionType.UNANSWERABLE]
+
+
+def _rerank_at_max_depth(
+    hybrid: HybridRetriever,
+    reranker: Reranker,
+    questions: Sequence[GoldenQuestion],
+    document_meta: dict[str, dict[str, str]],
+    text_map: Mapping[str, str],
+    max_depth: int,
+) -> dict[str, tuple[list[str], list[float]]]:
+    """Per scorable question: its top-``max_depth`` hybrid candidates and rerank scores.
+
+    Keyed by question text -- ``evaluate_questions`` only ever hands the retriever
+    the question string.
+    """
+    per_question: dict[str, tuple[list[str], list[float]]] = {}
+    for question in _scorable(questions):
+        metadata_filter = RetrievalFilter.from_manifest_row(
+            document_meta[question.document_id]
+        )
+        candidates = hybrid.retrieve(
+            question.question, k=max_depth, metadata_filter=metadata_filter
+        )
+        passages = [text_map.get(clause_id, "") for clause_id in candidates]
+        scores = reranker.rerank(question.question, passages) if passages else []
+        if question.question in per_question:
+            raise ValueError(f"duplicate golden question text: {question.question!r}")
+        per_question[question.question] = (candidates, scores)
+    return per_question
+
+
+def _probe_latency(
+    reranker: Reranker,
+    questions: Sequence[GoldenQuestion],
+    per_question: dict[str, tuple[list[str], list[float]]],
+    text_map: Mapping[str, str],
+    depth: int,
+    sample_size: int,
+) -> dict[str, float]:
+    """Time ``reranker`` re-scoring the top-``depth`` passages for a question sample."""
+    samples_ms: list[float] = []
+    for question in _scorable(questions)[:sample_size]:
+        candidates, _ = per_question[question.question]
+        passages = [text_map.get(c, "") for c in candidates[:depth]]
+        if not passages:
+            continue
+        start = time.perf_counter()
+        reranker.rerank(question.question, passages)
+        samples_ms.append((time.perf_counter() - start) * 1000.0)
+    return summarise_latency(samples_ms)
+
+
+def main() -> None:
+    """Run the sweep against the golden set and write the report."""
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    corpus = load_corpus(JSONL_PATH)
+    clause_by_id = {record.clause_id: record for record in corpus}
+    questions = load_golden_questions(GOLDEN_SET_DIR)
+    chunks = load_chunk_corpus()
+    text_map = build_clause_text_map(chunks)
+    hybrid_fields = _hybrid_config_fields(chunks, "rrf")
+    max_depth = max(RERANK_CANDIDATE_DEPTHS)
+
+    # Scoring on the GPU when present (device-independent scores, ~10x faster);
+    # the latency the docs/RERANKING.md trade-off reports is a CPU number, probed
+    # on its own instance.
+    score_reranker = _load_reranker()
+    scoring_device = str(getattr(score_reranker, "device", "unknown"))
+    cpu_reranker = _load_reranker(device="cpu")
+    reranker_device = str(getattr(cpu_reranker, "device", "unknown"))
+
+    engine = create_engine_from_settings()
+    session = create_session_factory(engine=engine)()
+    rows: list[dict[str, Any]] = []
+    try:
+        assert_chunk_table_ready(session)
+        embedder = CachingEmbedder(_load_query_embedder())
+        dense = DenseRetriever(session, embedder)
+        hybrid = HybridRetriever(build_lexical_retriever(chunks), dense)
+
+        baseline = _score_rows(hybrid, questions, document_meta, clause_by_id)
+        baseline |= {"candidate_depth": None, "latency_ms": summarise_latency([])}
+        rows.append(baseline)
+        print(
+            f"baseline hybrid RRF: R@10={baseline['recall@10']:.1%} "
+            f"MRR={baseline['mrr']:.1%}",
+            flush=True,
+        )
+
+        # One expensive pass: rerank every scorable question's top-`max_depth`
+        # candidates. Every shallower depth is a prefix of this, re-sorted.
+        per_question = _rerank_at_max_depth(
+            hybrid, score_reranker, questions, document_meta, text_map, max_depth
+        )
+        print(
+            f"reranked {len(per_question)} questions at depth {max_depth} "
+            f"on {scoring_device}",
+            flush=True,
+        )
+
+        for depth in RERANK_CANDIDATE_DEPTHS:
+            replay = {
+                text: _rerank_order(candidates[:depth], scores[:depth])
+                for text, (candidates, scores) in per_question.items()
+            }
+            row = _score_rows(
+                _ReplayRetriever(replay), questions, document_meta, clause_by_id
+            )
+            row["latency_ms"] = _probe_latency(
+                cpu_reranker,
+                questions,
+                per_question,
+                text_map,
+                depth,
+                LATENCY_PROBE_QUESTIONS,
+            )
+            row["candidate_depth"] = depth
+            rows.append(row)
+            print(
+                f"depth {depth:>3}: R@10={row['recall@10']:.1%} "
+                f"MRR={row['mrr']:.1%} nDCG={row[f'ndcg@{NDCG_K}']:.1%} "
+                f"excl={row['exclusion_recall']} "
+                f"cpu p50={row['latency_ms']['p50']:.0f}ms",
+                flush=True,
+            )
+
+        config = RerankTuningConfig(
+            schema_version=SCHEMA_VERSION,
+            run_at_utc=datetime.now(UTC),
+            golden_set_dir=str(GOLDEN_SET_DIR),
+            golden_set_question_count=len(questions),
+            corpus_path=str(JSONL_PATH),
+            corpus_clause_count=len(corpus),
+            chunk_corpus_chunk_count=len(chunks),
+            candidate_depths=list(RERANK_CANDIDATE_DEPTHS),
+            max_depth=max_depth,
+            latency_probe_questions=LATENCY_PROBE_QUESTIONS,
+            chosen_candidate_depth=RERANK_CANDIDATE_DEPTH,
+            reranker_model_id=RERANKER_MODEL_ID,
+            reranker_model_revision=RERANKER_MODEL_REVISION,
+            reranker_config_fingerprint=reranker_config_fingerprint(),
+            embedding_config_fingerprint=hybrid_fields["embedding_config_fingerprint"],
+            lexical_config_fingerprint=hybrid_fields["lexical_config_fingerprint"],
+            hybrid_config_fingerprint=hybrid_fields["hybrid_config_fingerprint"],
+            scoring_device=scoring_device,
+            reranker_device=reranker_device,
+            platform=platform.platform(),
+        )
+    finally:
+        session.close()
+        engine.dispose()
+
+    report = {"config": config.model_dump(mode="json"), "rows": rows}
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    MD_PATH.write_text(render_markdown_report(report), encoding="utf-8")
+    print(f"Wrote {JSON_PATH} and {MD_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/eval/test_hybrid_retrieval_baseline.py
+++ b/tests/eval/test_hybrid_retrieval_baseline.py
@@ -74,7 +74,7 @@ def test_filtered_hybrid_clears_a_floor_and_stays_in_document() -> None:
     from infrastructure.parsing.corpus_artifact import JSONL_PATH
 
     args = argparse.Namespace(
-        retriever="hybrid", fusion="rrf", filter_mode="default", seed=42
+        retriever="hybrid", fusion="rrf", filter_mode="default", seed=42, rerank=False
     )
     document_meta = load_document_metadata(MANIFEST_PATH)
     questions = load_golden_questions(GOLDEN_SET_DIR)

--- a/tests/eval/test_rerank_retrieval_baseline.py
+++ b/tests/eval/test_rerank_retrieval_baseline.py
@@ -1,0 +1,104 @@
+"""Sanity floor for the [M3-05] cross-encoder rerank of the filtered hybrid.
+
+The mirror of ``test_hybrid_retrieval_baseline.py`` for the rerank stage: proves
+that hybrid RRF + cross-encoder rerank, filtered to each question's SUSEP
+process + CNPJ, still clears a recall floor **and** does not push exclusion
+clauses out of the kept context relative to the no-rerank baseline (the M3-05
+DoD's named regression). A smoke check, not a quality gate -- the committed
+numbers, the curve and the verdict live in ``docs/RERANKING.md``.
+
+Needs ``build/chunks.jsonl``, a reachable Postgres with embedded chunks, and the
+optional ``embed`` uv group (which also ships the cross-encoder). Skips cleanly
+when any is absent, so ``make test-eval`` stays green on a machine without the
+stack.
+"""
+
+import argparse
+
+import pytest
+from sqlalchemy import func, select
+
+from infrastructure.rag.chunk_artifact import CHUNKS_JSONL_PATH
+
+pytestmark = pytest.mark.eval
+
+RECALL_FLOOR = 0.85
+MRR_FLOOR = 0.65
+
+
+def _skip_unless_ready() -> None:
+    if not CHUNKS_JSONL_PATH.exists():
+        pytest.skip("build/chunks.jsonl not built; run `make build-chunks`")
+    try:
+        import sentence_transformers  # noqa: F401
+    except ImportError:
+        pytest.skip("optional `embed` group not installed; `uv sync --group embed`")
+    from infrastructure.database import (
+        create_engine_from_settings,
+        create_session_factory,
+    )
+    from infrastructure.database.models import ChunkRow
+
+    try:
+        engine = create_engine_from_settings()
+        with create_session_factory(engine=engine)() as session:
+            embedded = session.execute(
+                select(func.count())
+                .select_from(ChunkRow)
+                .where(ChunkRow.embedding.is_not(None))
+            ).scalar_one()
+        engine.dispose()
+    except Exception as exc:  # noqa: BLE001 - any DB failure is a skip, not a fail
+        pytest.skip(f"database not ready for the rerank eval: {exc}")
+    if embedded < 100:
+        pytest.skip(f"only {embedded} embedded chunks; run `make embed-chunks`")
+
+
+@pytest.mark.eval
+def test_filtered_hybrid_rerank_clears_a_floor_and_keeps_exclusion_clauses() -> None:
+    _skip_unless_ready()
+
+    from scripts.eval_retrieval import (
+        GOLDEN_SET_DIR,
+        MANIFEST_PATH,
+        _build_filter_for,
+        _open_retriever,
+        aggregate,
+        compute_exclusion_clause_recall,
+        evaluate_questions,
+        load_corpus,
+        load_document_metadata,
+        load_golden_questions,
+    )
+
+    from infrastructure.parsing.corpus_artifact import JSONL_PATH
+
+    corpus = load_corpus(JSONL_PATH)
+    clause_by_id = {record.clause_id: record for record in corpus}
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    questions = load_golden_questions(GOLDEN_SET_DIR)
+    filter_for = _build_filter_for("default", document_meta)
+
+    def score(rerank: bool) -> tuple[dict[str, float], float | None]:
+        args = argparse.Namespace(
+            retriever="hybrid",
+            fusion="rrf",
+            filter_mode="default",
+            seed=42,
+            rerank=rerank,
+        )
+        with _open_retriever(args, corpus) as (retriever, _config):
+            rows, _ = evaluate_questions(
+                questions, retriever, document_meta, filter_for=filter_for
+            )
+        exclusion = compute_exclusion_clause_recall(rows, clause_by_id, k=10)
+        return aggregate(rows, (1, 5, 10), 10), exclusion["recall"]
+
+    baseline_overall, baseline_exclusion = score(rerank=False)
+    rerank_overall, rerank_exclusion = score(rerank=True)
+
+    assert rerank_overall["recall@10"] > RECALL_FLOOR
+    assert rerank_overall["mrr"] > MRR_FLOOR
+    # DoD item 4: reranking must not push exclusion clauses out of the context.
+    assert baseline_exclusion is not None and rerank_exclusion is not None
+    assert rerank_exclusion >= baseline_exclusion - 1e-9

--- a/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
+++ b/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
@@ -92,3 +92,32 @@ def test_v3_filter_and_fusion_fields_are_optional_and_round_trip() -> None:
         hybrid_config_fingerprint="279ed8ee0a668227",
     )
     assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config
+
+
+@pytest.mark.unit
+def test_v4_rerank_fields_are_optional_and_round_trip() -> None:
+    # Every non-rerank run leaves the [M3-05] fields None; `--rerank` sets them.
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "retriever_name": "hybrid",
+        "k_values": [1, 5, 10],
+        "ndcg_k": 10,
+        "golden_set_dir": "data/golden_set",
+        "golden_set_question_count": 140,
+        "corpus_path": "build/parsed_clauses.jsonl",
+        "corpus_clause_count": 4925,
+        "seed": None,
+        "run_at_utc": datetime.now(UTC),
+    }
+    assert RetrievalRunConfig(**base).reranker_model_id is None
+
+    config = RetrievalRunConfig(
+        **base,
+        filter_mode="default",
+        fusion_strategy="rrf",
+        reranker_model_id="Alibaba-NLP/gte-multilingual-reranker-base",
+        reranker_model_revision="8215cf04918ba6f7b6a62bb44238ce2953d8831c",
+        rerank_candidate_depth=10,
+        reranker_config_fingerprint="777c0503f1073d52",
+    )
+    assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config

--- a/tests/unit/infrastructure/rag/test_cross_encoder_reranker.py
+++ b/tests/unit/infrastructure/rag/test_cross_encoder_reranker.py
@@ -1,0 +1,125 @@
+"""The real reranker's wiring, proven without installing sentence-transformers.
+
+The optional ``embed`` dependency group is not in the env `make check` / CI run
+against, so these tests fake ``sentence_transformers`` in ``sys.modules`` and
+never import torch. Mirrors ``test_sentence_transformer_embedder.py``.
+"""
+
+import builtins
+import sys
+import types
+
+import pytest
+
+from infrastructure.rag.cross_encoder_reranker import CrossEncoderReranker
+from infrastructure.rag.reranker_config import (
+    RERANKER_MODEL_ID,
+    RERANKER_MODEL_REVISION,
+)
+
+
+class _FakeCrossEncoder:
+    def __init__(
+        self,
+        model_id: str,
+        *,
+        revision: str,
+        trust_remote_code: bool,
+        max_length: int,
+        device: str | None,
+    ) -> None:
+        self.init_kwargs = {
+            "model_id": model_id,
+            "revision": revision,
+            "trust_remote_code": trust_remote_code,
+            "max_length": max_length,
+        }
+        self.device = device or "cpu"
+        self.predict_calls: list[list[tuple[str, str]]] = []
+
+    def predict(self, pairs: list[tuple[str, str]], **kwargs: object) -> list[float]:
+        self.predict_calls.append(list(pairs))
+        # Deterministic, distinct score per passage: longer passage scores higher.
+        return [float(len(passage)) for _query, passage in pairs]
+
+
+def _install_fake(monkeypatch: pytest.MonkeyPatch) -> list[_FakeCrossEncoder]:
+    created: list[_FakeCrossEncoder] = []
+
+    def factory(
+        model_id: str,
+        *,
+        revision: str,
+        trust_remote_code: bool,
+        max_length: int,
+        device: str | None,
+    ) -> _FakeCrossEncoder:
+        model = _FakeCrossEncoder(
+            model_id,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+            max_length=max_length,
+            device=device,
+        )
+        created.append(model)
+        return model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        types.SimpleNamespace(CrossEncoder=factory),
+    )
+    return created
+
+
+@pytest.mark.unit
+def test_missing_dependency_raises_a_pointed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise ModuleNotFoundError("No module named 'sentence_transformers'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.delitem(sys.modules, "sentence_transformers", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError, match="--group embed"):
+        CrossEncoderReranker()
+
+
+@pytest.mark.unit
+def test_loads_the_pinned_model_and_scores_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = _install_fake(monkeypatch)
+
+    reranker = CrossEncoderReranker(device="cpu")
+
+    assert created[0].init_kwargs == {
+        "model_id": RERANKER_MODEL_ID,
+        "revision": RERANKER_MODEL_REVISION,
+        "trust_remote_code": True,
+        "max_length": 8192,
+    }
+    assert reranker.device == "cpu"
+
+    scores = reranker.rerank("qual a franquia?", ["curto", "um trecho bem mais longo"])
+
+    assert scores == [5.0, 24.0]
+    assert created[0].predict_calls[0] == [
+        ("qual a franquia?", "curto"),
+        ("qual a franquia?", "um trecho bem mais longo"),
+    ]
+
+
+@pytest.mark.unit
+def test_empty_passages_never_touches_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = _install_fake(monkeypatch)
+
+    assert CrossEncoderReranker().rerank("q", []) == []
+    assert created[0].predict_calls == []

--- a/tests/unit/infrastructure/rag/test_reranker_cache.py
+++ b/tests/unit/infrastructure/rag/test_reranker_cache.py
@@ -1,0 +1,131 @@
+"""The reranker cache and its fingerprint scoping -- [M3-05].
+
+Mirrors ``test_embedding_cache.py``.
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from infrastructure.rag.reranker_cache import CachingReranker
+
+
+def _score(query: str, passage: str) -> float:
+    """A deterministic, distinct pseudo-score per pair."""
+    return float(len(query) * 100 + len(passage))
+
+
+class CountingReranker:
+    """Records every batch of passages it was asked to score."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[str]]] = []
+
+    def rerank(self, query: str, passages: Sequence[str]) -> list[float]:
+        self.calls.append((query, list(passages)))
+        return [_score(query, passage) for passage in passages]
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
+
+
+@pytest.mark.unit
+def test_cache_miss_calls_inner_and_persists(tmp_path: Path) -> None:
+    inner = CountingReranker()
+    cache_path = tmp_path / "cache.jsonl"
+
+    result = CachingReranker(inner, cache_path=cache_path).rerank("q", ["a", "b"])
+
+    assert result == [_score("q", "a"), _score("q", "b")]
+    assert inner.call_count == 1
+    assert len(cache_path.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+@pytest.mark.unit
+def test_cache_hit_skips_inner(tmp_path: Path) -> None:
+    inner = CountingReranker()
+    cache_path = tmp_path / "cache.jsonl"
+    reranker = CachingReranker(inner, cache_path=cache_path)
+
+    first = reranker.rerank("q", ["a", "b"])
+    second = reranker.rerank("q", ["a", "b"])
+
+    assert first == second
+    assert inner.call_count == 1
+
+
+@pytest.mark.unit
+def test_batch_scores_only_missing_pairs_and_preserves_order(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    CachingReranker(CountingReranker(), cache_path=cache_path).rerank("q", ["a", "c"])
+
+    inner = CountingReranker()
+    result = CachingReranker(inner, cache_path=cache_path).rerank(
+        "q", ["a", "b", "c", "d"]
+    )
+
+    assert result == [_score("q", p) for p in ("a", "b", "c", "d")]
+    assert inner.calls == [("q", ["b", "d"])]  # only the two not already cached
+
+
+@pytest.mark.unit
+def test_same_passage_different_query_is_a_distinct_key(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    CachingReranker(CountingReranker(), cache_path=cache_path).rerank("q1", ["a"])
+
+    inner = CountingReranker()
+    CachingReranker(inner, cache_path=cache_path).rerank("q2", ["a"])
+
+    assert inner.calls == [("q2", ["a"])]
+
+
+@pytest.mark.unit
+def test_duplicate_passages_in_one_call_score_once(tmp_path: Path) -> None:
+    inner = CountingReranker()
+    cache_path = tmp_path / "cache.jsonl"
+
+    result = CachingReranker(inner, cache_path=cache_path).rerank("q", ["x", "x", "x"])
+
+    assert result == [_score("q", "x")] * 3
+    assert inner.calls == [("q", ["x"])]
+
+
+@pytest.mark.unit
+def test_hit_and_miss_counters_track_every_pair(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+
+    cold = CachingReranker(CountingReranker(), cache_path=cache_path)
+    cold.rerank("q", ["a", "b", "c"])
+    assert (cold.hits, cold.misses) == (0, 3)
+
+    warm = CachingReranker(CountingReranker(), cache_path=cache_path)
+    warm.rerank("q", ["a", "b", "new"])
+    assert (warm.hits, warm.misses) == (2, 1)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("attr", "value"),
+    [
+        ("RERANKER_MODEL_ID", "other/model"),
+        ("RERANKER_MODEL_REVISION", "0" * 40),
+        ("RERANK_CANDIDATE_DEPTH", 999),
+    ],
+)
+def test_config_change_invalidates_the_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, attr: str, value: object
+) -> None:
+    cache_path = tmp_path / "cache.jsonl"
+    warm_inner = CountingReranker()
+    CachingReranker(warm_inner, cache_path=cache_path).rerank("q", ["a"])
+    assert warm_inner.call_count == 1
+
+    # Same pair, but a different reranker contract -- must NOT reuse the score.
+    monkeypatch.setattr(f"infrastructure.rag.reranker_config.{attr}", value)
+
+    cold_inner = CountingReranker()
+    CachingReranker(cold_inner, cache_path=cache_path).rerank("q", ["a"])
+
+    assert cold_inner.calls == [("q", ["a"])]

--- a/tests/unit/infrastructure/rag/test_reranker_config.py
+++ b/tests/unit/infrastructure/rag/test_reranker_config.py
@@ -1,0 +1,71 @@
+"""The pinned cross-encoder-reranker contract and its anti-drift guards -- [M3-05]."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from infrastructure.rag import reranker_config
+from infrastructure.rag.reranker_config import (
+    RERANK_CANDIDATE_DEPTH,
+    RERANKER_MAX_INPUT_TOKENS,
+    RERANKER_MODEL_ID,
+    RERANKER_MODEL_REVISION,
+    RERANKER_TRUST_REMOTE_CODE,
+    config_fingerprint,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@pytest.mark.unit
+def test_model_contract_constants() -> None:
+    assert RERANKER_MODEL_ID == "Alibaba-NLP/gte-multilingual-reranker-base"
+    assert RERANKER_MAX_INPUT_TOKENS == 8192
+    assert RERANKER_TRUST_REMOTE_CODE is True
+    assert RERANK_CANDIDATE_DEPTH >= 10
+
+
+@pytest.mark.unit
+def test_revision_is_a_pinned_commit_not_a_floating_alias() -> None:
+    # A 40-char hex SHA -- never "main"/"master"/"" -- so a provider-side
+    # re-upload cannot change the ranking behind a published number.
+    assert re.fullmatch(r"[0-9a-f]{40}", RERANKER_MODEL_REVISION) is not None
+
+
+@pytest.mark.unit
+def test_config_fingerprint_is_stable() -> None:
+    # A pinned literal, so reordering or dropping a field from the payload is a
+    # visible test failure -- the reranker cache's key depends on this digest.
+    assert config_fingerprint() == "777c0503f1073d52"
+    assert re.fullmatch(r"[0-9a-f]{16}", config_fingerprint()) is not None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("attr", "value"),
+    [
+        ("RERANKER_MODEL_ID", "other/model"),
+        ("RERANKER_MODEL_REVISION", "0" * 40),
+        ("RERANKER_MAX_INPUT_TOKENS", 512),
+        ("RERANK_CANDIDATE_DEPTH", 999),
+    ],
+)
+def test_every_contract_field_changes_the_fingerprint(
+    monkeypatch: pytest.MonkeyPatch, attr: str, value: object
+) -> None:
+    baseline = config_fingerprint()
+    monkeypatch.setattr(reranker_config, attr, value)
+    assert config_fingerprint() != baseline
+
+
+@pytest.mark.unit
+def test_env_example_reranker_model_matches_the_pinned_id() -> None:
+    env_example = (_REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+    values = {
+        key.strip(): value.strip().strip('"').strip("'")
+        for line in env_example.splitlines()
+        if line.strip() and not line.lstrip().startswith("#") and "=" in line
+        for key, _, value in [line.partition("=")]
+    }
+    assert values["RERANKER_MODEL"] == RERANKER_MODEL_ID

--- a/tests/unit/infrastructure/rag/test_reranking_retriever.py
+++ b/tests/unit/infrastructure/rag/test_reranking_retriever.py
@@ -1,0 +1,114 @@
+"""Cross-encoder reranking of a base retriever's candidates -- [M3-05]."""
+
+from collections.abc import Sequence
+
+import pytest
+
+from infrastructure.rag.reranking_retriever import RerankingRetriever
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+class FakeBase:
+    """A base retriever double: returns a fixed clause-id list, records the call."""
+
+    def __init__(self, clause_ids: list[str]) -> None:
+        self._clause_ids = clause_ids
+        self.seen_k: int | None = None
+        self.seen_filter: RetrievalFilter | None = None
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        del question
+        self.seen_k = k
+        self.seen_filter = metadata_filter
+        return self._clause_ids[:k]
+
+
+class FakeReranker:
+    """Scores each passage by a fixed lookup, records the query it was given."""
+
+    def __init__(self, scores: dict[str, float]) -> None:
+        self._scores = scores
+        self.seen_query: str | None = None
+
+    def rerank(self, query: str, passages: Sequence[str]) -> list[float]:
+        self.seen_query = query
+        return [self._scores[passage] for passage in passages]
+
+
+_TEXT = {"a": "pa", "b": "pb", "c": "pc", "d": "pd"}
+
+
+@pytest.mark.unit
+def test_reorders_candidates_by_score_and_cuts_to_k() -> None:
+    base = FakeBase(["a", "b", "c"])
+    reranker = FakeReranker({"pa": 0.1, "pb": 0.9, "pc": 0.5})
+    retriever = RerankingRetriever(base, reranker, _TEXT, candidate_depth=10)
+
+    assert retriever.retrieve("q", k=2) == ["b", "c"]
+
+
+@pytest.mark.unit
+def test_asks_the_base_for_the_candidate_depth_not_k() -> None:
+    base = FakeBase(["a", "b", "c", "d"])
+    reranker = FakeReranker(dict.fromkeys(_TEXT.values(), 0.0))
+    retriever = RerankingRetriever(base, reranker, _TEXT, candidate_depth=3)
+
+    retriever.retrieve("q", k=1)
+
+    assert base.seen_k == 3
+
+
+@pytest.mark.unit
+def test_equal_scores_keep_the_base_order() -> None:
+    base = FakeBase(["c", "a", "b"])
+    reranker = FakeReranker({"pa": 1.0, "pb": 1.0, "pc": 1.0})
+    retriever = RerankingRetriever(base, reranker, _TEXT, candidate_depth=10)
+
+    # All tied -> the base retriever's order survives unchanged.
+    assert retriever.retrieve("q", k=3) == ["c", "a", "b"]
+
+
+@pytest.mark.unit
+def test_the_metadata_filter_reaches_the_base() -> None:
+    base = FakeBase(["a"])
+    reranker = FakeReranker({"pa": 1.0})
+    retriever = RerankingRetriever(base, reranker, _TEXT)
+    filt = RetrievalFilter(susep_process="P", cnpj="C")
+
+    retriever.retrieve("q", k=1, metadata_filter=filt)
+
+    assert base.seen_filter is filt
+
+
+@pytest.mark.unit
+def test_empty_candidate_set_returns_empty_without_calling_the_reranker() -> None:
+    reranker = FakeReranker({})
+    retriever = RerankingRetriever(FakeBase([]), reranker, _TEXT)
+
+    assert retriever.retrieve("q", k=10) == []
+    assert reranker.seen_query is None
+
+
+@pytest.mark.unit
+def test_non_positive_k_returns_empty() -> None:
+    base = FakeBase(["a", "b"])
+    retriever = RerankingRetriever(base, FakeReranker({"pa": 1.0}), _TEXT)
+
+    assert retriever.retrieve("q", k=0) == []
+    assert base.seen_k is None
+
+
+@pytest.mark.unit
+def test_a_candidate_missing_from_the_text_map_scores_as_empty_string() -> None:
+    base = FakeBase(["a", "unknown"])
+    reranker = FakeReranker({"pa": 0.2, "": 0.9})
+    retriever = RerankingRetriever(base, reranker, _TEXT, candidate_depth=10)
+
+    # "unknown" has no text -> scored as "" -> here that wins.
+    assert retriever.retrieve("q", k=2) == ["unknown", "a"]

--- a/tests/unit/scripts/test_eval_retrieval.py
+++ b/tests/unit/scripts/test_eval_retrieval.py
@@ -11,6 +11,7 @@ from scripts.eval_retrieval import (
     _output_stem,
     _parse_args,
     aggregate,
+    build_clause_text_map,
     build_lexical_retriever,
     compute_exclusion_clause_recall,
     compute_foreign_document_rate,
@@ -216,6 +217,10 @@ def test_output_stem_keeps_random_and_lexical_names_and_tags_the_rest(
     assert (
         stem_for("--retriever", "hybrid", "--fusion", "weighted", "--filter", "default")
         == "retrieval_eval_hybrid_weighted_filter-default"
+    )
+    assert (
+        stem_for("--retriever", "hybrid", "--filter", "default", "--rerank")
+        == "retrieval_eval_hybrid_rrf_rerank_filter-default"
     )
 
 
@@ -495,3 +500,78 @@ def test_render_markdown_report_includes_the_lexical_config_block() -> None:
     assert "Chunk corpus (BM25-indexed): `build/chunks.jsonl` (4540 chunks)" in markdown
     assert "BM25 k1=1.5, b=0.75" in markdown
     assert "deadbeefdeadbeef" in markdown
+
+
+@pytest.mark.unit
+def test_parse_args_rejects_rerank_with_the_random_retriever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "sys.argv", ["eval_retrieval.py", "--retriever", "random", "--rerank"]
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+@pytest.mark.unit
+def test_render_markdown_report_includes_the_reranker_config_block() -> None:
+    metrics_row = {
+        "n": 1.0,
+        "recall@1": 0.0,
+        "recall@5": 0.0,
+        "recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0,
+    }
+    report = {
+        "config": {
+            "schema_version": "v4",
+            "retriever_name": "hybrid",
+            "k_values": [1, 5, 10],
+            "ndcg_k": 10,
+            "golden_set_dir": "data/golden_set",
+            "golden_set_question_count": 140,
+            "corpus_path": "build/parsed_clauses.jsonl",
+            "corpus_clause_count": 4925,
+            "seed": None,
+            "run_at_utc": "2026-08-28T00:00:00+00:00",
+            "filter_mode": "default",
+            "reranker_model_id": "Alibaba-NLP/gte-multilingual-reranker-base",
+            "reranker_model_revision": "8215cf04",
+            "rerank_candidate_depth": 10,
+            "reranker_config_fingerprint": "777c0503f1073d52",
+        },
+        "overall": metrics_row,
+        "by_question_type": {
+            "direct_lookup": metrics_row,
+            "unanswerable": {"n": 23, "excluded_from_scoring": True},
+        },
+        "by_product_line": {"CASCO": metrics_row},
+        "by_extraction_mode": {"text": metrics_row},
+        "exclusion_clause_recall": {"k": 10, "hits": 25, "total": 27, "recall": 0.925},
+        "foreign_document_rate": {"k": 10, "hits": 0, "total": 90, "rate": 0.0},
+    }
+
+    markdown = render_markdown_report(report)
+
+    assert "gte-multilingual-reranker-base` @ `8215cf04`" in markdown
+    assert "candidate depth 10" in markdown
+    assert "777c0503f1073d52" in markdown
+
+
+@pytest.mark.unit
+def test_build_clause_text_map_joins_a_split_clause_in_chunk_index_order() -> None:
+    base = _chunk("1:c#0", "1:c", "primeira parte")
+    part0 = base.model_copy(update={"chunk_index": 0})
+    part1 = base.model_copy(
+        update={"chunk_id": "1:c#1", "chunk_index": 1, "text": "segunda parte"}
+    )
+    merged = _chunk("1:d", "1:d", "corpo de d").model_copy(
+        update={"source_clause_ids": ["1:d", "1:e"]}
+    )
+
+    text_map = build_clause_text_map([part1, part0, merged])
+
+    assert text_map["1:c"] == "primeira parte\n\nsegunda parte"
+    # A short clause merged into a neighbour's chunk gets that chunk's text.
+    assert text_map["1:e"] == "corpo de d"

--- a/tests/unit/scripts/test_tune_reranking.py
+++ b/tests/unit/scripts/test_tune_reranking.py
@@ -1,0 +1,103 @@
+"""Tests for the [M3-05] reranker candidate-depth sweep script."""
+
+import pytest
+from scripts.tune_reranking import (
+    RERANK_CANDIDATE_DEPTHS,
+    _ReplayRetriever,
+    _rerank_order,
+    render_markdown_report,
+    summarise_latency,
+)
+
+
+@pytest.mark.unit
+def test_candidate_depths_start_at_ten_and_ascend() -> None:
+    # 10 is the pure-reorder point (Recall@10 cannot move); the one rerank pass
+    # runs at max(depths), so shallower depths must be prefixes.
+    assert RERANK_CANDIDATE_DEPTHS[0] == 10
+    assert list(RERANK_CANDIDATE_DEPTHS) == sorted(RERANK_CANDIDATE_DEPTHS)
+
+
+@pytest.mark.unit
+def test_summarise_latency_handles_empty_and_populated() -> None:
+    assert summarise_latency([]) == {"n": 0, "p50": 0.0, "p95": 0.0, "mean": 0.0}
+    stats = summarise_latency([10.0, 20.0, 30.0, 40.0])
+    assert stats["n"] == 4
+    assert stats["mean"] == 25.0
+
+
+@pytest.mark.unit
+def test_rerank_order_sorts_by_score_desc_and_keeps_ties_in_candidate_order() -> None:
+    assert _rerank_order(["a", "b", "c"], [0.1, 0.9, 0.5]) == ["b", "c", "a"]
+    # All tied -> candidate order survives.
+    assert _rerank_order(["c", "a", "b"], [1.0, 1.0, 1.0]) == ["c", "a", "b"]
+
+
+@pytest.mark.unit
+def test_replay_retriever_returns_the_precomputed_list_cut_to_k() -> None:
+    retriever = _ReplayRetriever({"q": ["a", "b", "c", "d"]})
+    assert retriever.retrieve("q", k=2) == ["a", "b"]
+    assert retriever.retrieve("q", k=10) == ["a", "b", "c", "d"]
+
+
+@pytest.mark.unit
+def test_render_markdown_report_has_the_baseline_row_and_a_depth_row() -> None:
+    report = {
+        "config": {
+            "golden_set_dir": "data/golden_set",
+            "golden_set_question_count": 140,
+            "corpus_path": "build/parsed_clauses.jsonl",
+            "corpus_clause_count": 4925,
+            "chunk_corpus_chunk_count": 4540,
+            "reranker_model_id": "Alibaba-NLP/gte-multilingual-reranker-base",
+            "reranker_model_revision": "8215cf04",
+            "reranker_config_fingerprint": "777c0503f1073d52",
+            "embedding_config_fingerprint": "7ea39a621eaee88e",
+            "lexical_config_fingerprint": "ef0a2dd0c1dfb4e4",
+            "hybrid_config_fingerprint": "279ed8ee0a668227",
+            "scoring_device": "cuda:0",
+            "reranker_device": "cpu",
+            "latency_probe_questions": 20,
+            "platform": "Linux",
+            "candidate_depths": [10, 20, 30, 50],
+            "max_depth": 50,
+            "chosen_candidate_depth": 10,
+            "run_at_utc": "2026-08-28T00:00:00+00:00",
+        },
+        "rows": [
+            {
+                "candidate_depth": None,
+                "recall@1": 0.645,
+                "recall@5": 0.836,
+                "recall@10": 0.915,
+                "mrr": 0.788,
+                "ndcg@10": 0.803,
+                "exclusion_recall": 0.925,
+                "exclusion_hits": 25,
+                "exclusion_total": 27,
+                "latency_ms": {"n": 0, "p50": 0.0, "p95": 0.0, "mean": 0.0},
+            },
+            {
+                "candidate_depth": 30,
+                "recall@1": 0.70,
+                "recall@5": 0.85,
+                "recall@10": 0.92,
+                "mrr": 0.84,
+                "ndcg@10": 0.83,
+                "exclusion_recall": 0.925,
+                "exclusion_hits": 25,
+                "exclusion_total": 27,
+                "latency_ms": {"n": 40, "p50": 900.0, "p95": 1800.0, "mean": 1000.0},
+            },
+        ],
+    }
+
+    markdown = render_markdown_report(report)
+
+    assert "hybrid RRF (no rerank)" in markdown
+    assert "| 30 " in markdown
+    assert "900.0 / 1800.0 / 1000.0" in markdown
+    assert "777c0503f1073d52" in markdown
+    assert "one rerank pass at depth 50" in markdown
+    assert "`cuda:0` (scoring)" in markdown
+    assert "`cpu` (latency probe)" in markdown


### PR DESCRIPTION
## Summary

Adds the [M3-05] cross-encoder reranking stage. `Alibaba-NLP/gte-multilingual-reranker-base`
(the reranking half of the pinned embedder's mGTE family — one paper, one evidence
story, no new dependency) re-scores the [M3-04] hybrid RRF candidate set behind the
**same** `retrieve(question, *, k, metadata_filter)` interface, so the M4 graph node and
the [M2-06] eval harness stay unaware of it. `RerankingRetriever` asks the base retriever
for `RERANK_CANDIDATE_DEPTH` candidates, scores every `(question, clause text)` pair, and
returns the reordered top-k — a pure reorder, it never adds or pads.

The contract is pinned in `reranker_config.py` (model id + Hub revision + 8192-token input
cap + candidate depth, folded into `config_fingerprint()`); an on-disk `CachingReranker`
mirrors `CachingEmbedder`. `scripts/eval_retrieval.py` gains `--rerank` (`RetrievalRunConfig`
→ v4); `scripts/tune_reranking.py` sweeps the candidate depth and records the curve plus a
CPU latency probe. New targets `make eval-retrieval-rerank` / `make tune-reranking`, both
`uv run --group embed`.

**Candidate depth tuned to 10** from the golden-set sweep (`docs/RERANKING.md`): reranking
the hybrid top-10 lifts overall MRR 78.8 → 80.6, R@1 64.5 → 65.8, R@5 83.6 → 86.9, nDCG@10
80.3 → 82.0, with R@10 unchanged at 91.5% and exclusion-clause recall unchanged at 92.6%
(25/27). The curve has no rising limb — every deeper depth trades the top-rank gain away,
and depth ≥ 30 pushes exclusion clauses out of the top-10 (the DoD's named regression) and
drops R@10 below the no-rerank baseline.

Scoring runs on the GPU when present (scores are device-independent); the reported latency
is a deliberate CPU number, and it is bad — ~9.7 s/query (p50) at depth 10 on a Ryzen 5
5600H, ~50–100× the pre-registered prediction — so the CPU cross-encoder is a batch-eval /
GPU-serving tool, not a live-path component (M4 picks its own device). Three of five
predictions missed; all published in `docs/RERANKING.md` (prediction-vs-actual table +
deviation paragraph) with a dated `[M3-05]` note in `MILESTONES.md`, per the protocol.

`RERANK_BATCH_SIZE` is 1 — a batch pads to its longest member and one 8192-token clause
already fills a 4 GB GPU's activation budget (64 needs >12 GB). Pure memory/throughput
lever, not in the fingerprint, scores bit-identical.

## Related issue

[M3-05]. Also touches [M3-04]'s `test_hybrid_retrieval_baseline.py` (new `rerank` arg).
The four-configuration benchmark matrix, `make build-index`, and the RRF-vs-weighted
re-open with the reranker in the loop remain [M3-08].

## Checklist

- [x] Tests added/updated for the change — unit tests for `reranker` / `reranker_config` /
      `reranker_cache` / `reranking_retriever` / `cross_encoder_reranker` / `tune_reranking`
      and the `--rerank` harness path; `RetrievalRunConfig` v4 round-trip.
      `tests/eval/test_rerank_retrieval_baseline.py` asserts the recall floor **and** that
      reranking does not drop exclusion-clause recall vs. the no-rerank baseline (DoD item 4).
- [x] Docs updated — `docs/RERANKING.md` (rationale, model choice, curve, prediction-vs-actual,
      latency trade-off, verdict, limitations), `MILESTONES.md` M3 note, `.env.example`
      (`RERANKER_MODEL`), `Makefile` help.
- [x] Evaluation impact considered — **yes, this is an evaluation change.** hybrid RRF +
      rerank @ candidate depth 10, `--filter default`, `golden-set-v1` (117 scorable):
      R@1/5/10 = 65.8 / 86.9 / 91.5, MRR 80.6, nDCG@10 82.0, exclusion-clause recall 92.6%
      (25/27), foreign-doc rate 0.0%. Both M3 exit values (R@10 ≥ 0.85, MRR ≥ 0.60) clear.
      New `retrieval_eval_hybrid_rrf_rerank_filter-default` and `rerank_tuning` runs under
      `eval/runs/` (gitignored, regenerable).
- [x] `make check` passes locally (739 unit tests, ruff, format, mypy). `make test-eval`
      also passes (4 tests, incl. the rerank baseline).