### PR TITLE
feat(rag): reserve a context slot for the exclusion linked to each re…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank tune-reranking review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -50,7 +50,9 @@ help:
 	@echo "  eval-retrieval-dense - M3-04: score the dense pgvector retriever with the SUSEP-process+CNPJ pre-filter (needs a running Postgres with loaded+embedded chunks; runs the optional embed uv group); writes eval/runs/retrieval_eval_dense_filter-default.{md,json}"
 	@echo "  eval-retrieval-hybrid - M3-04: score the hybrid (RRF fusion of lexical+dense) retriever with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement as eval-retrieval-dense; pass --fusion weighted / --filter none on the script for the comparison); writes eval/runs/retrieval_eval_hybrid_*.{md,json}. Comparison and verdict: docs/HYBRID_RETRIEVAL.md"
 	@echo "  eval-retrieval-rerank - M3-05: score hybrid RRF + cross-encoder rerank with the SUSEP-process+CNPJ pre-filter at the chosen candidate depth (same Postgres + embed-group requirement); writes eval/runs/retrieval_eval_hybrid_rrf_rerank_filter-default.{md,json}. Verdict: docs/RERANKING.md"
+	@echo "  eval-retrieval-co-retrieval - M3-06: score hybrid RRF + rerank + exclusion co-retrieval with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement); reserves top-k slots for the exclusion clauses linked to each retrieved coverage clause; writes eval/runs/retrieval_eval_hybrid_rrf_rerank_co-retrieval_filter-default.{md,json}. Rule: docs/ARCHITECTURE.md; measurement: docs/EXCLUSION_CO_RETRIEVAL.md"
 	@echo "  tune-reranking    - M3-05: sweep the reranker candidate depth on the golden set and record the metrics + latency curve (same Postgres + embed-group requirement); writes eval/runs/rerank_tuning.{md,json}. Curve and chosen depth: docs/RERANKING.md"
+	@echo "  tune-exclusion-co-retrieval - M3-06: sweep the reserved exclusion-slot count on the golden set (pure-Python replay over one cached rerank pass; same Postgres + embed-group requirement for that pass); writes eval/runs/exclusion_co_retrieval_tuning.{md,json}. Curve and chosen count: docs/EXCLUSION_CO_RETRIEVAL.md"
 	@echo "  review-golden-set-sample - Independent second-reviewer pass over a stratified golden-set-v1 sample (--dry-run prints the sample composition, no model calls); writes data/golden_set/review/review_v1.jsonl and eval/runs/golden_set_review_v1.{md,json}"
 
 install:
@@ -206,8 +208,14 @@ eval-retrieval-hybrid:
 eval-retrieval-rerank:
 	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default --rerank
 
+eval-retrieval-co-retrieval:
+	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default --rerank --co-retrieval
+
 tune-reranking:
 	PYTHONPATH=app/src uv run --group embed python -m scripts.tune_reranking
+
+tune-exclusion-co-retrieval:
+	PYTHONPATH=app/src uv run --group embed python -m scripts.tune_exclusion_co_retrieval
 
 review-golden-set-sample:
 	PYTHONPATH=app/src uv run python scripts/review_golden_set_sample.py

--- a/app/src/infrastructure/evaluation/retrieval_run_schema.py
+++ b/app/src/infrastructure/evaluation/retrieval_run_schema.py
@@ -13,6 +13,8 @@ BM25/analyzer contract. ``v3`` [M3-04]: the dense and hybrid retrievers add the
 metadata-filter mode, the fusion strategy and its constants, and the embedding /
 hybrid config fingerprints. ``v4`` [M3-05]: the ``--rerank`` path adds the
 cross-encoder model id/revision, the candidate depth and the reranker config
+fingerprint. ``v5`` [M3-06]: the ``--co-retrieval`` path adds the reserved
+exclusion-slot count, the adjacent-section page gap and the co-retrieval config
 fingerprint. Every added field is optional -- a run without that leg leaves the
 new ones ``None``.
 """
@@ -21,7 +23,7 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-SCHEMA_VERSION = "v4"
+SCHEMA_VERSION = "v5"
 
 
 class RetrievalRunConfig(BaseModel):
@@ -73,3 +75,10 @@ class RetrievalRunConfig(BaseModel):
     reranker_model_revision: str | None = None
     rerank_candidate_depth: int | None = None
     reranker_config_fingerprint: str | None = None
+
+    # [M3-06] `--co-retrieval` only; None otherwise. `reserved_exclusion_slots`
+    # is how many final top-k slots were held for exclusion clauses linked to a
+    # retrieved coverage clause.
+    reserved_exclusion_slots: int | None = None
+    adjacent_section_max_page_gap: int | None = None
+    co_retrieval_config_fingerprint: str | None = None

--- a/app/src/infrastructure/rag/exclusion_co_retrieval.py
+++ b/app/src/infrastructure/rag/exclusion_co_retrieval.py
@@ -1,0 +1,380 @@
+"""Exclusion co-retrieval: pair a coverage clause with its exclusion -- [M3-06].
+
+The core retrieval problem of the domain: a coverage clause retrieved without
+the exclusion that limits it produces an assessment that is fluent, well-cited
+and wrong. The golden set's ``coverage_with_exclusion`` questions reference
+*both* clauses on purpose; lexical and dense retrieval bring back the coverage
+clause and miss the exclusion a few paragraphs away (``coverage_with_exclusion``
+is the weakest question type -- see ``docs/RERANKING.md``).
+
+[ExclusionCoRetrievalRetriever] wraps any filtered retriever (in practice
+[infrastructure.rag.reranking_retriever.RerankingRetriever]) behind the **same**
+``retrieve(question, *, k, metadata_filter)`` interface, so the [M2-06] harness
+and M4's graph node stay unaware of it -- exactly the composition
+``RerankingRetriever`` uses over ``HybridRetriever``. After the base ranks, for
+every retrieved ``coverage`` clause it pulls the linked ``exclusion`` clauses
+from [ClauseGraph] and reserves
+[infrastructure.rag.exclusion_co_retrieval_config.RESERVED_EXCLUSION_SLOTS] of
+the final top-k for them.
+
+[ClauseGraph] is a pure, deterministic structural index over the parsed corpus
+([infrastructure.parsing.clause_schema.ParsedClauseRecord]) -- no DB, no LLM. It
+links a coverage clause to exclusion clauses by three edges ([M3-06] DoD):
+
+- ``same_section`` -- the exclusion shares the coverage clause's top-level
+  section root (siblings, descendants of the coverage clause, exclusions
+  elsewhere in the same numbered section).
+- ``adjacent_section`` -- the exclusion is in a *different* section root whose
+  page span is within
+  [config.ADJACENT_SECTION_MAX_PAGE_GAP] pages (the flat / parent-less OCR
+  documents, where ``same_section`` cannot fire because every clause is its own
+  root).
+- ``cross_reference`` -- a ``cláusula N.M`` token in the coverage clause's text
+  resolves to an exclusion clause by numbering.
+
+Deviation from the DoD, recorded per the repo convention ([M3-04]
+RRF-vs-weighted, [M1-08c] predictions): the DoD says parse cross-references
+"during M1". M1's corpus schema is frozen and a re-parse (OCR + LLM
+classification + vision escalation) is disproportionate, so cross-reference
+edges are derived deterministically from the already-persisted ``clause.text``
+here, at graph-build time -- the same thing ``scripts/find_candidate_clauses.py``
+already does for [M2-08] curation.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Protocol
+
+from domain.clause_classification import ClauseType
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    ADJACENT_SECTION_MAX_PAGE_GAP,
+    CROSS_REFERENCE_PATTERN,
+    RESERVED_EXCLUSION_SLOTS,
+)
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+_CROSS_REFERENCE_RE = re.compile(CROSS_REFERENCE_PATTERN, re.IGNORECASE)
+
+
+def extract_cross_references(text: str) -> set[str]:
+    """Return the numbering tokens textually referenced in ``text``.
+
+    Matches "cláusula 12", "Cláusula 4.2", "conforme cláusula 10.2" and returns
+    the bare numbering ("12", "4.2", "10.2"). The production formalisation of
+    ``scripts/find_candidate_clauses.py``'s reduced-scope helper of the same name
+    ([M2-08]); the curation script keeps its own copy so the four frozen M2
+    authoring scripts that import it are untouched.
+    """
+    return {match.group(1) for match in _CROSS_REFERENCE_RE.finditer(text)}
+
+
+class ExclusionEdge(IntEnum):
+    """How an exclusion clause is linked to a coverage clause, best first.
+
+    The integer order is the ranking priority: a cross-referenced exclusion
+    outranks a same-section one, which outranks an adjacent-section one.
+    """
+
+    CROSS_REFERENCE = 0
+    SAME_SECTION = 1
+    ADJACENT_SECTION = 2
+
+
+@dataclass(frozen=True, order=True)
+class LinkedExclusion:
+    """One exclusion clause linked to a retrieved coverage clause.
+
+    Field order is the sort key: edge kind, then tree distance (only meaningful
+    within a section, otherwise 0), then page gap, then clause id -- fully
+    deterministic, with no reliance on dict order.
+    """
+
+    edge: ExclusionEdge
+    tree_distance: int
+    page_gap: int
+    clause_id: str
+
+
+class ClauseGraph:
+    """Deterministic structural index linking coverage clauses to exclusions."""
+
+    def __init__(self, records: Iterable[ParsedClauseRecord]) -> None:
+        """Build the index from the parsed corpus (one pass, then memoised walks)."""
+        self._by_id: dict[str, ParsedClauseRecord] = {
+            record.clause_id: record for record in records
+        }
+        self._exclusion_ids_by_document: dict[str, list[str]] = {}
+        # (document_id, last path segment) -> clause ids carrying that numbering.
+        self._by_numbering: dict[tuple[str, str], list[str]] = {}
+        self._section_root_cache: dict[str, str] = {}
+        self._ancestors_cache: dict[str, tuple[str, ...]] = {}
+        for record in self._by_id.values():
+            if record.clause_type is ClauseType.EXCLUSION:
+                self._exclusion_ids_by_document.setdefault(
+                    record.document_id, []
+                ).append(record.clause_id)
+            numbering = record.path.rsplit("/", 1)[-1]
+            self._by_numbering.setdefault((record.document_id, numbering), []).append(
+                record.clause_id
+            )
+
+    def is_coverage(self, clause_id: str) -> bool:
+        """Whether ``clause_id`` is a known ``coverage`` clause."""
+        record = self._by_id.get(clause_id)
+        return record is not None and record.clause_type is ClauseType.COVERAGE
+
+    def is_exclusion(self, clause_id: str) -> bool:
+        """Whether ``clause_id`` is a known ``exclusion`` clause."""
+        record = self._by_id.get(clause_id)
+        return record is not None and record.clause_type is ClauseType.EXCLUSION
+
+    def _ancestors(self, clause_id: str) -> tuple[str, ...]:
+        """``clause_id`` then each parent up to the section root, root last.
+
+        A ``parent_id`` pointing outside the corpus, or a cycle, stops the walk
+        -- the last id reached is treated as the root.
+        """
+        cached = self._ancestors_cache.get(clause_id)
+        if cached is not None:
+            return cached
+        chain: list[str] = []
+        seen: set[str] = set()
+        current: str | None = clause_id
+        while current is not None and current not in seen and current in self._by_id:
+            chain.append(current)
+            seen.add(current)
+            current = self._by_id[current].parent_id
+        result = tuple(chain)
+        self._ancestors_cache[clause_id] = result
+        return result
+
+    def _section_root(self, clause_id: str) -> str:
+        """The top-level ancestor of ``clause_id`` (itself when it has no parent)."""
+        cached = self._section_root_cache.get(clause_id)
+        if cached is not None:
+            return cached
+        ancestors = self._ancestors(clause_id)
+        root = ancestors[-1] if ancestors else clause_id
+        self._section_root_cache[clause_id] = root
+        return root
+
+    def _tree_distance(self, a_id: str, b_id: str) -> int:
+        """Edge count between two clauses in the tree, or 0 if unrelated."""
+        a_chain = self._ancestors(a_id)
+        b_index = {clause_id: i for i, clause_id in enumerate(self._ancestors(b_id))}
+        for i, clause_id in enumerate(a_chain):
+            if clause_id in b_index:
+                return i + b_index[clause_id]
+        return 0
+
+    @staticmethod
+    def _page_gap(a: ParsedClauseRecord, b: ParsedClauseRecord) -> int:
+        """Pages between two clause spans; 0 when the spans touch or overlap."""
+        return max(0, max(a.page_start, b.page_start) - min(a.page_end, b.page_end))
+
+    def _bundle_compatible(
+        self, coverage: ParsedClauseRecord, candidate: ParsedClauseRecord
+    ) -> bool:
+        """A bundle-doc guard: keep same-bundle or unknown-bundle exclusions only."""
+        if coverage.bundle_section is None:
+            return True
+        return candidate.bundle_section in (coverage.bundle_section, None)
+
+    def linked_exclusions(self, coverage_clause_id: str) -> list[LinkedExclusion]:
+        """Every exclusion clause linked to ``coverage_clause_id``, ranked best first.
+
+        Empty when ``coverage_clause_id`` is unknown or not a coverage clause. A
+        clause reachable by more than one edge is kept once, under its best
+        (lowest-sorting) link.
+        """
+        coverage = self._by_id.get(coverage_clause_id)
+        if coverage is None or coverage.clause_type is not ClauseType.COVERAGE:
+            return []
+
+        best: dict[str, LinkedExclusion] = {}
+
+        def offer(link: LinkedExclusion) -> None:
+            current = best.get(link.clause_id)
+            if current is None or link < current:
+                best[link.clause_id] = link
+
+        coverage_root = self._section_root(coverage_clause_id)
+
+        for exclusion_id in self._exclusion_ids_by_document.get(
+            coverage.document_id, []
+        ):
+            if exclusion_id == coverage_clause_id:
+                continue
+            candidate = self._by_id[exclusion_id]
+            if not self._bundle_compatible(coverage, candidate):
+                continue
+            if self._section_root(exclusion_id) == coverage_root:
+                offer(
+                    LinkedExclusion(
+                        edge=ExclusionEdge.SAME_SECTION,
+                        tree_distance=self._tree_distance(
+                            coverage_clause_id, exclusion_id
+                        ),
+                        page_gap=self._page_gap(coverage, candidate),
+                        clause_id=exclusion_id,
+                    )
+                )
+            else:
+                gap = self._page_gap(coverage, candidate)
+                if gap <= ADJACENT_SECTION_MAX_PAGE_GAP:
+                    offer(
+                        LinkedExclusion(
+                            edge=ExclusionEdge.ADJACENT_SECTION,
+                            tree_distance=0,
+                            page_gap=gap,
+                            clause_id=exclusion_id,
+                        )
+                    )
+
+        for numbering in extract_cross_references(coverage.text):
+            for candidate_id in self._by_numbering.get(
+                (coverage.document_id, numbering), []
+            ):
+                if candidate_id == coverage_clause_id or not self.is_exclusion(
+                    candidate_id
+                ):
+                    continue
+                candidate = self._by_id[candidate_id]
+                if not self._bundle_compatible(coverage, candidate):
+                    continue
+                offer(
+                    LinkedExclusion(
+                        edge=ExclusionEdge.CROSS_REFERENCE,
+                        tree_distance=0,
+                        page_gap=self._page_gap(coverage, candidate),
+                        clause_id=candidate_id,
+                    )
+                )
+
+        return sorted(best.values())
+
+    def ranked_linked_exclusions(
+        self, coverage_clause_ids: Sequence[str]
+    ) -> list[LinkedExclusion]:
+        """Merge :meth:`linked_exclusions` over several coverage clauses, ranked.
+
+        An exclusion linked to more than one retrieved coverage clause is kept
+        once, under its best link.
+        """
+        best: dict[str, LinkedExclusion] = {}
+        for coverage_clause_id in coverage_clause_ids:
+            for link in self.linked_exclusions(coverage_clause_id):
+                current = best.get(link.clause_id)
+                if current is None or link < current:
+                    best[link.clause_id] = link
+        return sorted(best.values())
+
+
+class _FilterableBase(Protocol):
+    """The wrapped retriever's contract: a filtered, clause-id-ranking ``retrieve``.
+
+    Re-declared here (rather than imported from ``infrastructure.evaluation``) so
+    ``infrastructure.rag`` still imports nothing from that package -- the same
+    split ``reranking_retriever._FilterableBase`` keeps.
+    """
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids, ranked best-match first, filtered."""
+        ...
+
+
+class ExclusionCoRetrievalRetriever:
+    """Reserves top-k budget for the exclusions that limit retrieved coverage."""
+
+    def __init__(
+        self,
+        base: _FilterableBase,
+        graph: ClauseGraph,
+        *,
+        reserved_slots: int = RESERVED_EXCLUSION_SLOTS,
+    ) -> None:
+        """Compose the base retriever with the structural clause graph."""
+        self._base = base
+        self._graph = graph
+        self._reserved_slots = reserved_slots
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        """Up to ``k`` clause ids: the base ranking with linked exclusions kept.
+
+        For the retrieved coverage clauses, the ``reserved_slots`` best-linked
+        exclusions the base ranked outside the top-k are each given a slot. The
+        output is identical to the base ranking when nothing links, or when every
+        linked exclusion is already in the top-k.
+        """
+        if k <= 0:
+            return []
+        ranked = self._base.retrieve(question, k=k, metadata_filter=metadata_filter)
+        reserved = min(self._reserved_slots, k)
+        if reserved <= 0:
+            return ranked
+
+        coverage_ids = [cid for cid in ranked if self._graph.is_coverage(cid)]
+        if not coverage_ids:
+            return ranked
+
+        links = self._graph.ranked_linked_exclusions(coverage_ids)
+        if not links:
+            return ranked
+
+        ranked_set = set(ranked)
+        to_inject = [
+            link.clause_id for link in links if link.clause_id not in ranked_set
+        ][:reserved]
+        if not to_inject:
+            return ranked
+
+        return self._reserve(ranked, to_inject, k)
+
+    def _reserve(
+        self, ranked: Sequence[str], to_inject: Sequence[str], k: int
+    ) -> list[str]:
+        """Append ``to_inject`` after ``ranked``, evicting supporting entries.
+
+        To hold the length at ``k``, one lowest-ranked base entry is dropped per
+        injected clause -- but only entries that are neither ``coverage`` nor
+        ``exclusion``. A coverage clause is the primary answer and an exclusion
+        the base already surfaced is the whole point of this step, so if nothing
+        else is left to drop the injection stops rather than displacing one.
+        """
+        survivors = list(ranked)
+        injected: list[str] = []
+        for clause_id in to_inject:
+            if len(survivors) + len(injected) < k:
+                injected.append(clause_id)
+                continue
+            drop_index = next(
+                (
+                    i
+                    for i in range(len(survivors) - 1, -1, -1)
+                    if not self._graph.is_coverage(survivors[i])
+                    and not self._graph.is_exclusion(survivors[i])
+                ),
+                None,
+            )
+            if drop_index is None:
+                break
+            survivors.pop(drop_index)
+            injected.append(clause_id)
+        return survivors + injected

--- a/app/src/infrastructure/rag/exclusion_co_retrieval_config.py
+++ b/app/src/infrastructure/rag/exclusion_co_retrieval_config.py
@@ -1,0 +1,74 @@
+"""The pinned exclusion co-retrieval contract -- [M3-06].
+
+Single source of truth for the post-ranking step that guarantees the exclusion
+clauses limiting a retrieved coverage clause survive into the final context. The
+[M2-06] eval harness (query side) and M4's retrieval node both reach the step
+through this module, so the ranking a golden-set number was measured under and
+the one M4 runs cannot drift apart. Recorded here, as code, not in a comment.
+
+Why these are module constants and not ``.env`` knobs: the reserved-slot count
+and the adjacent-section page gap together determine the exact top-k the
+published Recall@k / exclusion-clause recall are measured on. Per [M1-09]'s
+per-constant rule they are experimental design -- like ``RERANK_CANDIDATE_DEPTH``
+in ``reranker_config.py`` or ``SEED`` in ``scripts/sample_parsing_quality.py`` --
+and making them environment-dependent would let a ``.env`` edit silently move a
+published result. This issue introduces **no** new ``.env`` key -- the analog of
+``docs/RERANKING.md``'s "zero" and ``docs/HYBRID_RETRIEVAL.md``'s "zero".
+
+Rationale and evidence: docs/EXCLUSION_CO_RETRIEVAL.md. The domain rule the
+mechanism serves: docs/ARCHITECTURE.md.
+"""
+
+import hashlib
+
+# How many of the final top-k slots are reserved for exclusion clauses linked to
+# a retrieved coverage clause, so a higher-scoring coverage passage cannot
+# squeeze the exclusion that limits it out of the context ([M3-06] DoD: "reserve
+# context budget for exclusions"). Only ever consumed when a retrieved coverage
+# clause has a best-linked exclusion the base ranking missed -- otherwise the
+# output is the base ranking unchanged. Set to 1 from the ``make
+# tune-exclusion-co-retrieval`` sweep in docs/EXCLUSION_CO_RETRIEVAL.md: the
+# hybrid + rerank base already surfaces exclusions well, so one reserved slot
+# recovers the residual misses (exclusion-clause recall 25/27 -> 27/27) with no
+# collateral regression, while 2+ start displacing relevant lookup answers. A
+# code constant: it changes the top-k the golden-set numbers are measured on.
+RESERVED_EXCLUSION_SLOTS = 1
+
+# The adjacent-section edge fires for an exclusion clause in a *different*
+# top-level section of the same document whose page span is within this many
+# pages of the coverage clause's. Calibrated on the golden set's flat /
+# parent-less OCR documents (doc 4: the reference exclusion sits <= 1 page from
+# its coverage clause; doc 7: 2 pages), where the same-section edge structurally
+# cannot fire because every clause is its own section root. A code constant for
+# the same reason as above.
+ADJACENT_SECTION_MAX_PAGE_GAP = 3
+
+# In-text cross-reference pattern: matches "cláusula 12", "Cláusula 4.2",
+# "conforme cláusula 10.2" and captures the bare numbering token ("12", "4.2",
+# "10.2"), resolved against a candidate clause's ``path`` last segment. The same
+# expression ``scripts/find_candidate_clauses.py`` ([M2-08]) uses for golden-set
+# curation -- that issue's docstring names this step as the production
+# formalisation of it. Kept here (not only in the module that compiles it) so a
+# change to what counts as a cross-reference edge moves the fingerprint.
+CROSS_REFERENCE_PATTERN = r"cl[áa]usulas?\s+(\d+(?:\.\d+)*)"
+
+
+def config_fingerprint() -> str:
+    """Digest of every value that determines the co-retrieved top-k.
+
+    Threaded into the eval run's
+    [infrastructure.evaluation.retrieval_run_schema.RetrievalRunConfig] so a
+    report read in isolation says exactly what produced its numbers. Reads the
+    module constants at call time (not import time) so a test can monkeypatch one
+    and watch the digest move -- mirrors the sibling ``config_fingerprint``s in
+    ``reranker_config`` / ``hybrid_config`` / ``embedding_config`` /
+    ``lexical_config``.
+    """
+    payload = "\x00".join(
+        (
+            str(RESERVED_EXCLUSION_SLOTS),
+            str(ADJACENT_SECTION_MAX_PAGE_GAP),
+            CROSS_REFERENCE_PATTERN,
+        )
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,59 @@
+# Architecture
+
+Cross-cutting design decisions that shape the pipeline and are not owned by any
+one stage's document. Each entry states the decision, why it is a deliberate
+choice rather than an incidental one, and where the evidence lives.
+
+Stage-local rationale stays in the stage's own document — `docs/PARSING.md`,
+`docs/EMBEDDINGS.md`, `docs/LEXICAL_RETRIEVAL.md`, `docs/HYBRID_RETRIEVAL.md`,
+`docs/RERANKING.md`, `docs/EXCLUSION_CO_RETRIEVAL.md`. The project scope
+statement is `docs/SCOPE.md`.
+
+---
+
+## Exclusion co-retrieval is a domain rule, not a retrieval heuristic — [M3-06]
+
+**Decision.** After the retrieval pipeline ranks, for every retrieved `coverage`
+clause the system pulls the `exclusion` clauses structurally linked to it — a
+sibling or nested exclusion in the same section, an exclusion in an adjacent
+section of a flat document, or one named by an in-text `cláusula N` cross-
+reference — and reserves a slot of the final context for the best-linked
+exclusion the ranking missed. `ExclusionCoRetrievalRetriever` and `ClauseGraph`
+in `app/src/infrastructure/rag/exclusion_co_retrieval.py`; the tuned constants
+and the fingerprint in `exclusion_co_retrieval_config.py`.
+
+**Why it is a rule and not a heuristic.** A coverage clause tells you an event
+*is* covered; the exclusion three paragraphs down tells you it *is not*, under
+the circumstances that actually apply. An assessment built on the first without
+the second is fluent, cites a real clause id, and reaches the wrong verdict —
+the single failure mode M3 was scoped around ("a retriever that returns the
+first without the second is worse than one that returns nothing"). The linked
+exclusion is therefore not "a nice extra result" whose value a relevance score
+should decide; it is **as load-bearing as the coverage clause it modifies**, and
+the pipeline is not permitted to return one without the other when a structural
+link exists. Reranker scores order passages by topical similarity to the
+question — a question phrased as a coverage question will score the exclusion
+lower — so leaving this to the ranker is leaving it to the wrong signal. The
+step runs as deterministic Python over the M1 clause tree, in the same spirit as
+M4-06's deterministic consistency checks: a structural fact the system should
+not need a model's permission to act on.
+
+**What it costs.** The step fires on most questions that retrieve a coverage
+clause, not only exclusion questions, because insurance filings pair coverage
+and exclusion sections as siblings almost everywhere. With one reserved slot and
+an eviction rule that only ever drops a *supporting* clause (never a coverage or
+an exclusion clause), this is measurably free on `golden-set-v1`: exclusion-
+clause recall 92.6% → 100%, `coverage_with_exclusion` Recall@10 78.9% → 84.2%,
+every other question type unchanged, overall Recall@10 91.5% → 92.3%. The slot
+count, the adjacent-section page window and the "inject what the base missed"
+rule were all set from the sweep in `docs/EXCLUSION_CO_RETRIEVAL.md`, which also
+records the one design iteration and the residual limitations (a
+structurally-isolated coverage/exclusion pair is a blind spot; the remaining
+subset gap is now entirely coverage-side).
+
+**Deviation on record.** The DoD asks for in-text cross-references to be parsed
+during M1. M1's corpus schema is frozen and a re-parse is disproportionate for a
+pure function of text the artifact already carries, so `extract_cross_references`
+runs at graph-build time — the production formalisation of the helper
+`scripts/find_candidate_clauses.py` ([M2-08]) already uses for golden-set
+curation. Full rationale in `docs/EXCLUSION_CO_RETRIEVAL.md`.

--- a/docs/EXCLUSION_CO_RETRIEVAL.md
+++ b/docs/EXCLUSION_CO_RETRIEVAL.md
@@ -1,0 +1,276 @@
+# Exclusion co-retrieval
+
+The [M3-06] stage: after ranking, for every retrieved `coverage` clause, pull
+the `exclusion` clauses structurally linked to it and reserve a slot of the
+final context so a higher-scoring coverage passage cannot squeeze the exclusion
+that limits it out. The contract lives in code at
+`app/src/infrastructure/rag/exclusion_co_retrieval_config.py`; the domain rule is
+stated in `docs/ARCHITECTURE.md`; this document is the method, the evidence and
+the numbers.
+
+**Why this is the core retrieval problem of the domain.** A coverage clause
+retrieved without the exclusion that cancels it produces an assessment that is
+fluent, well-cited and wrong. `coverage_with_exclusion` is the golden set's
+weakest question type by a wide margin — its reference sets carry *both* the
+coverage clause and the limiting exclusion on purpose, and lexical + dense
+retrieval reliably return the first and miss the second.
+
+**Scope.** This issue adds the co-retrieval step behind the existing
+`retrieve(question, *, k, metadata_filter)` interface, on the [M3-05] hybrid RRF
++ rerank + SUSEP-process/CNPJ base, and tunes its one knob — the **reserved
+slot count** — on `golden-set-v1`. It does **not**:
+
+- produce the committed lexical / dense / hybrid / hybrid+rerank(+co-retrieval)
+  benchmark matrix or `make build-index` — that is [M3-08]'s;
+- re-tune the reranker depth, BM25 `k1`/`b` or the RRF constant — those stay
+  their pinned `docs/RERANKING.md` / `docs/LEXICAL_RETRIEVAL.md` /
+  `docs/HYBRID_RETRIEVAL.md` values;
+- add the insufficient-context gate ([M3-07]);
+- improve recall of the **coverage** clause itself — see Limitations.
+
+---
+
+## Method
+
+### The structural clause graph
+
+`ClauseGraph` (`exclusion_co_retrieval.py`) is a pure, deterministic index over
+the parsed corpus (`build/parsed_clauses.jsonl`, the same `ParsedClauseRecord`
+rows the eval harness already loads) — no database, no model. For a retrieved
+`coverage` clause it returns the linked `exclusion` clauses by three edge types,
+which are exactly the three the [M3-06] DoD names:
+
+- **`same_section`** — the exclusion shares the coverage clause's top-level
+  section root (walk `parent_id` to the root). This subsumes siblings (same
+  `parent_id`), descendants of the coverage clause, and exclusions elsewhere
+  in the same numbered section. When the coverage clause carries a
+  `bundle_section` the candidate must match it (or be `None`). *Covers ~13 of
+  the 19 golden pairs — the exclusion is a sibling `RISCOS EXCLUÍDOS` /
+  `PREJUÍZOS NÃO INDENIZÁVEIS` clause, or a nested `10.2.1`-style exclusion
+  under the coverage clause.*
+- **`adjacent_section`** — the exclusion is in a *different* section root of the
+  same document whose page span is within `ADJACENT_SECTION_MAX_PAGE_GAP` (3)
+  pages of the coverage clause's. This is for the flat / parent-less OCR
+  documents (doc 4, doc 7's annexes) where every clause is its own section root,
+  so `same_section` structurally cannot fire. In doc 4 the reference exclusion
+  sits ≤ 1 page from its coverage clause; the ±3 window is calibrated on that.
+- **`cross_reference`** — a `cláusula N` / `cláusula 10.2` token parsed from the
+  coverage clause's text and resolved to a same-document clause by its `path`'s
+  last numbering segment, kept if `exclusion`-typed.
+
+A clause reachable by more than one edge is kept once, under its best link.
+Candidates are ranked `cross_reference` → `same_section` → `adjacent_section`,
+then by tree distance, then by page gap, then by `clause_id` — fully
+deterministic, no reliance on dict order.
+
+**Cross-references are derived here, not "during M1".** The DoD says parse
+in-text cross-references during M1. M1's corpus schema is frozen and a re-parse
+(OCR + LLM classification + the vision boundary pass) is disproportionate for a
+pure function of text the artifact already carries, so `extract_cross_references`
+runs at graph-build time. It is the production formalisation of the identical
+helper `scripts/find_candidate_clauses.py` ([M2-08]) already uses for golden-set
+curation — that issue's docstring names this step as its production successor.
+The [M2-08] script keeps its own copy: four frozen M2 authoring scripts import
+it, and refactoring them is out of proportion to this issue. Recorded as a
+deviation per the repo convention ([M3-04] RRF-vs-weighted, [M1-08c]
+predictions).
+
+### The reserved-budget mechanism
+
+`ExclusionCoRetrievalRetriever` wraps the [M3-05] reranking retriever behind the
+**same** `retrieve(question, *, k, metadata_filter=None) -> list[str]`:
+
+1. ask the base for its top `k`;
+2. for the `coverage` clauses in that list, collect the linked exclusions the
+   base **missed**;
+3. take the `RESERVED_EXCLUSION_SLOTS` best-ranked of those and append them,
+   evicting one lowest-ranked *supporting* base entry each — a supporting entry
+   is one that is neither `coverage` nor `exclusion`. A coverage clause is the
+   primary answer and an exclusion the base already found is the whole point of
+   the step, so neither is ever evicted; if nothing supporting is left to drop,
+   the injection simply stops.
+
+With no retrieved coverage clause, no link, or every linked exclusion already in
+the top-k, the output is the base ranking **unchanged** — the step is inert on
+the questions it has nothing to say about.
+
+### The `[M1-09]` per-constant decision
+
+`RESERVED_EXCLUSION_SLOTS` (1), `ADJACENT_SECTION_MAX_PAGE_GAP` (3) and
+`CROSS_REFERENCE_PATTERN` live in `exclusion_co_retrieval_config.py` as module
+constants with a `config_fingerprint()`, not `.env` keys. They determine the
+exact top-k a published Recall@k / exclusion-clause recall is measured on, so —
+per [M1-09]'s per-constant rule — they are experimental design, like
+`RERANK_CANDIDATE_DEPTH` or `SEED`; a `.env` edit must not be able to move a
+published result. **This issue introduces no new `.env` key** — the analog of
+`docs/RERANKING.md`'s "zero".
+
+### The harness
+
+`scripts/eval_retrieval.py --co-retrieval` applies the step outermost, after
+`--rerank`, over the corpus the harness already loads. The report's existing
+`by_question_type` breakdown (the `coverage_with_exclusion` row) and pooled
+`exclusion_clause_recall` are the before/after signal — no new metric code.
+`scripts/tune_exclusion_co_retrieval.py` (`make tune-exclusion-co-retrieval`)
+computes the hybrid+rerank base ranking once per question, then replays
+co-retrieval at each slot count as pure Python (no model calls), so the whole
+sweep costs seconds.
+
+---
+
+## Prediction
+
+Formed from a clause-by-clause reading of all 19 `coverage_with_exclusion`
+golden pairs against the parsed corpus, before the sweep:
+
+1. The structural edges reach the reference exclusion for **~16 of 19** pairs;
+   q006 (`/18/18.2` ↔ `/13/13.3`, distant cousins), q016 (grandparent-level)
+   and q018 (`condicoes-gerais/2` ↔ `susep/26`, unrelated top-level sections)
+   are not structurally linkable.
+2. The hybrid + rerank base already has **high** exclusion-clause recall
+   (92.6%, 25/27), so co-retrieval's job is to close a *small* residual gap,
+   not to carry the number.
+3. `coverage_with_exclusion` Recall@10 should rise by a few points; the pooled
+   exclusion-clause recall should approach but not necessarily reach 100%.
+4. A larger reserved-slot count risks displacing relevant lookup answers on the
+   ~80% of golden questions that are not about exclusions, so the sweep should
+   show a low count winning.
+
+---
+
+## Outcome (2026-08-29)
+
+### The slot sweep
+
+`make tune-exclusion-co-retrieval`, `--filter default`, all 117 scorable
+`golden-set-v1` questions. `cov+excl` is the `coverage_with_exclusion` subset
+(n = 19).
+
+| reserved slots | overall R@1 | overall R@5 | overall R@10 | overall MRR | overall nDCG@10 | exclusion recall | cov+excl R@10 | cov+excl MRR |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0 (no co-retrieval) | 65.8% | 86.9% | 91.5% | 80.6% | 82.0% | 92.6% (25/27) | 78.9% | 64.8% |
+| **1** | 65.8% | 87.3% | **92.3%** | 80.6% | 82.3% | **100.0% (27/27)** | **84.2%** | 65.3% |
+| 2 | 64.9% | 86.9% | 91.5% | 79.8% | 81.5% | 100.0% (27/27) | 84.2% | 65.3% |
+| 3 | 61.1% | 82.2% | 86.3% | 75.9% | 77.2% | 100.0% (27/27) | 84.2% | 66.4% |
+
+**Chosen: 1 reserved slot.** It closes the exclusion-clause recall gap
+completely and lifts `coverage_with_exclusion` Recall@10 by 5.3 points **with
+zero regressions** — overall Recall@10 goes *up* (91.5 → 92.3) because the two
+recovered questions are in the golden set and nothing else moved. Slot count 2
+buys nothing further on the subset and gives back the overall gain; slot count 3
+displaces relevant lookup answers hard (overall Recall@10 −5.2 points). The
+base's exclusion recall is already high enough that one reserved slot is all the
+budget the residual gap needs.
+
+### Before / after — the committed configuration (1 reserved slot)
+
+| question_type | n | R@1 | R@5 | R@10 | MRR | nDCG@10 |
+| --- | --- | --- | --- | --- | --- | --- |
+| coverage_with_exclusion (before) | 19 | 23.7% | 63.2% | 78.9% | 64.8% | 61.8% |
+| coverage_with_exclusion (after) | 19 | 23.7% | **65.8%** | **84.2%** | **65.3%** | **64.0%** |
+| cross_document | 16 | 68.8% | 93.8% | 93.8% | 80.2% | 83.7% |
+| definition | 18 | 77.8% | 83.3% | 88.9% | 81.5% | 83.3% |
+| direct_lookup | 64 | 74.2% | 93.2% | 95.3% | 85.1% | 87.2% |
+
+`cross_document`, `definition` and `direct_lookup` are **identical** before and
+after — co-retrieval fires on many of those questions (they retrieve coverage
+clauses too) but only ever evicts a supporting clause that was not a reference,
+so the metric does not move.
+
+| pooled metric | before | after |
+| --- | --- | --- |
+| exclusion-clause recall | 92.6% (25/27) | **100.0% (27/27)** |
+| overall Recall@10 | 91.5% | **92.3%** |
+| overall MRR | 80.6% | 80.6% |
+| overall nDCG@10 | 82.0% | 82.3% |
+| foreign-document rate | 0.0% | 0.0% |
+
+### What actually changed
+
+Exactly two questions:
+
+- **`coverage_with_exclusion-005`** (0.50 → 1.00): the reference exclusion
+  `1:clausulas-adicionais/1/1.3` ("ALÉM DAS HIPÓTESES PREVISTAS EM PREJUÍZOS
+  NÃO INDENIZÁVEIS…"), a sibling of the retrieved coverage clause `.../1/1.2`,
+  was ranked outside the base top-10 and is now injected.
+- **`coverage_with_exclusion-004`** (0.50 → 1.00): the reference exclusion
+  `15:10-danos-aos-vidros-basica/10.2/10.2.1`, a descendant of the retrieved
+  coverage clause, likewise.
+
+These are the only two exclusion references the [M3-05] base missed, and
+co-retrieval recovers both.
+
+### Prediction vs actual
+
+| # | predicted | actual |
+| --- | --- | --- |
+| 1 | structural edges reach ~16/19 | correct — the two the base missed are both reached and recovered |
+| 2 | co-retrieval closes a small residual gap | correct — 25/27 → 27/27, two questions |
+| 3 | subset R@10 up a few points, recall approaches 100% | **beat it** — subset R@10 +5.3, exclusion recall exactly 100% |
+| 4 | a low slot count wins | correct — 1 is optimal, 2 neutral, 3 harmful |
+
+### One design iteration
+
+The first sweep used a "budget = reserved − exclusions already present"
+rule and slot count 2. It moved almost nothing: the hybrid + rerank base
+already puts ≥ 1 linked exclusion in the top-10 for nearly every coverage
+question, so the budget was usually already "spent" on a *different* exclusion
+than the reference one, and slot 2's extra injection cost one regression
+(`definition-017`). Switching to "inject the N best linked exclusions the base
+**missed**, regardless of how many other links are present" and slot count 1
+gave the clean result above. The intermediate state is recorded here rather than
+discarded, per `MILESTONES.md`.
+
+---
+
+## Verdict
+
+**Keep exclusion co-retrieval, 1 reserved slot, on the [M3-05] base.** It does
+exactly what [M3-06] is for: it guarantees the exclusion that limits a retrieved
+coverage clause reaches the context, structurally, rather than trusting the
+reranker to have ordered it in. On `golden-set-v1` that means exclusion-clause
+recall goes to 100%, `coverage_with_exclusion` Recall@10 rises 5.3 points, and
+nothing regresses. For M4 the guarantee matters more than the 5 points: the
+compatibility node is required to weigh retrieved exclusions against retrieved
+coverage, and it can only do that for exclusions retrieval actually returned.
+
+---
+
+## Limitations
+
+- **The residual `coverage_with_exclusion` gap is now entirely on the coverage
+  side.** Every exclusion reference is retrieved; the six subset questions still
+  at Recall@10 0.50 (`-001`, `-002`, `-010`, `-016`, `-017`, `-018`) are each
+  missing the *coverage* clause, which the base retriever failed to surface and
+  which co-retrieval by construction does not touch. Closing that is base-
+  retrieval tuning — [M3-08]'s benchmark matrix, or a future issue.
+- **q018 is not structurally linkable.** `7:condicoes-gerais-seguro-automovel-
+  individual-mensal/2` and `7:susep/26` are in unrelated top-level sections,
+  far apart on the page — no `same_section`, `adjacent_section` or
+  `cross_reference` edge connects them. It happens that q018's exclusion is
+  retrieved anyway (the base finds it), so this costs nothing here, but a
+  structurally-isolated coverage/exclusion pair is a real blind spot.
+- **The step fires broadly.** Insurance filings pair a coverage section with an
+  exclusion section as siblings almost everywhere, so co-retrieval triggers on
+  most `direct_lookup` and `definition` questions too. With 1 reserved slot and
+  the supporting-only eviction rule this is provably harmless on
+  `golden-set-v1` (identical metrics), but on a different question set a
+  supporting clause that happens to be a reference and happens to sit at rank 10
+  could be displaced. The sweep is the guardrail: re-run it if the base
+  changes.
+- **`clause_type` comes from the [M1-05b] LLM classifier** (99.7% of the
+  corpus). A coverage clause mistyped as `condition` gets no co-retrieval; an
+  exclusion mistyped as `condition` is not a candidate. This is the same
+  dependency the pooled exclusion-clause-recall metric already has.
+
+---
+
+## Deferred / handed to later issues
+
+- The lexical / dense / hybrid / hybrid+rerank+co-retrieval **benchmark
+  matrix** and `make build-index` — [M3-08].
+- Coverage-clause recall on the `coverage_with_exclusion` subset — base
+  retrieval tuning, [M3-08] or later.
+- M4's retrieval node constructs its own `ExclusionCoRetrievalRetriever` with a
+  `reserved_slots` sized for its context budget; the config constant is the
+  default and the golden-set-validated value.

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -94,6 +94,17 @@ from infrastructure.rag.embedding_config import (
 from infrastructure.rag.embedding_config import (
     config_fingerprint as embedding_config_fingerprint,
 )
+from infrastructure.rag.exclusion_co_retrieval import (
+    ClauseGraph,
+    ExclusionCoRetrievalRetriever,
+)
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    ADJACENT_SECTION_MAX_PAGE_GAP,
+    RESERVED_EXCLUSION_SLOTS,
+)
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    config_fingerprint as co_retrieval_config_fingerprint,
+)
 from infrastructure.rag.hybrid_config import (
     CANDIDATE_DEPTH,
     FUSION_WEIGHTS,
@@ -184,11 +195,24 @@ def _parse_args() -> argparse.Namespace:
             "group and the chunk corpus)."
         ),
     )
+    parser.add_argument(
+        "--co-retrieval",
+        dest="co_retrieval",
+        action="store_true",
+        help=(
+            "After ranking, reserve top-k slots for the [M3-06] exclusion "
+            "clauses linked to each retrieved coverage clause (lexical/dense/"
+            "hybrid only; applied outermost, after --rerank). Pure structural "
+            "post-processing over the parsed corpus -- no model calls."
+        ),
+    )
     args = parser.parse_args()
     if args.filter_mode == "default" and args.retriever == "random":
         parser.error("--filter default is not supported by --retriever random")
     if args.rerank and args.retriever == "random":
         parser.error("--rerank is not supported by --retriever random")
+    if args.co_retrieval and args.retriever == "random":
+        parser.error("--co-retrieval is not supported by --retriever random")
     return args
 
 
@@ -592,6 +616,14 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             f"{config['rerank_candidate_depth']}",
             f"- Reranker config fingerprint: `{config['reranker_config_fingerprint']}`",
         ]
+    if config.get("reserved_exclusion_slots") is not None:
+        lines += [
+            f"- Exclusion co-retrieval ([M3-06]): {config['reserved_exclusion_slots']} "
+            f"reserved slot(s), adjacent-section page gap "
+            f"{config['adjacent_section_max_page_gap']}",
+            "- Co-retrieval config fingerprint: "
+            f"`{config['co_retrieval_config_fingerprint']}`",
+        ]
     if config.get("filter_mode"):
         lines.append(f"- Metadata filter: `{config['filter_mode']}`")
     lines += [
@@ -747,6 +779,37 @@ def _apply_rerank(
     return wrapped, {**extra_config, **_rerank_config_fields()}
 
 
+def _co_retrieval_config_fields() -> dict[str, Any]:
+    """The `--co-retrieval` slice of RetrievalRunConfig: the [M3-06] contract."""
+    return {
+        "reserved_exclusion_slots": RESERVED_EXCLUSION_SLOTS,
+        "adjacent_section_max_page_gap": ADJACENT_SECTION_MAX_PAGE_GAP,
+        "co_retrieval_config_fingerprint": co_retrieval_config_fingerprint(),
+    }
+
+
+def _apply_co_retrieval(
+    args: argparse.Namespace,
+    base: Retriever,
+    corpus: Sequence[ParsedClauseRecord],
+    extra_config: dict[str, Any],
+) -> tuple[Retriever, dict[str, Any]]:
+    """Wrap ``base`` in a [M3-06] ExclusionCoRetrievalRetriever for ``--co-retrieval``.
+
+    Applied outermost -- after ``--rerank`` -- over the same parsed corpus the
+    harness already loaded. Pure structural post-processing, no model calls, so
+    (unlike ``--rerank``) it needs nothing from the ``embed`` uv group. ``base``
+    is always a filterable retriever here (``random`` rejects ``--co-retrieval``
+    in ``_parse_args``).
+    """
+    if not args.co_retrieval:
+        return base, extra_config
+    wrapped = ExclusionCoRetrievalRetriever(
+        cast(FilterableRetriever, base), ClauseGraph(corpus)
+    )
+    return wrapped, {**extra_config, **_co_retrieval_config_fields()}
+
+
 @contextmanager
 def _open_retriever(
     args: argparse.Namespace, corpus: Sequence[ParsedClauseRecord]
@@ -771,7 +834,10 @@ def _open_retriever(
     if name == "lexical":
         chunks = load_chunk_corpus()
         lexical = build_lexical_retriever(chunks)
-        yield _apply_rerank(args, lexical, chunks, _lexical_config_fields(chunks))
+        base, config = _apply_rerank(
+            args, lexical, chunks, _lexical_config_fields(chunks)
+        )
+        yield _apply_co_retrieval(args, base, corpus, config)
         return
 
     engine = create_engine_from_settings()
@@ -782,7 +848,8 @@ def _open_retriever(
         dense = DenseRetriever(session, embedder)
         if name == "dense":
             chunks = load_chunk_corpus() if args.rerank else []
-            yield _apply_rerank(args, dense, chunks, _dense_config_fields())
+            base, config = _apply_rerank(args, dense, chunks, _dense_config_fields())
+            yield _apply_co_retrieval(args, base, corpus, config)
         else:
             chunks = load_chunk_corpus()
             hybrid = HybridRetriever(
@@ -790,9 +857,10 @@ def _open_retriever(
                 dense,
                 fusion=FusionStrategy(args.fusion),
             )
-            yield _apply_rerank(
+            base, config = _apply_rerank(
                 args, hybrid, chunks, _hybrid_config_fields(chunks, args.fusion)
             )
+            yield _apply_co_retrieval(args, base, corpus, config)
     finally:
         session.close()
         engine.dispose()
@@ -879,6 +947,8 @@ def _output_stem(args: argparse.Namespace) -> str:
         parts.append(args.fusion)
     if args.rerank:
         parts.append("rerank")
+    if args.co_retrieval:
+        parts.append("co-retrieval")
     if args.filter_mode != "none":
         parts.append(f"filter-{args.filter_mode}")
     return "retrieval_eval_" + "_".join(parts)

--- a/scripts/tune_exclusion_co_retrieval.py
+++ b/scripts/tune_exclusion_co_retrieval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Sweep the [M3-06] reserved exclusion-slot count -- record the curve.
+
+The M3-06 DoD asks to "measure the effect on the ``coverage_with_exclusion``
+subset specifically, before and after". This does that across the one knob that
+moves what the golden-set metrics see: ``RESERVED_EXCLUSION_SLOTS`` -- how many
+of the final top-k slots are held for the exclusion clauses linked to a retrieved
+coverage clause.
+
+**One expensive pass, then pure-Python replay.** The base ranking (hybrid RRF +
+cross-encoder rerank, filtered to each question's SUSEP process + CNPJ -- the
+same configuration as ``make eval-retrieval-rerank``) is computed once per
+scorable question. Exclusion co-retrieval at each slot count is then a
+deterministic structural post-process over the parsed corpus
+(``ExclusionCoRetrievalRetriever``) -- no model calls, so the sweep itself costs
+seconds.
+
+Reports, for the no-co-retrieval baseline and each slot count: overall
+Recall@{1,5,10} / MRR / nDCG@10 and pooled exclusion-clause recall over all 117
+scorable ``golden-set-v1`` questions, plus the ``coverage_with_exclusion`` subset
+(n = 19) broken out on its own -- the number M3-06 exists to move.
+
+Needs a running Postgres with loaded + embedded chunks and the optional ``embed``
+uv group (for the single base pass only). Run via ``make
+tune-exclusion-co-retrieval``. Writes ``eval/runs/exclusion_co_retrieval_tuning.
+{md,json}`` (gitignored); the committed curve and the chosen slot count live in
+``docs/EXCLUSION_CO_RETRIEVAL.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from infrastructure.evaluation.golden_set_schema import GoldenQuestion, QuestionType
+from infrastructure.evaluation.retriever import FilterableRetriever
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import JSONL_PATH
+from infrastructure.rag.exclusion_co_retrieval import (
+    ClauseGraph,
+    ExclusionCoRetrievalRetriever,
+)
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    ADJACENT_SECTION_MAX_PAGE_GAP,
+    RESERVED_EXCLUSION_SLOTS,
+)
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    config_fingerprint as co_retrieval_config_fingerprint,
+)
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+from scripts.eval_retrieval import (
+    GOLDEN_SET_DIR,
+    K_VALUES,
+    MANIFEST_PATH,
+    NDCG_K,
+    RETRIEVE_K,
+    _build_filter_for,
+    _open_retriever,
+    aggregate,
+    compute_exclusion_clause_recall,
+    evaluate_questions,
+    load_corpus,
+    load_document_metadata,
+    load_golden_questions,
+)
+
+SCHEMA_VERSION = "v1"
+OUTPUT_DIR = Path("eval/runs")
+JSON_PATH = OUTPUT_DIR / "exclusion_co_retrieval_tuning.json"
+MD_PATH = OUTPUT_DIR / "exclusion_co_retrieval_tuning.md"
+
+# The reserved-slot grid. 0 is not in it -- the "no co-retrieval" row is the raw
+# base ranking, reported separately. The golden ``coverage_with_exclusion``
+# reference sets carry one limiting exclusion each, so 1-3 brackets the useful
+# range; a deeper sweep would only trade more displacement risk for nothing.
+SLOT_COUNTS: tuple[int, ...] = (1, 2, 3)
+
+_SUBSET = QuestionType.COVERAGE_WITH_EXCLUSION.value
+
+
+class _ReplayRetriever:
+    """Returns a precomputed base ranking per question text, cut to k."""
+
+    def __init__(self, by_question: Mapping[str, list[str]]) -> None:
+        self._by_question = by_question
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        del metadata_filter
+        return self._by_question[question][:k]
+
+
+class ExclusionCoRetrievalTuningConfig(BaseModel):
+    """The reproducibility stamp for one ``make tune-exclusion-co-retrieval`` run."""
+
+    schema_version: str
+    run_at_utc: datetime
+    golden_set_dir: str
+    golden_set_question_count: int
+    corpus_path: str
+    corpus_clause_count: int
+    slot_counts: list[int]
+    chosen_reserved_exclusion_slots: int
+    adjacent_section_max_page_gap: int
+    co_retrieval_config_fingerprint: str
+    base_reranker_config_fingerprint: str
+    base_hybrid_config_fingerprint: str
+    platform: str
+
+
+def _scorable(questions: Sequence[GoldenQuestion]) -> list[GoldenQuestion]:
+    return [q for q in questions if q.question_type is not QuestionType.UNANSWERABLE]
+
+
+def _metric_row(
+    retriever: Any,
+    questions: Sequence[GoldenQuestion],
+    document_meta: dict[str, dict[str, str]],
+    clause_by_id: dict[str, ParsedClauseRecord],
+) -> dict[str, Any]:
+    """Score one retriever over the filtered golden set; overall + subset row."""
+    filter_for = _build_filter_for("default", document_meta)
+    rows, _ = evaluate_questions(
+        questions, retriever, document_meta, filter_for=filter_for
+    )
+    overall = aggregate(rows, K_VALUES, NDCG_K)
+    exclusion = compute_exclusion_clause_recall(rows, clause_by_id, k=max(K_VALUES))
+    subset = aggregate(
+        [row for row in rows if row.question_type == _SUBSET], K_VALUES, NDCG_K
+    )
+    return {
+        "recall@1": overall["recall@1"],
+        "recall@5": overall["recall@5"],
+        "recall@10": overall["recall@10"],
+        "mrr": overall["mrr"],
+        f"ndcg@{NDCG_K}": overall[f"ndcg@{NDCG_K}"],
+        "exclusion_recall": exclusion["recall"],
+        "exclusion_hits": exclusion["hits"],
+        "exclusion_total": exclusion["total"],
+        "n": int(overall["n"]),
+        "subset_n": int(subset["n"]),
+        "subset_recall@10": subset["recall@10"],
+        "subset_mrr": subset["mrr"],
+        f"subset_ndcg@{NDCG_K}": subset[f"ndcg@{NDCG_K}"],
+    }
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    """Render the sweep as Markdown; numbers are copied into the topic doc."""
+    config = report["config"]
+    lines = [
+        "# Reserved exclusion-slot sweep",
+        "",
+        "Generated by `scripts/tune_exclusion_co_retrieval.py` "
+        "(`make tune-exclusion-co-retrieval`) against the golden set in "
+        "`data/golden_set/` under the `--filter default` SUSEP-process + CNPJ "
+        "pre-filter. Regenerable; the committed curve and the chosen slot count "
+        "live in `docs/EXCLUSION_CO_RETRIEVAL.md`.",
+        "",
+        "## Run configuration",
+        "",
+        f"- Golden set: `{config['golden_set_dir']}` "
+        f"({config['golden_set_question_count']} questions)",
+        f"- Corpus: `{config['corpus_path']}` "
+        f"({config['corpus_clause_count']} clauses)",
+        f"- Base ranking: hybrid RRF + cross-encoder rerank "
+        f"(reranker fingerprint `{config['base_reranker_config_fingerprint']}`, "
+        f"hybrid `{config['base_hybrid_config_fingerprint']}`) -- one pass, then "
+        f"pure-Python co-retrieval replay",
+        f"- Co-retrieval: adjacent-section page gap "
+        f"{config['adjacent_section_max_page_gap']}; config fingerprint "
+        f"`{config['co_retrieval_config_fingerprint']}`",
+        f"- Reserved-slot counts swept: {config['slot_counts']}; chosen "
+        f"(in `exclusion_co_retrieval_config.py`): "
+        f"**{config['chosen_reserved_exclusion_slots']}**",
+        f"- Run at (UTC): {config['run_at_utc']}",
+        f"- Platform: {config['platform']}",
+        "",
+        "## Curve",
+        "",
+        "`coverage_with_exclusion` is the subset M3-06 exists to move "
+        f"(n = {report['rows'][0]['subset_n']}); the overall columns watch for "
+        "collateral regression on the other 98 questions.",
+        "",
+        "| reserved slots | overall R@1 | overall R@5 | overall R@10 | overall "
+        f"MRR | overall nDCG@{NDCG_K} | exclusion recall | cov+excl R@10 | "
+        "cov+excl MRR |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in report["rows"]:
+        label = (
+            "0 (no co-retrieval)"
+            if row["reserved_slots"] is None
+            else str(row["reserved_slots"])
+        )
+        exclusion = row["exclusion_recall"]
+        exclusion_cell = (
+            f"{exclusion:.1%} ({row['exclusion_hits']}/{row['exclusion_total']})"
+            if exclusion is not None
+            else "n/a"
+        )
+        lines.append(
+            f"| {label} | {row['recall@1']:.1%} | {row['recall@5']:.1%} "
+            f"| {row['recall@10']:.1%} | {row['mrr']:.1%} "
+            f"| {row[f'ndcg@{NDCG_K}']:.1%} | {exclusion_cell} "
+            f"| {row['subset_recall@10']:.1%} | {row['subset_mrr']:.1%} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run the sweep against the golden set and write the report."""
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    corpus = load_corpus(JSONL_PATH)
+    clause_by_id = {record.clause_id: record for record in corpus}
+    questions = load_golden_questions(GOLDEN_SET_DIR)
+    graph = ClauseGraph(corpus)
+
+    base_args = argparse.Namespace(
+        retriever="hybrid",
+        fusion="rrf",
+        filter_mode="default",
+        seed=42,
+        rerank=True,
+        co_retrieval=False,
+    )
+    base_by_question: dict[str, list[str]] = {}
+    with _open_retriever(base_args, corpus) as (retriever, base_config):
+        filterable = cast(FilterableRetriever, retriever)
+        for question in _scorable(questions):
+            metadata_filter = RetrievalFilter.from_manifest_row(
+                document_meta[question.document_id]
+            )
+            if question.question in base_by_question:
+                raise ValueError(
+                    f"duplicate golden question text: {question.question!r}"
+                )
+            base_by_question[question.question] = filterable.retrieve(
+                question.question, k=RETRIEVE_K, metadata_filter=metadata_filter
+            )
+    print(f"cached the base ranking for {len(base_by_question)} questions", flush=True)
+
+    rows: list[dict[str, Any]] = []
+    baseline = _metric_row(
+        _ReplayRetriever(base_by_question), questions, document_meta, clause_by_id
+    )
+    baseline["reserved_slots"] = None
+    rows.append(baseline)
+    print(
+        f"baseline (no co-retrieval): overall R@10={baseline['recall@10']:.1%} "
+        f"excl={baseline['exclusion_recall']} "
+        f"cov+excl R@10={baseline['subset_recall@10']:.1%}",
+        flush=True,
+    )
+
+    for slots in SLOT_COUNTS:
+        retriever = ExclusionCoRetrievalRetriever(
+            _ReplayRetriever(base_by_question), graph, reserved_slots=slots
+        )
+        row = _metric_row(retriever, questions, document_meta, clause_by_id)
+        row["reserved_slots"] = slots
+        rows.append(row)
+        print(
+            f"slots {slots}: overall R@10={row['recall@10']:.1%} "
+            f"excl={row['exclusion_recall']} "
+            f"cov+excl R@10={row['subset_recall@10']:.1%} "
+            f"MRR={row['subset_mrr']:.1%}",
+            flush=True,
+        )
+
+    config = ExclusionCoRetrievalTuningConfig(
+        schema_version=SCHEMA_VERSION,
+        run_at_utc=datetime.now(UTC),
+        golden_set_dir=str(GOLDEN_SET_DIR),
+        golden_set_question_count=len(questions),
+        corpus_path=str(JSONL_PATH),
+        corpus_clause_count=len(corpus),
+        slot_counts=list(SLOT_COUNTS),
+        chosen_reserved_exclusion_slots=RESERVED_EXCLUSION_SLOTS,
+        adjacent_section_max_page_gap=ADJACENT_SECTION_MAX_PAGE_GAP,
+        co_retrieval_config_fingerprint=co_retrieval_config_fingerprint(),
+        base_reranker_config_fingerprint=base_config["reranker_config_fingerprint"],
+        base_hybrid_config_fingerprint=base_config["hybrid_config_fingerprint"],
+        platform=platform.platform(),
+    )
+
+    report = {"config": config.model_dump(mode="json"), "rows": rows}
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    MD_PATH.write_text(render_markdown_report(report), encoding="utf-8")
+    print(f"Wrote {JSON_PATH} and {MD_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/eval/test_co_retrieval_retrieval_baseline.py
+++ b/tests/eval/test_co_retrieval_retrieval_baseline.py
@@ -1,11 +1,12 @@
-"""Sanity floor for the [M3-05] cross-encoder rerank of the filtered hybrid.
+"""Sanity floor for the [M3-06] exclusion co-retrieval step.
 
-The mirror of ``test_hybrid_retrieval_baseline.py`` for the rerank stage: proves
-that hybrid RRF + cross-encoder rerank, filtered to each question's SUSEP
-process + CNPJ, still clears a recall floor **and** does not push exclusion
-clauses out of the kept context relative to the no-rerank baseline (the M3-05
-DoD's named regression). A smoke check, not a quality gate -- the committed
-numbers, the curve and the verdict live in ``docs/RERANKING.md``.
+The mirror of ``test_rerank_retrieval_baseline.py`` for the co-retrieval stage:
+proves that hybrid RRF + rerank + exclusion co-retrieval, filtered to each
+question's SUSEP process + CNPJ, still clears a recall floor **and** does not
+lose ground against the no-co-retrieval baseline on the two numbers M3-06 exists
+to move -- pooled exclusion-clause recall and the ``coverage_with_exclusion``
+Recall@10. A smoke check, not a quality gate -- the committed numbers, the slot
+sweep and the verdict live in ``docs/EXCLUSION_CO_RETRIEVAL.md``.
 
 Needs ``build/chunks.jsonl``, a reachable Postgres with embedded chunks, and the
 optional ``embed`` uv group (which also ships the cross-encoder). Skips cleanly
@@ -49,13 +50,13 @@ def _skip_unless_ready() -> None:
             ).scalar_one()
         engine.dispose()
     except Exception as exc:  # noqa: BLE001 - any DB failure is a skip, not a fail
-        pytest.skip(f"database not ready for the rerank eval: {exc}")
+        pytest.skip(f"database not ready for the co-retrieval eval: {exc}")
     if embedded < 100:
         pytest.skip(f"only {embedded} embedded chunks; run `make embed-chunks`")
 
 
 @pytest.mark.eval
-def test_filtered_hybrid_rerank_clears_a_floor_and_keeps_exclusion_clauses() -> None:
+def test_co_retrieval_clears_a_floor_and_does_not_lose_exclusion_ground() -> None:
     _skip_unless_ready()
 
     from scripts.eval_retrieval import (
@@ -79,27 +80,33 @@ def test_filtered_hybrid_rerank_clears_a_floor_and_keeps_exclusion_clauses() -> 
     questions = load_golden_questions(GOLDEN_SET_DIR)
     filter_for = _build_filter_for("default", document_meta)
 
-    def score(rerank: bool) -> tuple[dict[str, float], float | None]:
+    def score(co_retrieval: bool) -> tuple[dict[str, float], float | None, float]:
         args = argparse.Namespace(
             retriever="hybrid",
             fusion="rrf",
             filter_mode="default",
             seed=42,
-            rerank=rerank,
-            co_retrieval=False,
+            rerank=True,
+            co_retrieval=co_retrieval,
         )
         with _open_retriever(args, corpus) as (retriever, _config):
             rows, _ = evaluate_questions(
                 questions, retriever, document_meta, filter_for=filter_for
             )
         exclusion = compute_exclusion_clause_recall(rows, clause_by_id, k=10)
-        return aggregate(rows, (1, 5, 10), 10), exclusion["recall"]
+        subset = aggregate(
+            [row for row in rows if row.question_type == "coverage_with_exclusion"],
+            (1, 5, 10),
+            10,
+        )
+        return aggregate(rows, (1, 5, 10), 10), exclusion["recall"], subset["recall@10"]
 
-    baseline_overall, baseline_exclusion = score(rerank=False)
-    rerank_overall, rerank_exclusion = score(rerank=True)
+    base_overall, base_exclusion, base_subset = score(co_retrieval=False)
+    co_overall, co_exclusion, co_subset = score(co_retrieval=True)
 
-    assert rerank_overall["recall@10"] > RECALL_FLOOR
-    assert rerank_overall["mrr"] > MRR_FLOOR
-    # DoD item 4: reranking must not push exclusion clauses out of the context.
-    assert baseline_exclusion is not None and rerank_exclusion is not None
-    assert rerank_exclusion >= baseline_exclusion - 1e-9
+    assert co_overall["recall@10"] > RECALL_FLOOR
+    assert co_overall["mrr"] > MRR_FLOOR
+    # M3-06's purpose: never regress the exclusion-side numbers.
+    assert base_exclusion is not None and co_exclusion is not None
+    assert co_exclusion >= base_exclusion - 1e-9
+    assert co_subset >= base_subset - 1e-9

--- a/tests/eval/test_hybrid_retrieval_baseline.py
+++ b/tests/eval/test_hybrid_retrieval_baseline.py
@@ -74,7 +74,12 @@ def test_filtered_hybrid_clears_a_floor_and_stays_in_document() -> None:
     from infrastructure.parsing.corpus_artifact import JSONL_PATH
 
     args = argparse.Namespace(
-        retriever="hybrid", fusion="rrf", filter_mode="default", seed=42, rerank=False
+        retriever="hybrid",
+        fusion="rrf",
+        filter_mode="default",
+        seed=42,
+        rerank=False,
+        co_retrieval=False,
     )
     document_meta = load_document_metadata(MANIFEST_PATH)
     questions = load_golden_questions(GOLDEN_SET_DIR)

--- a/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
+++ b/tests/unit/infrastructure/evaluation/test_retrieval_run_schema.py
@@ -121,3 +121,31 @@ def test_v4_rerank_fields_are_optional_and_round_trip() -> None:
         reranker_config_fingerprint="777c0503f1073d52",
     )
     assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config
+
+
+@pytest.mark.unit
+def test_v5_co_retrieval_fields_are_optional_and_round_trip() -> None:
+    # Every non-co-retrieval run leaves the [M3-06] fields None; the flag sets them.
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "retriever_name": "hybrid",
+        "k_values": [1, 5, 10],
+        "ndcg_k": 10,
+        "golden_set_dir": "data/golden_set",
+        "golden_set_question_count": 140,
+        "corpus_path": "build/parsed_clauses.jsonl",
+        "corpus_clause_count": 4925,
+        "seed": None,
+        "run_at_utc": datetime.now(UTC),
+    }
+    assert RetrievalRunConfig(**base).reserved_exclusion_slots is None
+
+    config = RetrievalRunConfig(
+        **base,
+        filter_mode="default",
+        fusion_strategy="rrf",
+        reserved_exclusion_slots=2,
+        adjacent_section_max_page_gap=3,
+        co_retrieval_config_fingerprint="7ed4c97c4e8f1cb4",
+    )
+    assert RetrievalRunConfig.model_validate_json(config.model_dump_json()) == config

--- a/tests/unit/infrastructure/rag/test_exclusion_co_retrieval.py
+++ b/tests/unit/infrastructure/rag/test_exclusion_co_retrieval.py
@@ -1,0 +1,372 @@
+"""Structural exclusion co-retrieval and its reserved-budget merge -- [M3-06]."""
+
+import pytest
+
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.rag.exclusion_co_retrieval import (
+    ClauseGraph,
+    ExclusionCoRetrievalRetriever,
+    ExclusionEdge,
+    extract_cross_references,
+)
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+def _clause(
+    clause_id: str,
+    clause_type: str,
+    *,
+    parent_id: str | None = None,
+    text: str = "corpo da cláusula",
+    page_start: int = 1,
+    page_end: int | None = None,
+    bundle_section: str | None = None,
+    document_id: str = "1",
+) -> ParsedClauseRecord:
+    """A minimal ParsedClauseRecord; ``path`` is the id's segment after the doc."""
+    return ParsedClauseRecord.model_validate(
+        {
+            "schema_version": "v1",
+            "clause_id": clause_id,
+            "document_id": document_id,
+            "parent_id": parent_id,
+            "path": clause_id.split(":", 1)[1],
+            "title": "Título",
+            "text": text,
+            "clause_type": clause_type,
+            "type_source": "rule",
+            "confidence": 1.0,
+            "bundle_section": bundle_section,
+            "page_start": page_start,
+            "page_end": page_start if page_end is None else page_end,
+            "source": "text",
+            "susep_process": "123",
+            "insurer": "Insurer",
+            "cnpj": "C1",
+            "product_line": "CASCO",
+            "indemnity_regime": "VD",
+            "filing_year": "2020",
+        }
+    )
+
+
+class FakeBase:
+    """A base retriever double: returns a fixed clause-id list, records the call."""
+
+    def __init__(self, clause_ids: list[str]) -> None:
+        self._clause_ids = clause_ids
+        self.seen_k: int | None = None
+        self.seen_filter: RetrievalFilter | None = None
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        del question
+        self.seen_k = k
+        self.seen_filter = metadata_filter
+        return self._clause_ids[:k]
+
+
+# --- extract_cross_references -------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_cross_references_finds_plain_and_decimal_numbers() -> None:
+    assert extract_cross_references(
+        "conforme a Cláusula 12 e a cláusula 4.2 acima"
+    ) == {"12", "4.2"}
+
+
+@pytest.mark.unit
+def test_extract_cross_references_is_accent_and_case_insensitive() -> None:
+    assert extract_cross_references("ver CLAUSULA 26 - PREJUÍZOS") == {"26"}
+
+
+@pytest.mark.unit
+def test_extract_cross_references_no_match_returns_empty_set() -> None:
+    assert extract_cross_references("nenhuma referência de numeração aqui") == set()
+
+
+# --- ClauseGraph edges ------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_same_section_links_a_sibling_exclusion() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:root/1", "coverage", parent_id="1:root"),
+            _clause("1:root/10", "exclusion", parent_id="1:root"),
+            _clause("1:root/2", "condition", parent_id="1:root"),
+        ]
+    )
+    links = graph.linked_exclusions("1:root/1")
+
+    assert [link.clause_id for link in links] == ["1:root/10"]
+    assert links[0].edge is ExclusionEdge.SAME_SECTION
+    assert links[0].tree_distance == 2  # sibling: up to the parent and back down
+
+
+@pytest.mark.unit
+def test_same_section_links_a_descendant_exclusion() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:cov", "coverage"),
+            _clause("1:cov/2", "condition", parent_id="1:cov"),
+            _clause("1:cov/2/2.1", "exclusion", parent_id="1:cov/2"),
+        ]
+    )
+    links = graph.linked_exclusions("1:cov")
+
+    assert [link.clause_id for link in links] == ["1:cov/2/2.1"]
+    assert links[0].tree_distance == 2
+
+
+@pytest.mark.unit
+def test_adjacent_section_links_a_nearby_exclusion_in_another_section() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:1", "coverage", page_start=43, page_end=43),
+            _clause("1:2", "exclusion", page_start=42, page_end=42),
+            _clause("1:99", "exclusion", page_start=80, page_end=80),
+        ]
+    )
+    links = graph.linked_exclusions("1:1")
+
+    assert [link.clause_id for link in links] == ["1:2"]
+    assert links[0].edge is ExclusionEdge.ADJACENT_SECTION
+    assert links[0].page_gap == 1
+
+
+@pytest.mark.unit
+def test_cross_reference_edge_outranks_same_section() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause(
+                "1:root/1",
+                "coverage",
+                parent_id="1:root",
+                text="indeniza salvo o disposto na cláusula 10.2",
+            ),
+            _clause("1:root/9", "exclusion", parent_id="1:root"),
+            _clause("1:root/x/10.2", "exclusion", parent_id="1:root"),
+        ]
+    )
+    links = graph.linked_exclusions("1:root/1")
+
+    # Both are same-section; the cross-referenced one is promoted and sorts first.
+    assert links[0].clause_id == "1:root/x/10.2"
+    assert links[0].edge is ExclusionEdge.CROSS_REFERENCE
+    assert {link.clause_id for link in links} == {"1:root/9", "1:root/x/10.2"}
+
+
+@pytest.mark.unit
+def test_bundle_section_guard_excludes_a_different_bundle() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:root/1", "coverage", parent_id="1:root", bundle_section="MOTO"),
+            _clause(
+                "1:root/8", "exclusion", parent_id="1:root", bundle_section="CARGA"
+            ),
+            _clause("1:root/9", "exclusion", parent_id="1:root", bundle_section="MOTO"),
+            _clause("1:root/10", "exclusion", parent_id="1:root"),
+        ]
+    )
+    linked = {link.clause_id for link in graph.linked_exclusions("1:root/1")}
+
+    assert linked == {"1:root/9", "1:root/10"}  # same bundle, or unknown
+
+
+@pytest.mark.unit
+def test_linked_exclusions_empty_for_non_coverage_or_unknown() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:e", "exclusion"),
+            _clause("1:c", "condition"),
+        ]
+    )
+    assert graph.linked_exclusions("1:e") == []
+    assert graph.linked_exclusions("1:c") == []
+    assert graph.linked_exclusions("1:missing") == []
+
+
+@pytest.mark.unit
+def test_ranking_and_dedup_are_deterministic_regardless_of_input_order() -> None:
+    records = [
+        _clause("1:root", "other"),
+        _clause("1:root/1", "coverage", parent_id="1:root", page_start=1, page_end=1),
+        _clause("1:root/10", "exclusion", parent_id="1:root", page_start=9, page_end=9),
+        _clause("1:root/11", "exclusion", parent_id="1:root", page_start=5, page_end=5),
+    ]
+    forward = ClauseGraph(records).linked_exclusions("1:root/1")
+    reverse = ClauseGraph(list(reversed(records))).linked_exclusions("1:root/1")
+
+    # Same edge + tree distance -> ordered by page gap: /11 (gap 4) before /10 (gap 8).
+    assert [link.clause_id for link in forward] == ["1:root/11", "1:root/10"]
+    assert forward == reverse
+
+
+@pytest.mark.unit
+def test_ranked_linked_exclusions_merges_over_several_coverage_clauses() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:root/1", "coverage", parent_id="1:root"),
+            _clause("1:root/2", "coverage", parent_id="1:root"),
+            _clause("1:root/10", "exclusion", parent_id="1:root"),
+        ]
+    )
+    links = graph.ranked_linked_exclusions(["1:root/1", "1:root/2"])
+
+    assert [link.clause_id for link in links] == ["1:root/10"]  # kept once
+
+
+# --- ExclusionCoRetrievalRetriever ------------------------------------------
+
+
+def _graph_with_one_link() -> ClauseGraph:
+    return ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:cov", "coverage", parent_id="1:root"),
+            _clause("1:exc", "exclusion", parent_id="1:root"),
+            _clause("1:n1", "condition", parent_id="1:root"),
+            _clause("1:n2", "condition", parent_id="1:root"),
+            _clause("1:n3", "condition", parent_id="1:root"),
+        ]
+    )
+
+
+@pytest.mark.unit
+def test_injects_a_linked_exclusion_and_evicts_the_lowest_non_exclusion() -> None:
+    base = FakeBase(["1:cov", "1:n1", "1:n2", "1:n3"])
+    retriever = ExclusionCoRetrievalRetriever(
+        base, _graph_with_one_link(), reserved_slots=2
+    )
+
+    # k=4, one linked exclusion missing from the base -> it takes the last slot,
+    # the lowest-ranked non-exclusion ("1:n3") is dropped.
+    assert retriever.retrieve("q", k=4) == ["1:cov", "1:n1", "1:n2", "1:exc"]
+
+
+@pytest.mark.unit
+def test_appends_without_eviction_when_the_base_under_fills() -> None:
+    base = FakeBase(["1:cov", "1:n1"])
+    retriever = ExclusionCoRetrievalRetriever(
+        base, _graph_with_one_link(), reserved_slots=2
+    )
+
+    assert retriever.retrieve("q", k=4) == ["1:cov", "1:n1", "1:exc"]
+
+
+@pytest.mark.unit
+def test_passthrough_when_no_coverage_clause_was_retrieved() -> None:
+    base = FakeBase(["1:n1", "1:n2", "1:n3"])
+    retriever = ExclusionCoRetrievalRetriever(
+        base, _graph_with_one_link(), reserved_slots=2
+    )
+
+    assert retriever.retrieve("q", k=3) == ["1:n1", "1:n2", "1:n3"]
+
+
+@pytest.mark.unit
+def test_passthrough_when_the_linked_exclusion_is_already_in_the_ranking() -> None:
+    base = FakeBase(["1:cov", "1:exc", "1:n1"])
+    retriever = ExclusionCoRetrievalRetriever(
+        base, _graph_with_one_link(), reserved_slots=2
+    )
+
+    assert retriever.retrieve("q", k=3) == ["1:cov", "1:exc", "1:n1"]
+
+
+@pytest.mark.unit
+def test_only_the_reserved_number_of_missing_exclusions_is_injected() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:cov", "coverage", parent_id="1:root"),
+            _clause("1:exc1", "exclusion", parent_id="1:root", page_start=2),
+            _clause("1:exc2", "exclusion", parent_id="1:root", page_start=9),
+            _clause("1:n1", "condition", parent_id="1:root"),
+            _clause("1:n2", "condition", parent_id="1:root"),
+        ]
+    )
+    # Two linked exclusions missing, reserved_slots=1 -> only the best-ranked
+    # one ("1:exc1", smaller page gap) is injected.
+    base = FakeBase(["1:cov", "1:n1", "1:n2"])
+    retriever = ExclusionCoRetrievalRetriever(base, graph, reserved_slots=1)
+
+    assert retriever.retrieve("q", k=3) == ["1:cov", "1:n1", "1:exc1"]
+
+
+@pytest.mark.unit
+def test_a_missing_exclusion_is_injected_even_when_another_link_is_present() -> None:
+    # The [M3-06] case that set RESERVED_EXCLUSION_SLOTS -> "inject the N best
+    # linked exclusions the base missed", not "N minus however many links are
+    # already there": a coverage clause can retrieve one section exclusion while
+    # still missing the specific one that limits it.
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:cov", "coverage", parent_id="1:root"),
+            _clause("1:exc_here", "exclusion", parent_id="1:root", page_start=2),
+            _clause("1:exc_missing", "exclusion", parent_id="1:root", page_start=9),
+            _clause("1:n1", "condition", parent_id="1:root"),
+        ]
+    )
+    base = FakeBase(["1:cov", "1:exc_here", "1:n1"])
+    retriever = ExclusionCoRetrievalRetriever(base, graph, reserved_slots=1)
+
+    assert retriever.retrieve("q", k=3) == ["1:cov", "1:exc_here", "1:exc_missing"]
+
+
+@pytest.mark.unit
+def test_injection_stops_when_only_coverage_and_exclusion_survivors_remain() -> None:
+    graph = ClauseGraph(
+        [
+            _clause("1:root", "other"),
+            _clause("1:cov", "coverage", parent_id="1:root", page_start=1, page_end=1),
+            _clause("1:exc", "exclusion", parent_id="1:root", page_start=2, page_end=2),
+            # A second coverage clause and an unrelated exclusion, far away.
+            _clause("1:cov2", "coverage", page_start=80, page_end=80),
+            _clause("1:exc_other", "exclusion", page_start=90, page_end=90),
+        ]
+    )
+    base = FakeBase(["1:cov", "1:cov2", "1:exc_other"])
+    retriever = ExclusionCoRetrievalRetriever(base, graph, reserved_slots=2)
+
+    # "1:exc" links to "1:cov", but every base entry is coverage or exclusion --
+    # none may be evicted, so the ranking is returned untouched.
+    assert retriever.retrieve("q", k=3) == ["1:cov", "1:cov2", "1:exc_other"]
+
+
+@pytest.mark.unit
+def test_reserved_slots_zero_and_non_positive_k_are_passthrough() -> None:
+    base = FakeBase(["1:cov", "1:n1"])
+    assert ExclusionCoRetrievalRetriever(
+        base, _graph_with_one_link(), reserved_slots=0
+    ).retrieve("q", k=2) == ["1:cov", "1:n1"]
+    assert (
+        ExclusionCoRetrievalRetriever(
+            FakeBase(["1:cov"]), _graph_with_one_link()
+        ).retrieve("q", k=0)
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_the_metadata_filter_reaches_the_base() -> None:
+    base = FakeBase(["1:cov"])
+    retriever = ExclusionCoRetrievalRetriever(base, _graph_with_one_link())
+    filt = RetrievalFilter(susep_process="P", cnpj="C")
+
+    retriever.retrieve("q", k=1, metadata_filter=filt)
+
+    assert base.seen_filter is filt
+    assert base.seen_k == 1

--- a/tests/unit/infrastructure/rag/test_exclusion_co_retrieval_config.py
+++ b/tests/unit/infrastructure/rag/test_exclusion_co_retrieval_config.py
@@ -1,0 +1,47 @@
+"""The pinned exclusion co-retrieval contract and its anti-drift guards -- [M3-06]."""
+
+import re
+
+import pytest
+
+from infrastructure.rag import exclusion_co_retrieval_config as config
+from infrastructure.rag.exclusion_co_retrieval_config import (
+    ADJACENT_SECTION_MAX_PAGE_GAP,
+    CROSS_REFERENCE_PATTERN,
+    RESERVED_EXCLUSION_SLOTS,
+    config_fingerprint,
+)
+
+
+@pytest.mark.unit
+def test_contract_constants() -> None:
+    assert RESERVED_EXCLUSION_SLOTS >= 1
+    assert ADJACENT_SECTION_MAX_PAGE_GAP >= 0
+    # The pattern must compile and capture the numbering token.
+    match = re.search(CROSS_REFERENCE_PATTERN, "conforme cláusula 10.2", re.IGNORECASE)
+    assert match is not None and match.group(1) == "10.2"
+
+
+@pytest.mark.unit
+def test_config_fingerprint_is_stable() -> None:
+    # A pinned literal, so reordering or dropping a field from the payload is a
+    # visible test failure.
+    assert config_fingerprint() == "7ed4c97c4e8f1cb4"
+    assert re.fullmatch(r"[0-9a-f]{16}", config_fingerprint()) is not None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("attr", "value"),
+    [
+        ("RESERVED_EXCLUSION_SLOTS", 99),
+        ("ADJACENT_SECTION_MAX_PAGE_GAP", 99),
+        ("CROSS_REFERENCE_PATTERN", r"artigos?\s+(\d+)"),
+    ],
+)
+def test_every_contract_field_changes_the_fingerprint(
+    monkeypatch: pytest.MonkeyPatch, attr: str, value: object
+) -> None:
+    baseline = config_fingerprint()
+    monkeypatch.setattr(config, attr, value)
+    assert config_fingerprint() != baseline

--- a/tests/unit/scripts/test_eval_retrieval.py
+++ b/tests/unit/scripts/test_eval_retrieval.py
@@ -222,6 +222,12 @@ def test_output_stem_keeps_random_and_lexical_names_and_tags_the_rest(
         stem_for("--retriever", "hybrid", "--filter", "default", "--rerank")
         == "retrieval_eval_hybrid_rrf_rerank_filter-default"
     )
+    assert (
+        stem_for(
+            "--retriever", "hybrid", "--filter", "default", "--rerank", "--co-retrieval"
+        )
+        == "retrieval_eval_hybrid_rrf_rerank_co-retrieval_filter-default"
+    )
 
 
 @pytest.mark.unit
@@ -511,6 +517,62 @@ def test_parse_args_rejects_rerank_with_the_random_retriever(
     )
     with pytest.raises(SystemExit):
         _parse_args()
+
+
+@pytest.mark.unit
+def test_parse_args_rejects_co_retrieval_with_the_random_retriever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "sys.argv", ["eval_retrieval.py", "--retriever", "random", "--co-retrieval"]
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+@pytest.mark.unit
+def test_render_markdown_report_includes_the_co_retrieval_config_block() -> None:
+    metrics_row = {
+        "n": 1.0,
+        "recall@1": 0.0,
+        "recall@5": 0.0,
+        "recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0,
+    }
+    report = {
+        "config": {
+            "schema_version": "v5",
+            "retriever_name": "hybrid",
+            "k_values": [1, 5, 10],
+            "ndcg_k": 10,
+            "golden_set_dir": "data/golden_set",
+            "golden_set_question_count": 140,
+            "corpus_path": "build/parsed_clauses.jsonl",
+            "corpus_clause_count": 4925,
+            "seed": None,
+            "run_at_utc": "2026-08-29T00:00:00+00:00",
+            "filter_mode": "default",
+            "reserved_exclusion_slots": 2,
+            "adjacent_section_max_page_gap": 3,
+            "co_retrieval_config_fingerprint": "7ed4c97c4e8f1cb4",
+        },
+        "overall": metrics_row,
+        "by_question_type": {
+            "direct_lookup": metrics_row,
+            "unanswerable": {"n": 23, "excluded_from_scoring": True},
+        },
+        "by_product_line": {"CASCO": metrics_row},
+        "by_extraction_mode": {"text": metrics_row},
+        "exclusion_clause_recall": {"k": 10, "hits": 27, "total": 27, "recall": 1.0},
+        "foreign_document_rate": {"k": 10, "hits": 0, "total": 90, "rate": 0.0},
+    }
+
+    markdown = render_markdown_report(report)
+
+    assert "Exclusion co-retrieval ([M3-06]): 2 reserved slot(s)" in markdown
+    assert "adjacent-section page gap 3" in markdown
+    assert "7ed4c97c4e8f1cb4" in markdown
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Adds the [M3-06] exclusion co-retrieval step: after the [M3-05] hybrid RRF +
rerank pipeline ranks, for every retrieved `coverage` clause the system pulls the
`exclusion` clauses structurally linked to it and reserves one slot of the final
top-k for the best-linked exclusion the ranking missed. This is the core
retrieval problem of the domain — a coverage clause retrieved without the
exclusion that limits it produces an assessment that is fluent, well-cited and
wrong — so the linked exclusion is treated as load-bearing as the coverage
clause, not as a result whose inclusion a relevance score should decide.

New:
- `infrastructure/rag/exclusion_co_retrieval.py` — `ClauseGraph` (deterministic
  structural index over the parsed corpus; no DB, no LLM) linking coverage to
  exclusion clauses by three edges (same section root, adjacent section by page
  proximity, in-text `cláusula N` cross-reference), and
  `ExclusionCoRetrievalRetriever` wrapping the reranker behind the same
  `retrieve(question, *, k, metadata_filter)` interface.
- `infrastructure/rag/exclusion_co_retrieval_config.py` — the tuned constants
  (`RESERVED_EXCLUSION_SLOTS=1`, `ADJACENT_SECTION_MAX_PAGE_GAP=3`, the
  cross-reference pattern) + `config_fingerprint()`. No new `.env` key.
- `scripts/tune_exclusion_co_retrieval.py` + `make tune-exclusion-co-retrieval`
  — the reserved-slot sweep (one cached rerank pass, pure-Python replay).
- `make eval-retrieval-co-retrieval` and a `--co-retrieval` flag on
  `scripts/eval_retrieval.py`; `RetrievalRunConfig` → schema v5.
- `docs/ARCHITECTURE.md` (the domain rule) and `docs/EXCLUSION_CO_RETRIEVAL.md`
  (method, pre-registered prediction, sweep, before/after, one design iteration,
  limitations).

Deviation on record (module docstring + both docs): the DoD asks for
cross-references to be parsed "during M1". M1's corpus schema is frozen and a
re-parse is disproportionate for a pure function of text the artifact already
carries, so `extract_cross_references` runs at graph-build time — the production
formalisation of the identical helper `scripts/find_candidate_clauses.py`
([M2-08]) already uses, as that issue's docstring anticipated.
`find_candidate_clauses.py` is left untouched (four frozen M2 scripts import it).

## Related issue

[M3-06]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
      — 26 unit tests for `ClauseGraph`, the reserved-budget merge and the
      config fingerprint; `tests/eval/test_co_retrieval_retrieval_baseline.py`
      (skip-unless-ready smoke test); extended `test_eval_retrieval.py` and
      `test_retrieval_run_schema.py` for the flag / v5 fields; the two eval
      baseline `argparse.Namespace`s updated.
- [x] Docs updated — `docs/ARCHITECTURE.md` (new), `docs/EXCLUSION_CO_RETRIEVAL.md`
      (new).
- [x] Evaluation impact considered — **yes, retrieval numbers move (favourably)**.
      On `golden-set-v1`, hybrid RRF + rerank + `--filter default`, 1 reserved
      slot: pooled exclusion-clause recall 92.6% (25/27) → **100% (27/27)**;
      `coverage_with_exclusion` Recall@10 78.9% → **84.2%**; overall Recall@10
      91.5% → **92.3%**; `cross_document` / `definition` / `direct_lookup`
      identical; foreign-document rate still 0.0%. Two questions change
      (`coverage_with_exclusion-004`, `-005` — the only two exclusion references
      the reranker missed); zero regressions. Slot sweep: 1 optimal, 2 neutral,
      3 harmful. Full curve and the reasoning in `docs/EXCLUSION_CO_RETRIEVAL.md`.
- [x] `make check` passes locally (ruff, format, mypy strict, 767 unit tests);
      `pytest -m eval` also green (5, incl. the new smoke test).