### PR TITLE
feat(rag): run the benchmark matrix and make the index reproducible (…

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -53,7 +53,7 @@ is cleared.
 | M0        | Foundations                | done |
 | M1        | Policy parsing              | done        |
 | M2        | Ground truth                | done        |
-| M3        | Retrieval                   | todo        |
+| M3        | Retrieval                   | done        |
 | M4        | Agent graph                 | todo        |
 | M5        | Service and hardening       | todo        |
 | M6        | Release and portfolio       | todo        |
@@ -333,6 +333,38 @@ framing — they don't; the "only the 3 decoys are high" framing — six are), o
 was beaten (precision recovered to 100%, not the low-to-mid 80s). Full method,
 sweep, fragility table and prediction-vs-actual: `docs/INSUFFICIENT_CONTEXT_GATE.md`.
 Wiring the gate into the graph is [M4-04]; the benchmark matrix is [M3-08].
+
+**[M3-08] outcome (2026-08-30). M3 closes.** The benchmark matrix
+(`scripts/benchmark_retrieval_matrix.py`, `make eval-retrieval-matrix`,
+committed in `docs/RETRIEVAL_BENCHMARK.md`) scores every configuration on the
+117 scorable `golden-set-v1` questions over the `--filter default`
+SUSEP-process + CNPJ path. **Best configuration — hybrid RRF + cross-encoder
+rerank (depth 10) + exclusion co-retrieval (1 slot): Recall@10 92.3%, MRR
+80.6%, nDCG@10 82.3%, exclusion-clause recall 100% (27/27), foreign-document
+rate 0.0%** — both exit bars (Recall@10 ≥ 0.85, MRR ≥ 0.60) cleared, and every
+exclusion reference in the golden set retrieved. The four core rows reproduce
+their [M3-03]/[M3-04]/[M3-05] committed numbers exactly and are byte-identical
+across two matrix runs (retrieval is deterministic; tolerance is fp32 reranker
+rounding across hardware, ≤ ~1 question). **RRF-vs-weighted, re-opened with the
+reranker in the loop: RRF wins every metric** (Recall@10 92.3 vs 89.3, MRR 80.6
+vs 80.4) — the reranker erased the fusion-stage MRR edge weighted had, and
+weighted's weaker candidate *set* is what remains; `DEFAULT_FUSION_STRATEGY`
+unchanged, and the [M3-04] deviation is now a measured result. **Real-embedding
+ANN A/B** (`make benchmark-ann-index-real`, second measurement in
+`docs/EMBEDDINGS.md`): HNSW recall@10 vs. exact is **0.9932** (vs the 0.448
+synthetic), but the verdict is unchanged — the filtered default path's planner
+reads the btree partition (`Bitmap Heap Scan`), never the index, so
+`make build-index` does not build it. **`make build-index`** rebuilds the index
+end to end (`parse` → `build-chunks` → `migrate` → `load-chunks` →
+`embed-chunks`); it needs the same `LLM_*` + Tesseract environment as
+`make parse`, and a file-target prerequisite skips the parse stage when the
+parsed corpus is already present. **Deviation, stated per this file:** the DoD's
+`make eval-retrieval` is the [M2-06] random self-test, so the matrix is realised
+as the new target `make eval-retrieval-matrix`. Pre-registered predictions: the
+four-core reproduction held; "keep RRF" held but for a stronger reason than
+predicted (RRF wins outright, not on a trade-off); the ANN prediction held.
+Not re-run: rerank-depth / `k1`,`b` / `RRF_K` re-tuning — the bars are cleared
+and each was tuned on this golden set.
 
 ## M4 — Agent graph
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks benchmark-ann-index sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-insufficient-context-gate tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -23,7 +23,9 @@ help:
 	@echo "  check-embedding-input-length - M3-02: tokenise build/chunks.jsonl with the pinned embedding model and check every chunk fits its input window"
 	@echo "  load-chunks       - M3-02: upsert build/chunks.jsonl into the chunk table (idempotent; needs Postgres + make migrate)"
 	@echo "  embed-chunks      - M3-02: embed every chunk still missing a vector with the local sentence-transformers model (depends on load-chunks; runs the optional embed uv group; writes eval/runs/embedding_cost_report.{md,json})"
+	@echo "  build-index       - M3-08: end-to-end reproducible index build: raw PDFs -> parse -> chunk -> Postgres -> embeddings (composes parse/build-chunks/migrate/load-chunks/embed-chunks; needs the same LLM_* env + tesseract as make parse, and a running Postgres; the parse stage is skipped when build/parsed_clauses.jsonl already exists)"
 	@echo "  benchmark-ann-index - M3-02: build the HNSW index against TEST_DATABASE_URL and measure build time, size, exact-vs-ANN latency and filtered result counts (synthetic vectors; writes eval/runs/ann_index_benchmark.{md,json})"
+	@echo "  benchmark-ann-index-real - M3-08: the ANN-earns-its-place A/B on the REAL embeddings in DATABASE_URL - HNSW recall@10 vs exact + latency, all inside a rolled-back transaction (runs the optional embed uv group; writes eval/runs/ann_index_benchmark_real.{md,json})"
 	@echo "  sample-parsing-quality - Draw the M1-08 stratified 50-clause sample"
 	@echo "  validate-parsing-quality-sample - Automated LLM validation of the M1-08b sample (fills judgment columns)"
 	@echo "  score-parsing-quality  - Score the annotated M1-08 sample and write eval/parsing_quality_results.md"
@@ -51,6 +53,7 @@ help:
 	@echo "  eval-retrieval-hybrid - M3-04: score the hybrid (RRF fusion of lexical+dense) retriever with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement as eval-retrieval-dense; pass --fusion weighted / --filter none on the script for the comparison); writes eval/runs/retrieval_eval_hybrid_*.{md,json}. Comparison and verdict: docs/HYBRID_RETRIEVAL.md"
 	@echo "  eval-retrieval-rerank - M3-05: score hybrid RRF + cross-encoder rerank with the SUSEP-process+CNPJ pre-filter at the chosen candidate depth (same Postgres + embed-group requirement); writes eval/runs/retrieval_eval_hybrid_rrf_rerank_filter-default.{md,json}. Verdict: docs/RERANKING.md"
 	@echo "  eval-retrieval-co-retrieval - M3-06: score hybrid RRF + rerank + exclusion co-retrieval with the SUSEP-process+CNPJ pre-filter (same Postgres + embed-group requirement); reserves top-k slots for the exclusion clauses linked to each retrieved coverage clause; writes eval/runs/retrieval_eval_hybrid_rrf_rerank_co-retrieval_filter-default.{md,json}. Rule: docs/ARCHITECTURE.md; measurement: docs/EXCLUSION_CO_RETRIEVAL.md"
+	@echo "  eval-retrieval-matrix - M3-08: run every retrieval configuration (lexical / dense / hybrid RRF / +rerank / +co-retrieval / weighted+rerank+co-retrieval) on the SUSEP-process+CNPJ path in one pass, with per-query latency (same Postgres + embed-group requirement); writes eval/runs/retrieval_benchmark_matrix.{md,json}. Committed table and verdict: docs/RETRIEVAL_BENCHMARK.md"
 	@echo "  eval-insufficient-context-gate - M3-07: calibrate the insufficient-context gate on retrieval signals over the 23 unanswerable golden questions (hybrid RRF + rerank, SUSEP-process+CNPJ filter; same Postgres + embed-group requirement); sweeps the abstain threshold, reports precision/recall + the false-negative cases; writes eval/runs/insufficient_context_gate.{md,json} + the committed snapshot eval/insufficient_context_gate_signals.json. Verdict: docs/INSUFFICIENT_CONTEXT_GATE.md"
 	@echo "  tune-reranking    - M3-05: sweep the reranker candidate depth on the golden set and record the metrics + latency curve (same Postgres + embed-group requirement); writes eval/runs/rerank_tuning.{md,json}. Curve and chosen depth: docs/RERANKING.md"
 	@echo "  tune-exclusion-co-retrieval - M3-06: sweep the reserved exclusion-slot count on the golden set (pure-Python replay over one cached rerank pass; same Postgres + embed-group requirement for that pass); writes eval/runs/exclusion_co_retrieval_tuning.{md,json}. Curve and chosen count: docs/EXCLUSION_CO_RETRIEVAL.md"
@@ -112,8 +115,23 @@ load-chunks:
 embed-chunks: load-chunks
 	PYTHONPATH=app/src uv run --group embed python scripts/embed_chunks.py
 
+# M3-08: the whole index, reproducibly, from raw PDFs. Needs the same
+# environment as `make parse` (LLM_* in .env, tesseract) plus a running
+# Postgres. The file prerequisite skips the expensive parse stage (OCR + LLM
+# classification + vision escalation) when build/parsed_clauses.jsonl is already
+# there; build-chunks still runs but is cache-served, and load-chunks /
+# embed-chunks are idempotent / short-circuiting, so a re-run is cheap.
+build/parsed_clauses.jsonl:
+	$(MAKE) parse
+
+build-index: build/parsed_clauses.jsonl build-chunks check-embedding-input-length migrate load-chunks embed-chunks
+	@echo "build-index: raw -> parsed clauses -> chunks -> Postgres -> embeddings. Index ready for 'make eval-retrieval-matrix'."
+
 benchmark-ann-index:
 	PYTHONPATH=app/src uv run python scripts/benchmark_ann_index.py
+
+benchmark-ann-index-real:
+	PYTHONPATH=app/src uv run --group embed python -m scripts.benchmark_ann_index --real-embeddings
 
 sample-parsing-quality:
 	PYTHONPATH=app/src uv run python scripts/sample_parsing_quality.py
@@ -211,6 +229,9 @@ eval-retrieval-rerank:
 
 eval-retrieval-co-retrieval:
 	PYTHONPATH=app/src uv run --group embed python scripts/eval_retrieval.py --retriever hybrid --filter default --rerank --co-retrieval
+
+eval-retrieval-matrix:
+	PYTHONPATH=app/src uv run --group embed python -m scripts.benchmark_retrieval_matrix
 
 eval-insufficient-context-gate:
 	PYTHONPATH=app/src uv run --group embed python -m scripts.eval_insufficient_context_gate

--- a/README.md
+++ b/README.md
@@ -83,11 +83,20 @@ and the sync-vs-async engine decision.
 
 ### Index the corpus
 
-With the database migrated and `build/chunks.jsonl` in place (from `make
-build-chunks`, or `make fetch-corpus-artifacts` for the pre-built corpus):
+One command rebuilds the whole searchable index from `data/policies/raw/`:
 
 ```bash
-make load-chunks     # upsert the chunk corpus into Postgres
+make build-index     # parse -> chunk -> Postgres -> embeddings
+```
+
+It needs the same environment as `make parse` (the `LLM_*` keys in `.env`, plus
+Tesseract) and a running Postgres. When `build/parsed_clauses.jsonl` is already
+present — from an earlier `make parse` or `make fetch-corpus-artifacts` — the
+parse stage is skipped and the rest runs from cache. The manual breakdown of the
+last two steps:
+
+```bash
+make load-chunks     # upsert the chunk corpus into Postgres (idempotent)
 make embed-chunks    # embed the chunks; installs the optional `embed` group on first run
 ```
 
@@ -96,6 +105,10 @@ dollar cost is **$0.00** — no API key needed. A cold pass over the ~4,540-chun
 corpus is ~41 min of CPU time on an AMD Ryzen 5 5600H (a few minutes on a GPU);
 re-runs are served from an on-disk cache and do zero inference. See
 [`docs/EMBEDDINGS.md`](docs/EMBEDDINGS.md).
+
+Score every retrieval configuration on the golden set with
+`make eval-retrieval-matrix` — the committed comparison table and verdict are in
+[`docs/RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md).
 
 ### Pre-commit hooks
 

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -391,6 +391,43 @@ penalty that has to be measured and tuned. The definition stays in
 is one call away when the corpus grows (~10× is where exact scan starts to
 hurt); it does not go into the schema now.
 
+## Does the ANN index earn its place? Second measurement, real embeddings (2026-08-30, [M3-08])
+
+The measurement above rested on synthetic vectors — its recall number (0.448)
+"does not transfer". `make benchmark-ann-index-real`
+(`scripts/benchmark_ann_index.py --real-embeddings`) closes that gap: it builds
+the HNSW index on the **real 4,540 `chunk.embedding` vectors** already in
+`DATABASE_URL` and measures it against the **117 real `golden-set-v1` query
+vectors**, inside a single transaction that is rolled back — the dev database is
+left untouched, with no `ix_chunk_embedding_hnsw`. Regenerable output:
+`eval/runs/ann_index_benchmark_real.{md,json}` (gitignored).
+
+| measurement | synthetic (above, 2026-08-28) | **real (2026-08-30)** |
+| --- | ---: | ---: |
+| `CREATE INDEX` wall time | ~0.8 s | **0.39 s** |
+| index size | ~9 MB (0.69× the table) | **8.8 MB (0.45× the table)** |
+| exact `<=>`, full corpus, no index | p50 ~11.4 ms | p50 **9.8 ms** |
+| exact `<=>`, single partition, no index | p50 ~0.6 ms | p50 **0.58 ms** |
+| HNSW, full corpus | p50 ~0.8 ms | p50 **0.62 ms** |
+| HNSW available, single partition | p50 ~0.6 ms (planner chose btree) | p50 **0.55 ms (planner chose btree)** |
+| HNSW recall@10 vs. exact, full corpus | 0.448 *(synthetic — does not transfer)* | **0.9932** |
+
+The two are **not one series** — the synthetic run's recall was noise; the real
+one is the number. Everything else confirms the synthetic run: build time, index
+size and latency are structural and transferred as [M3-02] predicted.
+
+**Verdict: unchanged. The HNSW index still does not earn its place — and
+[M3-08]'s `make build-index` does not call `create_hnsw_index`.** Real recall is
+99.3%, not 44.8%, but that only matters on a path the system does not use. The
+default retrieval path is filtered to one SUSEP process + CNPJ, and there the
+planner reads the `(susep_process, cnpj)` btree partition and sorts it exactly
+in 0.55 ms — plan `Bitmap Heap Scan`, never the HNSW index, *whether or not the
+index exists*. The index only speeds the unfiltered full-corpus scan
+(9.8 → 0.62 ms), which is a degradation mode ([M3-04] item 5), not the default.
+Against a real, non-zero recall penalty (0.7%), 8.8 MB and a build step, on a
+path nobody takes: no. The [M3-08] benchmark matrix (`docs/RETRIEVAL_BENCHMARK.md`)
+records this alongside the four-configuration comparison.
+
 ## Filtered search and the fewer-than-`k` question
 
 Whether a metadata-filtered vector search can return fewer than `k` rows, and
@@ -440,12 +477,14 @@ index artifact rather than a property of the retriever. See
 
 ## Still deferred in [M3-02]
 
-Two items remain open:
+One item remains open:
 
 - **Stale vector on a changed `embedded_text`** ("What it does *not* fix" above)
   — a chunk whose text changes under a stable `chunk_id` keeps its old vector.
   Needs a stored content hash or a null-on-change step.
-- **The ANN-earns-its-place check on *real* embeddings** — the verdict above
-  rests on latency and synthetic vectors. [M3-08]'s benchmark matrix re-runs it
-  on the real embeddings and settles whether `make build-index` should call
-  `create_hnsw_index`.
+
+**Closed (2026-08-30, [M3-08]):** the ANN-earns-its-place check on *real*
+embeddings — see "Does the ANN index earn its place? Second measurement" above.
+Real HNSW recall@10 vs. exact is 0.9932, but the verdict is unchanged: the
+default filtered path never routes through the index, so `make build-index` does
+not build it.

--- a/docs/EXCLUSION_CO_RETRIEVAL.md
+++ b/docs/EXCLUSION_CO_RETRIEVAL.md
@@ -268,9 +268,11 @@ coverage, and it can only do that for exclusions retrieval actually returned.
 ## Deferred / handed to later issues
 
 - The lexical / dense / hybrid / hybrid+rerank+co-retrieval **benchmark
-  matrix** and `make build-index` — [M3-08].
+  matrix** and `make build-index` — done: [M3-08], `docs/RETRIEVAL_BENCHMARK.md`.
+  The committed best config is this one (Recall@10 92.3%, exclusion recall 100%).
 - Coverage-clause recall on the `coverage_with_exclusion` subset — base
-  retrieval tuning, [M3-08] or later.
+  retrieval tuning, not re-run by [M3-08] (bars cleared); a future issue or
+  golden-set-v2.
 - M4's retrieval node constructs its own `ExclusionCoRetrievalRetriever` with a
   `reserved_slots` sized for its context budget; the config constant is the
   default and the golden-set-validated value.

--- a/docs/HYBRID_RETRIEVAL.md
+++ b/docs/HYBRID_RETRIEVAL.md
@@ -228,6 +228,14 @@ pre-commitment against post-hoc cherry-picking; the deviation is on reasons
 strategies remain one flag apart (`--fusion weighted`). [M3-08] re-opens this
 with reranking in the matrix.
 
+**Resolved by [M3-08] (2026-08-30):** with the reranker *and* exclusion
+co-retrieval in the loop, RRF wins **every** metric — Recall@10 92.3 vs 89.3,
+MRR 80.6 vs 80.4, nDCG 82.3 vs 81.1, exclusion recall 100% vs 96.3%. The
+reranker erased weighted's fusion-stage MRR edge (both ~80.5); what remained was
+weighted's weaker *candidate set*, which the reranker cannot recover from. The
+deviation above is now a measured result. Full comparison:
+`docs/RETRIEVAL_BENCHMARK.md`.
+
 ### DoD item 4 — cross-document errors are eliminated
 
 The 16 `cross_document` questions each target a document whose same-insurer
@@ -296,9 +304,11 @@ strict drops it) and `tests/unit/infrastructure/rag/test_retrieval_filter.py`.
   That one-off rebuilt BM25 per single-document index, sharpening IDF; the
   proper filtered lexical number with corpus-wide IDF is **87.2%**. Still
   clears 0.85; the 6-point gap is the IDF effect, not a regression.
-- **`fusion_weights` are untuned** at `(0.5, 0.5)`. Weighted fusion already
-  beats RRF on MRR/nDCG untuned; a tilt was not explored — [M3-08]'s, with the
-  reranker in the loop.
+- **`fusion_weights` are untuned** at `(0.5, 0.5)`. Weighted fusion beats RRF on
+  MRR/nDCG at the fusion stage untuned; a tilt was not explored. [M3-08] settled
+  the fusion choice (RRF, with the reranker in the loop — see "Resolved by
+  [M3-08]" above) without a weight sweep, since the deciding factor turned out
+  to be weighted's weaker candidate *set*, not its weighting.
 
 ---
 
@@ -314,7 +324,8 @@ strict drops it) and `tests/unit/infrastructure/rag/test_retrieval_filter.py`.
   every filtered partition returns a full `k` and the rank-1 reranked score
   carries the decision.
 - **The lexical / dense / hybrid / hybrid+rerank benchmark matrix and `make
-  build-index`** — [M3-08], which also re-opens the RRF-vs-weighted call with
-  reranking in the mix and re-runs the ANN-earns-its-place check on real
-  embeddings.
+  build-index`** — done: [M3-08], `docs/RETRIEVAL_BENCHMARK.md`. It re-opened
+  the RRF-vs-weighted call with reranking in the mix (RRF wins — see "Resolved
+  by [M3-08]" above) and re-ran the ANN-earns-its-place check on real embeddings
+  (recall 0.9932, verdict unchanged — `docs/EMBEDDINGS.md`).
 - **A DB-side lexical column** — still declined (see Scope).

--- a/docs/INSUFFICIENT_CONTEXT_GATE.md
+++ b/docs/INSUFFICIENT_CONTEXT_GATE.md
@@ -314,4 +314,5 @@ answer before it starts, and on the evidence available it does.
   cannot be *evaluated* (as opposed to calibrated) without one.
 - **A real query-intent classifier** to replace the `needs_verified_instance_value`
   keyword heuristic — future work, most naturally alongside M4's intake node.
-- **The four-configuration benchmark matrix** — [M3-08].
+- **The four-configuration benchmark matrix** — done: [M3-08],
+  `docs/RETRIEVAL_BENCHMARK.md`.

--- a/docs/LEXICAL_RETRIEVAL.md
+++ b/docs/LEXICAL_RETRIEVAL.md
@@ -300,9 +300,9 @@ the bottleneck.
   reuses this module's `TextAnalyzer` unchanged and may key a cache on
   `config_fingerprint()`. No cache in this issue — the index builds in ~3 s.
 - **Hybrid fusion (RRF), metadata pre-filtering** — [M3-04].
-- **The lexical-vs-dense-vs-hybrid benchmark matrix** — [M3-08].
-- **`make build-index`** — [M3-08]; `make eval-retrieval-lexical` is composable
-  into it.
+- **The lexical-vs-dense-vs-hybrid benchmark matrix** and **`make build-index`**
+  — done: [M3-08], `docs/RETRIEVAL_BENCHMARK.md`. Filtered lexical Recall@10 is
+  87.2% in the matrix (the committed baseline here is `--filter none`, 58.7%).
 
 ## Limitations
 

--- a/docs/RERANKING.md
+++ b/docs/RERANKING.md
@@ -315,12 +315,18 @@ evidence. A dated `[M3-05]` note is added to `MILESTONES.md`'s M3 section.
 ## Deferred / handed to later issues
 
 - **The lexical / dense / hybrid / hybrid+rerank benchmark matrix and
-  `make build-index`** — [M3-08], which also re-opens the RRF-vs-weighted fusion
-  call now that the reranker exists.
+  `make build-index`** — done: [M3-08], `docs/RETRIEVAL_BENCHMARK.md`. It also
+  re-opened the RRF-vs-weighted fusion call with the reranker in the loop (RRF
+  wins every metric — 92.3 vs 89.3 Recall@10) and confirmed at depth 10 the
+  reranked+co-retrieval best config clears both M3 bars (Recall@10 92.3%, MRR
+  80.6%).
 - **Exclusion co-retrieval** (pull the exclusion linked to every retrieved
   coverage clause) — [M3-06]. `coverage_with_exclusion` is the weakest question
   type and reranking does not fix it — it can only reorder what retrieval found.
 - **The insufficient-context gate** on the retrieval signals — [M3-07] (done:
   `docs/INSUFFICIENT_CONTEXT_GATE.md`; the gate reads the rank-1 reranked score
   this stage produces).
-- **BM25 `k1`/`b` and RRF `k` tuning with the reranker in the loop** — [M3-08].
+- **BM25 `k1`/`b` and RRF `k` tuning with the reranker in the loop** — not
+  re-run by [M3-08]: the M3 bars are cleared and each value was tuned on this
+  same golden set. The `make tune-*` targets remain for a changed corpus or
+  golden-set-v2.

--- a/docs/RETRIEVAL_BENCHMARK.md
+++ b/docs/RETRIEVAL_BENCHMARK.md
@@ -1,0 +1,346 @@
+# Retrieval benchmark matrix
+
+The [M3-08] consolidation: every retrieval configuration built across M3, scored
+on `golden-set-v1` through one harness, in one table, with the exact config
+behind each row and a reproducible build path. The runner is
+`scripts/benchmark_retrieval_matrix.py` (`make eval-retrieval-matrix`); this
+document is the committed table, the per-question-type analysis, and the
+verdict.
+
+**Scope.** This issue produces the comparison table and `make build-index`. It:
+
+- runs **lexical only / dense only / hybrid RRF / hybrid RRF + rerank / hybrid
+  RRF + rerank + co-retrieval** on the `--filter default` SUSEP-process + CNPJ
+  path — the system's real retrieval path (`docs/HYBRID_RETRIEVAL.md`);
+- adds one row, **hybrid weighted + rerank + co-retrieval**, to re-open the
+  RRF-vs-weighted fusion call `docs/HYBRID_RETRIEVAL.md` deferred here, now with
+  the reranker and co-retrieval in the loop;
+- re-runs the **ANN-earns-its-place A/B on the real embeddings** (M3-02 measured
+  synthetic vectors only) — full method and numbers in `docs/EMBEDDINGS.md`,
+  summarised here;
+- implements **`make build-index`** end to end.
+
+It does **not**:
+
+- re-run every configuration unfiltered — the unfiltered degradation table stays
+  in `docs/HYBRID_RETRIEVAL.md` (the pre-filter is the default path, not an
+  optimisation);
+- re-tune the reranker candidate depth, BM25 `k1`/`b` or the RRF constant with
+  the full pipeline in the loop — the M3 exit bars are cleared and each value
+  was tuned on this same golden set (`docs/RERANKING.md`,
+  `docs/LEXICAL_RETRIEVAL.md`, `docs/HYBRID_RETRIEVAL.md`); the `make tune-*`
+  targets do this if a later issue wants it;
+- broaden scorable golden-set coverage past CASCO / CARTA VERDE — new authoring
+  ([M2], golden-set-v2).
+
+---
+
+## Method
+
+### The harness
+
+`scripts/benchmark_retrieval_matrix.py` drives the [M2-06] harness exactly as
+`scripts/tune_reranking.py` does: one `argparse.Namespace` per configuration,
+`_open_retriever` builds the leg → fusion → rerank wrapper → co-retrieval
+wrapper, a timing proxy wraps `retrieve()`, and `evaluate_questions` scores it.
+No metric code is re-implemented. Every configuration is scored on the same
+117 scorable questions (the 23 `unanswerable` carry no reference clauses and are
+excluded from every ranking metric — `docs/EVALUATION.md`); all reference CASCO
+(114) or CARTA VERDE (3) documents, all `text` extraction mode.
+
+Output: `eval/runs/retrieval_benchmark_matrix.{md,json}` (regenerable,
+gitignored), each row stamped with its `RetrievalRunConfig` and every
+`config_fingerprint()`. The committed numbers are transcribed below.
+
+### The `make eval-retrieval` deviation
+
+The M3-08 DoD says `make build-index && make eval-retrieval` reproduces the
+committed numbers. `make eval-retrieval` is the [M2-06] random self-test
+(`tests/eval/test_retrieval_eval_collapse.py`, `docs/EVALUATION.md` both depend
+on it), so the matrix is realised as **`make eval-retrieval-matrix`** — a
+new target, not a repurposed one. Recorded here and in `MILESTONES.md` per the
+repo's state-every-deviation convention.
+
+### Latency and cost
+
+The latency column is per-query `retrieve()` wall-clock over the 117 questions
+on the dev machine (AMD Ryzen 5 5600H; RTX 3050 for model scoring), **embedding
+and reranker caches warm** — so it is the retrieval-machinery cost with the
+model passes served from cache. It is complete for `lexical` / `dense` /
+`hybrid` (no model, or the cached query vector), and for the reranked rows it is
+the machinery around a cached cross-encoder. The **cold model costs are additive
+and measured elsewhere**:
+
+- the query embedder — one short-query forward pass through
+  `gte-multilingual-base` (`docs/EMBEDDINGS.md`); a few tens of ms, cached here
+  (every `golden-set-v1` query vector is already on disk);
+- the CPU cross-encoder at depth 10 — **~9.7 s/query p50** (`docs/RERANKING.md`),
+  the number that rules it out of an interactive path; the eval runs it on the
+  GPU (~2 min for the whole golden set) and the cache makes every re-run a dict
+  lookup;
+- exclusion co-retrieval — pure structural lookup over the parsed corpus, `< 1 ms`.
+
+**Dollar cost per query: $0.00.** Both models run locally via
+sentence-transformers — no API, no per-token charge — so no price constant is
+introduced ([M1-09] stale-pricing rule). The reproducible cost is machine time.
+
+---
+
+## Pre-registered prediction
+
+The four core configurations and the co-retrieval row were each measured and
+their predictions pre-registered in [M3-03] / [M3-04] / [M3-05] / [M3-06]; this
+matrix confirms they reproduce under one harness (prediction: **exact
+reproduction** — retrieval is deterministic) and adds the cross-configuration
+latency. The two genuinely new questions are predicted here, unedited:
+
+> **Fusion.** Weighted score fusion keeps a small MRR / R@1 edge over RRF even
+> with the reranker and co-retrieval on top — the reranker reorders the top-`k`
+> but cannot fully erase the better top-rank ordering weighted's normalised
+> score fusion produced at the fusion stage (`docs/HYBRID_RETRIEVAL.md`: MRR
+> 83.1 vs 78.8). RRF wins or ties Recall@10. Net call: **keep RRF** as
+> `DEFAULT_FUSION_STRATEGY` — Recall@10 is M3's exit metric and feeds the LLM
+> context, and the reranker captures most of weighted's top-rank advantage
+> anyway.
+>
+> **ANN.** HNSW recall@10 vs. exact on the real embeddings is **≥ 0.95** — real
+> vectors have cluster structure, unlike the 0.448 the synthetic-vector M3-02
+> benchmark measured. The planner still reads the `(susep_process, cnpj)` btree
+> partition for the default filtered path and never touches the index.
+> `make build-index` does **not** call `create_hnsw_index`.
+
+---
+
+## Outcome (2026-08-30)
+
+`make eval-retrieval-matrix` →
+`eval/runs/retrieval_benchmark_matrix.{md,json}`. Embedding
+`7ea39a621eaee88e`, hybrid RRF `279ed8ee0a668227`, lexical `ef0a2dd0c1dfb4e4`,
+reranker `777c0503f1073d52` (depth 10), co-retrieval `7ed4c97c4e8f1cb4`
+(1 slot). Run twice: every Recall / MRR / nDCG / exclusion number is
+byte-identical across runs.
+
+### The matrix
+
+| configuration | R@1 | R@5 | R@10 | MRR | nDCG@10 | exclusion recall | foreign-doc | latency ms (p50 / mean, warm) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| random (self-test) | 0.0% | 0.0% | 0.0% | 0.0% | 0.0% | 0.0% (0/27) | 95.9% | 0.0 / 0.0 |
+| lexical | 62.9% | 83.4% | 87.2% | 79.0% | 78.5% | 85.2% (23/27) | 0.0% | 12.8 / 13.0 |
+| dense | 56.8% | 79.0% | 84.3% | 71.8% | 73.3% | 70.4% (19/27) | 0.0% | 1.4 / 1.8 |
+| hybrid RRF | 64.5% | 83.6% | 91.5% | 78.8% | 80.3% | 92.6% (25/27) | 0.0% | 17.5 / 18.0 |
+| hybrid RRF + rerank | 65.8% | 86.9% | 91.5% | 80.6% | 82.0% | 92.6% (25/27) | 0.0% | 17.3 / 17.5 |
+| **hybrid RRF + rerank + co-retrieval** | **65.8%** | **87.3%** | **92.3%** | **80.6%** | **82.3%** | **100.0% (27/27)** | **0.0%** | 18.0 / 18.3 |
+| hybrid weighted + rerank + co-retrieval | 66.2% | 86.0% | 89.3% | 80.4% | 81.1% | 96.3% (26/27) | 0.0% | 17.8 / 18.2 |
+
+Every filtered configuration clears M3's Recall@10 ≥ 0.85 bar. The best
+configuration, **hybrid RRF + rerank + exclusion co-retrieval**, clears both:
+**Recall@10 92.3%, MRR 80.6%** (bars 0.85 / 0.60). The four core rows reproduce
+their [M3-03] / [M3-04] / [M3-05] committed numbers exactly.
+
+### By question type — Recall@10 and MRR
+
+| question_type | metric | lexical | dense | hybrid RRF | + rerank | + rerank + co-retrieval | weighted + rerank + co-retrieval |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `direct_lookup` (n=64) | R@10 | 90.6% | 91.7% | 95.3% | 95.3% | **95.3%** | 93.8% |
+| | MRR | 76.3% | 78.5% | 80.7% | 85.1% | **85.1%** | 84.8% |
+| `coverage_with_exclusion` (n=19) | R@10 | 73.7% | 63.2% | 78.9% | 78.9% | **84.2%** | 76.3% |
+| | MRR | 87.7% | 58.2% | 68.2% | 64.8% | **65.3%** | 66.1% |
+| `cross_document` (n=16) | R@10 | 93.8% | 87.5% | 93.8% | 93.8% | **93.8%** | 87.5% |
+| | MRR | 78.1% | 81.2% | 82.1% | 80.2% | **80.2%** | 78.1% |
+| `definition` (n=18) | R@10 | 83.3% | 77.8% | 88.9% | 88.9% | **88.9%** | 88.9% |
+| | MRR | 80.6% | 53.9% | 80.4% | 81.5% | **81.5%** | 81.5% |
+
+**Which configuration wins where, and why:**
+
+- **`direct_lookup` (55% of the scored set) — hybrid RRF, then the reranker.**
+  Fusion lifts Recall@10 90.6 / 91.7 → 95.3 (each leg rescues the other's
+  misses); the cross-encoder then lifts MRR 80.7 → 85.1 by reading the query and
+  the exact-term clause together. Co-retrieval is inert here (these questions
+  retrieve coverage clauses, but the eviction rule only ever drops a
+  non-reference supporting clause).
+- **`coverage_with_exclusion` (the hard type) — co-retrieval is decisive.**
+  Recall@10 78.9 → 84.2 and pooled exclusion-clause recall 92.6% → **100%
+  (27/27)**: the two exclusion references the reranked base missed are the two
+  co-retrieval injects (`docs/EXCLUSION_CO_RETRIEVAL.md`). The reranker slightly
+  *lowers* this type's MRR (68.2 → 65.3) — a fluent coverage clause scores above
+  the terse exclusion that limits it, the documented [M3-05] effect — but that
+  is top-rank ordering, not presence: the DoD metric (is the exclusion in the
+  top-10 at all) goes to 100%. Note lexical's high MRR here (87.7%) against a low
+  Recall@10 (73.7%): when BM25 finds a cov+excl reference it ranks it near the
+  top, but it misses more of them than the hybrid does.
+- **`cross_document` and `definition` — fusion saturates them; rerank and
+  co-retrieval leave Recall@10 untouched.** RRF already reaches 93.8% / 88.9%;
+  the reranker nudges MRR ~2 pt either way (`definition` +1.1, `cross_document`
+  −1.9 — the cross-encoder can demote the right clause on a two-document
+  question) and Recall@10 not at all.
+- **Nowhere does `dense` alone win.** Filtered BM25 is the stronger single leg on
+  every type except `direct_lookup` (where dense edges it 91.7 vs 90.6) — the
+  same reversal of the pre-registered prediction `docs/HYBRID_RETRIEVAL.md`
+  records.
+
+### Prediction vs actual
+
+| prediction | actual | call |
+| --- | --- | --- |
+| Four core configs reproduce their committed per-stage numbers exactly | lexical 87.2 / dense 84.3 / hybrid RRF 91.5 / +rerank 91.5, MRR 80.6 — identical to [M3-03]/[M3-04]/[M3-05], byte-identical across two matrix runs | **held** |
+| Weighted fusion keeps a small MRR / R@1 edge over RRF with the reranker on top; RRF wins/ties Recall@10; keep RRF | **RRF wins every metric**: Recall@10 92.3 vs 89.3 (**+3.0 pt**), MRR 80.6 vs 80.4, nDCG 82.3 vs 81.1, exclusion recall 100% vs 96.3%. The reranker fully erased weighted's fusion-stage MRR edge (both ~80.5), and weighted's worse candidate *set* costs it 3 pt of Recall@10 | **missed** — the "keep RRF" conclusion holds, but for a stronger reason: with the reranker in the loop there is no trade-off left to weigh |
+| Real-embedding HNSW recall@10 vs. exact ≥ 0.95; planner still btree; no index in build-index | **0.9932**; the filtered path plan is `Bitmap Heap Scan` (btree partition), not the HNSW index | **held** |
+
+---
+
+## RRF vs. weighted fusion — resolved
+
+`docs/HYBRID_RETRIEVAL.md` kept RRF over weighted at the fusion stage as a
+**stated deviation** from its pre-registered rule ("pick weighted if it wins MRR
+by > 2 pt"; weighted won MRR by 4.3 pt), on the argument that Recall@10 matters
+more and the reranker would capture weighted's top-rank advantage. [M3-08] tests
+that argument directly, with the reranker and co-retrieval both in the loop:
+
+| | RRF + rerank + co-retrieval | weighted + rerank + co-retrieval |
+| --- | ---: | ---: |
+| Recall@10 | **92.3%** | 89.3% |
+| MRR | **80.6%** | 80.4% |
+| nDCG@10 | **82.3%** | 81.1% |
+| exclusion-clause recall | **100.0% (27/27)** | 96.3% (26/27) |
+
+**Verdict: keep RRF; `DEFAULT_FUSION_STRATEGY` unchanged.** The reranker did
+exactly what `docs/HYBRID_RETRIEVAL.md` predicted it would — it erased weighted's
+MRR edge (80.6 vs 80.4, was 83.1 vs 78.8 before reranking). What is left is
+weighted's *weaker candidate set*: it feeds the reranker a top-100 that is 3
+points worse on Recall@10 and one exclusion clause short, and the reranker
+cannot recover a clause that was never fused in. The M3-04 deviation is now a
+measured result, not an argument.
+
+---
+
+## `make build-index`
+
+`make build-index` rebuilds the full searchable index from `data/policies/raw/`:
+
+```
+build/parsed_clauses.jsonl (make parse)  →  build-chunks  →  check-embedding-input-length
+  →  migrate  →  load-chunks  →  embed-chunks
+```
+
+It needs the same environment as `make parse` — the `LLM_*` keys in `.env` (the
+clause classifier) and Tesseract (OCR for the two text-layer-less documents) —
+plus a running Postgres. The `build/parsed_clauses.jsonl` prerequisite is a
+**file target**, so the expensive parse stage (OCR + LLM classification + the
+vision boundary pass) is **skipped when the parsed corpus is already present**;
+`build-chunks` still runs but is served from the classification cache, `migrate`
+is idempotent, `load-chunks` is an idempotent upsert by `chunk_id`, and
+`embed-chunks` exits before loading the model when no vector is missing — so a
+re-run of `make build-index` is cheap. `make fetch-corpus-artifacts` (the
+pre-built corpus + LLM caches, committed as `dist/corpus-artifacts.tar.gz`)
+provides `build/parsed_clauses.jsonl` for inspection, but `build-chunks` still
+constructs the classifier, so `LLM_*` must be set even then.
+
+`make build-index` stops at the **embedded, queryable Postgres table** (exact
+`<=>` search over the filtered partition). It does **not** create the HNSW index
+— see below.
+
+### The HNSW index does not earn its place, on the real embeddings either
+
+`make benchmark-ann-index-real` (full report: `docs/EMBEDDINGS.md`, dated second
+measurement) builds the HNSW index on the real 4,540 vectors inside a
+rolled-back transaction and measures it against the 117 real golden queries:
+
+| | synthetic (M3-02) | real ([M3-08]) |
+| --- | ---: | ---: |
+| `CREATE INDEX` | ~0.8 s | 0.39 s |
+| index size | ~9 MB (0.69× table) | 8.8 MB (0.45× table) |
+| HNSW recall@10 vs. exact, full corpus | 0.448 (does not transfer) | **0.9932** |
+| exact, single partition (the default path) | ~0.6 ms | 0.58 ms |
+| filtered-path plan with the index present | btree bitmap scan | **btree bitmap scan** |
+
+Real recall is 99.3%, not 44.8% — but the verdict is unchanged. The default
+retrieval path is filtered to one SUSEP process + CNPJ, and there the planner
+reads the `(susep_process, cnpj)` btree partition and sorts it exactly in
+~0.6 ms; it never touches the HNSW index, so on the path that matters the index
+is inert. It only speeds the *unfiltered* full-corpus scan (9.8 ms → 0.6 ms),
+which is a degradation mode, not the default. Against that: 8.8 MB, a build
+step, and a 0.7% recall penalty on a path nobody uses. The definition stays in
+`infrastructure.rag.ann_index` — one `create_hnsw_index` call away when the
+corpus grows ~10×.
+
+### Reproducibility and tolerance
+
+Verified locally (this is a manual measurement — CI runs no retrieval eval and
+never installs the `embed` group, as with every M3-03…07 doc). On a machine with
+`LLM_*` configured, Tesseract installed, and the `embed` uv group:
+
+```
+docker compose up -d postgres && make migrate
+make build-index          # from raw; skips the parse stage if build/parsed_clauses.jsonl exists
+make eval-retrieval-matrix
+```
+
+**Tolerance.** Retrieval is fully deterministic — BM25 with `doc_id` tie-breaks,
+exact `<=>` vector search, stable-sorted reranking, RRF / weighted fusion,
+structural co-retrieval — so every Recall / MRR / nDCG / exclusion number
+reproduces **exactly** given the same corpus and the pinned models on
+equivalent hardware. This was confirmed: two matrix runs produced byte-identical
+metrics. The one source of drift is fp32 rounding in the cross-encoder across
+different GPU / CPU hardware, which could reorder a borderline `(question,
+clause)` pair and move a reranked-configuration metric by **≤ ~1 question
+(≈ 0.9 pt at n = 117)**. The corpus itself reproduces byte-identical via
+`make fetch-corpus-artifacts` (`README.md`); a `make parse` from raw differs
+only on `build/manifest.json`'s `built_at_utc`. Latency is hardware-specific and
+reported with the machine. Cost is $0.00.
+
+---
+
+## Verdict
+
+**Ship hybrid RRF + cross-encoder rerank (depth 10) + exclusion co-retrieval (1
+reserved slot), over the SUSEP-process + CNPJ pre-filter.** On `golden-set-v1`:
+Recall@10 **92.3%**, MRR **80.6%**, nDCG@10 82.3%, exclusion-clause recall
+**100% (27/27)**, foreign-document rate **0.0%** — both M3 exit bars cleared,
+and the milestone's specific hard case (the exclusion clause three paragraphs
+from the coverage it cancels) handled: every exclusion reference in the golden
+set is retrieved.
+
+The pre-filter is the load-bearing decision — it takes every leg from below
+M3's bar to above it (`docs/HYBRID_RETRIEVAL.md`). On top of it, fusion buys ~4
+pt of Recall@10 over the better single leg, the reranker buys ~2 pt of MRR and
+~3 pt of R@5 (concentrated in `direct_lookup`), and co-retrieval closes the
+exclusion gap to zero. RRF beats weighted fusion once the reranker is in the
+loop, resolving the M3-04 deviation.
+
+---
+
+## Limitations
+
+- **Product-line coverage stays 2 of 5.** The 117 scorable questions reference
+  only CASCO (114) and CARTA VERDE (3); RCF-A, ASSIST and GAR.EST appear only
+  among the excluded `unanswerable` questions — the `golden-set-v1` limit
+  `docs/EVALUATION.md`, `docs/HYBRID_RETRIEVAL.md` and `docs/RERANKING.md` all
+  record. `by_product_line` is populated for 2 lines.
+- **Latency is a warm-cache, single-machine number.** It isolates the retrieval
+  machinery; the cold model costs are cited from `docs/EMBEDDINGS.md` and
+  `docs/RERANKING.md`, not re-derived. The CPU cross-encoder (~9.7 s/query)
+  makes the reranked configurations a batch-eval / GPU-serving tool, not an
+  interactive-path component as written — M4 picks its own serving hardware
+  (`docs/RERANKING.md`).
+- **The dense leg reads the dev database** and the models load locally; not
+  hermetic the way the file-based lexical eval is. The config fingerprints pin
+  the contract.
+- **`coverage_with_exclusion` top-rank precision is still soft** (MRR 65.3%).
+  Co-retrieval guarantees the exclusion is *present*; ordering it above the
+  fluent coverage clause is the reranker's job and it does the opposite. M4's
+  assessment node reads all `k`, so presence is what matters — but a smaller
+  context budget would expose this.
+
+---
+
+## Deferred / handed to later issues
+
+- **Re-tuning `RERANK_CANDIDATE_DEPTH` / BM25 `k1`,`b` / `RRF_K` with the full
+  pipeline in the loop** — the `make tune-*` targets do this; not re-run because
+  the M3 bars are cleared and each value was tuned on this same golden set. A
+  later issue with a changed corpus or golden-set-v2 should.
+- **Broadening scorable golden-set coverage** past CASCO / CARTA VERDE — new
+  authoring, golden-set-v2.
+- **The HNSW index** — one `create_hnsw_index` call away when the corpus grows
+  ~10× (`docs/EMBEDDINGS.md`).
+- **Wiring the [M3-07] insufficient-context gate into the graph** — [M4-04].

--- a/scripts/benchmark_ann_index.py
+++ b/scripts/benchmark_ann_index.py
@@ -54,6 +54,7 @@ from sqlalchemy.orm import Session
 
 from infrastructure.database import (
     create_engine_from_database_url,
+    create_engine_from_settings,
     create_session_factory,
 )
 from infrastructure.database.chunk_repository import (
@@ -61,6 +62,7 @@ from infrastructure.database.chunk_repository import (
     upsert_chunks,
     write_chunk_embeddings,
 )
+from infrastructure.evaluation.golden_set_schema import QuestionType
 from infrastructure.rag.ann_index import (
     HNSW_EF_CONSTRUCTION,
     HNSW_EF_SEARCH,
@@ -71,12 +73,18 @@ from infrastructure.rag.ann_index import (
 )
 from infrastructure.rag.chunk_artifact import CHUNKS_JSONL_PATH, read_chunks_jsonl
 from infrastructure.rag.chunk_schema import ChunkRecord
-from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS
+from infrastructure.rag.embedding_cache import CachingEmbedder
+from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS, format_query
+from infrastructure.rag.embedding_config import (
+    config_fingerprint as embedding_config_fingerprint,
+)
 
 SCHEMA_VERSION = "v1"
 OUTPUT_DIR = Path("eval/runs")
 JSON_PATH = OUTPUT_DIR / "ann_index_benchmark.json"
 MD_PATH = OUTPUT_DIR / "ann_index_benchmark.md"
+REAL_JSON_PATH = OUTPUT_DIR / "ann_index_benchmark_real.json"
+REAL_MD_PATH = OUTPUT_DIR / "ann_index_benchmark_real.md"
 
 VECTOR_SEED = 20260828
 QUERY_SEED = 920260828
@@ -575,6 +583,269 @@ def render_markdown_report(report: dict[str, Any]) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Real-embeddings A/B -- [M3-08]                                             #
+# --------------------------------------------------------------------------- #
+
+_REAL_CAVEAT = (
+    "**Real embeddings.** This runs against the `chunk.embedding` vectors "
+    "already in `DATABASE_URL` (from `make embed-chunks`) and the real "
+    "`golden-set-v1` query vectors -- so the ANN recall@k number here is the "
+    "one [M3-02]'s synthetic-vector benchmark could not produce. `CREATE "
+    "INDEX` and every measurement run inside a single transaction that is "
+    "**rolled back**: the dev database is left exactly as it was, with no "
+    "`ix_chunk_embedding_hnsw`."
+)
+
+
+def load_golden_query_vectors() -> list[tuple[str, str, list[float]]]:
+    """``(susep_process, cnpj, query_vector)`` for every scorable golden question.
+
+    The query embedder is lazy and wrapped in ``CachingEmbedder``; every golden
+    query vector is already in ``data/cache/embeddings/`` from prior dense runs,
+    so this does zero forward passes on a warm cache.
+    """
+    # Deferred so the synthetic ``make benchmark-ann-index`` stays path-runnable
+    # (this is the only ``scripts.*`` import, and ``--real-embeddings`` runs as
+    # ``python -m scripts.benchmark_ann_index``).
+    from scripts.eval_retrieval import (
+        GOLDEN_SET_DIR,
+        MANIFEST_PATH,
+        _load_query_embedder,
+        load_document_metadata,
+        load_golden_questions,
+    )
+
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    questions = [
+        question
+        for question in load_golden_questions(GOLDEN_SET_DIR)
+        if question.question_type is not QuestionType.UNANSWERABLE
+    ]
+    embedder = CachingEmbedder(_load_query_embedder())
+    vectors = embedder.embed([format_query(q.question) for q in questions])
+    return [
+        (
+            document_meta[question.document_id]["susep_process"],
+            document_meta[question.document_id]["cnpj"],
+            vector,
+        )
+        for question, vector in zip(questions, vectors, strict=True)
+    ]
+
+
+def measure_real_recall(
+    session: Session, query_vectors: Sequence[Sequence[float]]
+) -> float:
+    """Mean full-corpus HNSW recall@k vs. the exact top-k, per query.
+
+    The full-corpus ``ORDER BY <=> LIMIT k`` is the one path the planner routes
+    through the HNSW index; the default (filtered) path never touches it -- see
+    the plan check in :func:`run_real_embeddings`. The index must already be
+    built when this is called.
+    """
+    sql = f"SELECT chunk_id FROM chunk {_ORDER_BY_DISTANCE}"
+    recalls: list[float] = []
+    for vector in query_vectors:
+        params: dict[str, Any] = {"q": vector_literal(vector), "k": K}
+        session.execute(text("SET LOCAL enable_indexscan = off"))
+        session.execute(text("SET LOCAL enable_indexonlyscan = off"))
+        exact_ids = _topk_ids(session, sql, params)
+        _reset_planner_gucs(session)
+        apply_ann_search_gucs(session)
+        approx_ids = _topk_ids(session, sql, params)
+        recalls.append(recall_at_k(approx_ids, exact_ids))
+    return round(statistics.fmean(recalls), 4)
+
+
+def run_real_embeddings() -> None:
+    """The [M3-08] ANN-earns-its-place A/B on the real embeddings.
+
+    Connects to ``DATABASE_URL`` (not the test DB -- the real vectors live
+    there), reads the existing rows, and does everything inside one rolled-back
+    transaction.
+    """
+    queries = load_golden_query_vectors()
+    example_process, example_cnpj, example_vector = queries[0]
+    filter_params = {"susep_process": example_process, "cnpj": example_cnpj}
+
+    engine = create_engine_from_settings()
+    session = create_session_factory(engine=engine)()
+    try:
+        assert_chunk_table_ready(session)
+        total = session.execute(text("SELECT count(*) FROM chunk")).scalar_one()
+        embedded = session.execute(
+            text("SELECT count(*) FROM chunk WHERE embedding IS NOT NULL")
+        ).scalar_one()
+        if embedded == 0 or embedded != total:
+            raise RuntimeError(
+                f"{embedded}/{total} chunks embedded -- run `make embed-chunks` "
+                "first (this A/B needs every chunk's real vector)."
+            )
+        print(f"real-embeddings A/B: {total} chunks, all embedded", flush=True)
+
+        exact_full = measure_latency(
+            session, where="", base_params={}, query_vectors=[example_vector]
+        )
+        exact_partition = measure_latency(
+            session,
+            where=_DEFAULT_FILTER,
+            base_params=filter_params,
+            query_vectors=[example_vector],
+        )
+
+        build = build_and_measure_index(session)
+        apply_ann_search_gucs(session)
+        indexed_full = measure_latency(
+            session, where="", base_params={}, query_vectors=[example_vector]
+        )
+        indexed_partition = measure_latency(
+            session,
+            where=_DEFAULT_FILTER,
+            base_params=filter_params,
+            query_vectors=[example_vector],
+        )
+
+        recall_full = measure_real_recall(session, [v for _, _, v in queries])
+        filtered_plan = explain_scan(
+            session,
+            f"SELECT chunk_id FROM chunk WHERE {_DEFAULT_FILTER} {_ORDER_BY_DISTANCE}",
+            {**filter_params, "q": vector_literal(example_vector), "k": K},
+        )
+
+        config = AnnBenchmarkConfig(
+            schema_version=SCHEMA_VERSION,
+            run_at_utc=datetime.now(UTC),
+            corpus_path="DATABASE_URL/chunk (real embeddings)",
+            chunk_count=int(total),
+            partition_count=session.execute(
+                text("SELECT count(DISTINCT (susep_process, cnpj)) FROM chunk")
+            ).scalar_one(),
+            smallest_partition_size=session.execute(
+                text(
+                    "SELECT min(c) FROM (SELECT count(*) c FROM chunk "
+                    "GROUP BY susep_process, cnpj) s"
+                )
+            ).scalar_one(),
+            median_partition_size=0,
+            largest_partition_size=session.execute(
+                text(
+                    "SELECT max(c) FROM (SELECT count(*) c FROM chunk "
+                    "GROUP BY susep_process, cnpj) s"
+                )
+            ).scalar_one(),
+            hnsw_m=HNSW_M,
+            hnsw_ef_construction=HNSW_EF_CONSTRUCTION,
+            hnsw_ef_search=HNSW_EF_SEARCH,
+            synthetic_vectors=False,
+            vector_seed=0,
+            query_seed=0,
+            query_count=len(queries),
+            measure_iterations=MEASURE_ITERATIONS,
+            k=K,
+            platform=platform.platform(),
+            **server_versions(session),
+        )
+        report = {
+            "config": config.model_dump(mode="json"),
+            "caveat": _REAL_CAVEAT,
+            "embedding_config_fingerprint": embedding_config_fingerprint(),
+            "build": build,
+            "latency": {
+                "exact_full": exact_full,
+                "exact_partition": exact_partition,
+                "indexed_full": indexed_full,
+                "indexed_partition": indexed_partition,
+            },
+            "ann_recall_at_k_full_corpus": recall_full,
+            "filtered_path_plan": filtered_plan,
+        }
+    finally:
+        session.rollback()
+        session.close()
+        engine.dispose()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    REAL_JSON_PATH.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    REAL_MD_PATH.write_text(render_real_report(report), encoding="utf-8")
+    print(
+        f"real HNSW recall@{K} (full corpus) = {recall_full:.4f}; "
+        f"filtered path plan: {filtered_plan}"
+    )
+    print(f"Wrote {REAL_JSON_PATH} and {REAL_MD_PATH}")
+
+
+def render_real_report(report: dict[str, Any]) -> str:
+    """Render the real-embeddings A/B (numbers copied into docs/EMBEDDINGS.md)."""
+    config = report["config"]
+    build = report["build"]
+    latency = report["latency"]
+    return "\n".join(
+        [
+            "# ANN index benchmark -- real embeddings ([M3-08])",
+            "",
+            "Generated by `scripts/benchmark_ann_index.py --real-embeddings` "
+            "(`make benchmark-ann-index-real`). Regenerable; the committed "
+            "verdict lives in `docs/EMBEDDINGS.md` as a dated second measurement "
+            "and is summarised in `docs/RETRIEVAL_BENCHMARK.md`.",
+            "",
+            report["caveat"],
+            "",
+            "## Run configuration",
+            "",
+            f"- Corpus: {config['chunk_count']} real-embedded chunks, "
+            f"{config['partition_count']} `(susep_process, cnpj)` partitions "
+            f"(smallest {config['smallest_partition_size']}, largest "
+            f"{config['largest_partition_size']})",
+            f"- Embedding contract fingerprint: "
+            f"`{report['embedding_config_fingerprint']}`",
+            f"- HNSW: `m={config['hnsw_m']}`, "
+            f"`ef_construction={config['hnsw_ef_construction']}`, "
+            f"`ef_search={config['hnsw_ef_search']}`",
+            f"- Queries: {config['query_count']} real `golden-set-v1` query "
+            f"vectors; k={config['k']}",
+            f"- pgvector {config['pgvector_version']}; {config['postgres_version']}",
+            f"- Platform: {config['platform']}",
+            f"- Run at (UTC): {config['run_at_utc']}",
+            "",
+            "## Build time and index size",
+            "",
+            f"- `CREATE INDEX` wall time: **{build['build_seconds']:.3f} s**",
+            f"- Index size: **{build['index_size_pretty']}** "
+            f"({build['index_bytes']} bytes); index/table ratio "
+            f"{build['index_to_table_ratio']}",
+            "",
+            "## Latency: exact scan vs. HNSW",
+            "",
+            "| scope | p50 ms | p95 ms | mean ms | plan |",
+            "| --- | ---: | ---: | ---: | --- |",
+            _latency_row("exact, full corpus (no index)", latency["exact_full"]),
+            _latency_row(
+                "exact, single partition (no index)", latency["exact_partition"]
+            ),
+            _latency_row("with HNSW index, full corpus", latency["indexed_full"]),
+            _latency_row(
+                "with HNSW index, single partition", latency["indexed_partition"]
+            ),
+            "",
+            "## ANN recall vs. exact",
+            "",
+            f"- **HNSW recall@{config['k']} vs. exact, full corpus: "
+            f"{report['ann_recall_at_k_full_corpus']:.4f}** -- averaged over the "
+            f"{config['query_count']} real golden queries.",
+            f"- Default (filtered) retrieval path plan with the index present: "
+            f"`{report['filtered_path_plan']}` -- the planner reads the "
+            f"`(susep_process, cnpj)` btree partition and sorts it exactly; it "
+            f"does **not** touch the HNSW index, so the default path returns the "
+            f"exact top-{config['k']} whether the index exists or not "
+            f"(recall 1.0 by construction).",
+            "",
+        ]
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Entry point                                                                #
 # --------------------------------------------------------------------------- #
 
@@ -585,6 +856,14 @@ def _parse_args() -> argparse.Namespace:
         "--allow-nontest-db",
         action="store_true",
         help="run even if the target database name has no 'test' in it",
+    )
+    parser.add_argument(
+        "--real-embeddings",
+        action="store_true",
+        help=(
+            "[M3-08] A/B against the real vectors in DATABASE_URL (not the "
+            "synthetic-vector test-DB benchmark); all changes rolled back"
+        ),
     )
     return parser.parse_args()
 
@@ -602,6 +881,9 @@ def load_records() -> list[ChunkRecord]:
 def main() -> None:
     """Run the benchmark against the test database and write the report."""
     args = _parse_args()
+    if args.real_embeddings:
+        run_real_embeddings()
+        return
     url = resolve_test_database_url()
     assert_target_is_test_db(url, allow_nontest=args.allow_nontest_db)
     records = load_records()

--- a/scripts/benchmark_retrieval_matrix.py
+++ b/scripts/benchmark_retrieval_matrix.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Run the [M3-08] benchmark matrix: every retrieval configuration, one table.
+
+The M3-08 DoD asks to "run all four configurations on ``golden-set-v1``: lexical
+only, dense only, hybrid, hybrid + rerank (+ exclusion co-retrieval)" and
+"report Recall@1/5/10, MRR, nDCG@10, exclusion recall, mean latency and cost per
+query for each", broken down by question type. This script is the single driver
+that produces that comparison in one pass, so ``make build-index &&
+make eval-retrieval-matrix`` reproduces every committed number.
+
+It does **not** re-implement scoring -- it drives the [M2-06] harness
+(``scripts/eval_retrieval.py``) exactly as ``scripts/tune_reranking.py`` and
+``scripts/tune_exclusion_co_retrieval.py`` do: build an ``argparse.Namespace``
+per configuration, open the retriever via ``_open_retriever``, wrap it in a
+timing proxy, run ``evaluate_questions``. Every configuration runs on the
+**filtered default path** (SUSEP process + CNPJ), the system's real retrieval
+path (``docs/HYBRID_RETRIEVAL.md``); the unfiltered degradation numbers stay in
+that document.
+
+Two configurations beyond the DoD's four are included, both settled with the
+project owner:
+
+* ``hybrid RRF + rerank`` and ``hybrid RRF + rerank + co-retrieval`` are both
+  shown so the co-retrieval delta is visible; the second is the best
+  configuration.
+* ``hybrid weighted + rerank + co-retrieval`` re-opens the RRF-vs-weighted
+  fusion call ``docs/HYBRID_RETRIEVAL.md`` deferred here, now with the reranker
+  in the loop.
+
+A ``random`` reference row is included as in ``docs/HYBRID_RETRIEVAL.md``.
+
+**Latency + cost.** Per-query wall-clock of ``retrieve()`` over the 117 scorable
+questions, on this machine, reported p50 / p95 / mean (the
+``scripts/tune_reranking.summarise_latency`` shape). The embedding and reranker
+caches are warm, so the number is the warm-path cost; the doc decomposes the
+cold components (the query embedder, ``docs/EMBEDDINGS.md``; the CPU
+cross-encoder, ``docs/RERANKING.md``). Both models run locally, so the dollar
+cost per query is **$0.00** and no price constant is introduced -- the [M1-09]
+stale-pricing rule.
+
+Needs a running Postgres with loaded + embedded chunks and the optional ``embed``
+uv group (same as ``make eval-retrieval-hybrid``). Run via
+``make eval-retrieval-matrix``. Writes ``eval/runs/retrieval_benchmark_matrix.
+{md,json}`` (gitignored); the committed table and the verdict live in
+``docs/RETRIEVAL_BENCHMARK.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from infrastructure.evaluation.golden_set_schema import GoldenQuestion
+from infrastructure.evaluation.random_retriever import DEFAULT_SEED
+from infrastructure.evaluation.retrieval_run_schema import (
+    SCHEMA_VERSION as RUN_SCHEMA_VERSION,
+)
+from infrastructure.evaluation.retrieval_run_schema import RetrievalRunConfig
+from infrastructure.evaluation.retriever import FilterableRetriever, Retriever
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import JSONL_PATH
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+from scripts.eval_retrieval import (
+    GOLDEN_SET_DIR,
+    K_VALUES,
+    MANIFEST_PATH,
+    NDCG_K,
+    _build_filter_for,
+    _open_retriever,
+    build_report,
+    evaluate_questions,
+    load_corpus,
+    load_document_metadata,
+    load_golden_questions,
+)
+from scripts.tune_reranking import summarise_latency
+
+SCHEMA_VERSION = "v1"
+OUTPUT_DIR = Path("eval/runs")
+JSON_PATH = OUTPUT_DIR / "retrieval_benchmark_matrix.json"
+MD_PATH = OUTPUT_DIR / "retrieval_benchmark_matrix.md"
+
+_COST_NOTE = (
+    "Dollar cost per query: **$0.00**. Both the embedder "
+    "(`Alibaba-NLP/gte-multilingual-base`) and the cross-encoder "
+    "(`Alibaba-NLP/gte-multilingual-reranker-base`) run locally via "
+    "sentence-transformers -- no API, no per-token charge -- so no price "
+    "constant is introduced ([M1-09] stale-pricing rule). The reproducible "
+    "cost is machine time, in the latency column."
+)
+
+
+@dataclass(frozen=True)
+class MatrixConfig:
+    """One row of the benchmark matrix and the harness Namespace that runs it."""
+
+    key: str
+    label: str
+    retriever: str
+    fusion: str
+    rerank: bool
+    co_retrieval: bool
+    filter_mode: str
+
+    def namespace(self) -> argparse.Namespace:
+        """The ``argparse.Namespace`` the harness helpers read."""
+        return argparse.Namespace(
+            retriever=self.retriever,
+            seed=DEFAULT_SEED,
+            fusion=self.fusion,
+            filter_mode=self.filter_mode,
+            rerank=self.rerank,
+            co_retrieval=self.co_retrieval,
+        )
+
+
+# Every real configuration runs on the filtered default path (SUSEP process +
+# CNPJ). `random` is the unfiltered self-test floor, as in docs/HYBRID_RETRIEVAL.md.
+MATRIX: tuple[MatrixConfig, ...] = (
+    MatrixConfig("random", "random (self-test)", "random", "rrf", False, False, "none"),
+    MatrixConfig("lexical", "lexical", "lexical", "rrf", False, False, "default"),
+    MatrixConfig("dense", "dense", "dense", "rrf", False, False, "default"),
+    MatrixConfig("hybrid_rrf", "hybrid RRF", "hybrid", "rrf", False, False, "default"),
+    MatrixConfig(
+        "hybrid_rrf_rerank",
+        "hybrid RRF + rerank",
+        "hybrid",
+        "rrf",
+        True,
+        False,
+        "default",
+    ),
+    MatrixConfig(
+        "hybrid_rrf_rerank_co_retrieval",
+        "hybrid RRF + rerank + co-retrieval",
+        "hybrid",
+        "rrf",
+        True,
+        True,
+        "default",
+    ),
+    MatrixConfig(
+        "hybrid_weighted_rerank_co_retrieval",
+        "hybrid weighted + rerank + co-retrieval",
+        "hybrid",
+        "weighted",
+        True,
+        True,
+        "default",
+    ),
+)
+
+
+class _TimingRetriever:
+    """Wraps a retriever, recording per-call ``retrieve`` wall-clock in ms.
+
+    Satisfies [infrastructure.evaluation.retriever.FilterableRetriever]: the
+    ``metadata_filter`` default lets ``evaluate_questions`` call it with or
+    without a filter (``random`` is scored unfiltered).
+    """
+
+    def __init__(self, inner: Retriever) -> None:
+        self._inner = inner
+        self.samples_ms: list[float] = []
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        start = time.perf_counter()
+        try:
+            if metadata_filter is None:
+                return self._inner.retrieve(question, k=k)
+            filterable = cast(FilterableRetriever, self._inner)
+            return filterable.retrieve(question, k=k, metadata_filter=metadata_filter)
+        finally:
+            self.samples_ms.append((time.perf_counter() - start) * 1000.0)
+
+
+class MatrixRunConfig(BaseModel):
+    """The reproducibility stamp for one ``make eval-retrieval-matrix`` run."""
+
+    schema_version: str
+    run_at_utc: datetime
+    golden_set_dir: str
+    golden_set_question_count: int
+    corpus_path: str
+    corpus_clause_count: int
+    filter_mode: str
+    configurations: list[str]
+    platform: str
+
+
+def score_configuration(
+    matrix_config: MatrixConfig,
+    questions: Sequence[GoldenQuestion],
+    corpus: Sequence[ParsedClauseRecord],
+    document_meta: dict[str, dict[str, str]],
+    clause_by_id: dict[str, ParsedClauseRecord],
+) -> dict[str, Any]:
+    """Run one configuration through the harness and return its full report dict."""
+    namespace = matrix_config.namespace()
+    filter_for = _build_filter_for(namespace.filter_mode, document_meta)
+    with _open_retriever(namespace, corpus) as (retriever, extra_config):
+        timed = _TimingRetriever(retriever)
+        rows, unanswerable_count = evaluate_questions(
+            questions, timed, document_meta, filter_for=filter_for
+        )
+        run_config = RetrievalRunConfig(
+            schema_version=RUN_SCHEMA_VERSION,
+            retriever_name=namespace.retriever,
+            k_values=list(K_VALUES),
+            ndcg_k=NDCG_K,
+            golden_set_dir=str(GOLDEN_SET_DIR),
+            golden_set_question_count=len(questions),
+            corpus_path=str(JSONL_PATH),
+            corpus_clause_count=len(corpus),
+            run_at_utc=datetime.now(UTC),
+            filter_mode=namespace.filter_mode,
+            **extra_config,
+        )
+    report = build_report(run_config, rows, unanswerable_count, clause_by_id)
+    report["matrix_key"] = matrix_config.key
+    report["matrix_label"] = matrix_config.label
+    report["latency_ms"] = summarise_latency(timed.samples_ms)
+    return report
+
+
+def _fmt(value: float) -> str:
+    return f"{value:.1%}"
+
+
+def _matrix_table(reports: Sequence[dict[str, Any]]) -> list[str]:
+    """The headline comparison table: one row per configuration."""
+    lines = [
+        "## The matrix",
+        "",
+        "| configuration | n | R@1 | R@5 | R@10 | MRR | nDCG@10 | "
+        "exclusion recall | foreign-doc | latency ms (p50 / mean) |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for report in reports:
+        overall = report["overall"]
+        exclusion = report["exclusion_clause_recall"]
+        exclusion_cell = (
+            f"{_fmt(exclusion['recall'])} ({exclusion['hits']}/{exclusion['total']})"
+            if exclusion["recall"] is not None
+            else "n/a"
+        )
+        foreign = report["foreign_document_rate"]["rate"]
+        foreign_cell = _fmt(foreign) if foreign is not None else "n/a"
+        latency = report["latency_ms"]
+        lines.append(
+            f"| {report['matrix_label']} | {int(overall['n'])} "
+            f"| {_fmt(overall['recall@1'])} | {_fmt(overall['recall@5'])} "
+            f"| {_fmt(overall['recall@10'])} | {_fmt(overall['mrr'])} "
+            f"| {_fmt(overall[f'ndcg@{NDCG_K}'])} | {exclusion_cell} "
+            f"| {foreign_cell} "
+            f"| {latency['p50']:.1f} / {latency['mean']:.1f} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _by_question_type_table(reports: Sequence[dict[str, Any]]) -> list[str]:
+    """Recall@10 and MRR per question_type, configurations as columns."""
+    types = ("direct_lookup", "coverage_with_exclusion", "cross_document", "definition")
+    scored = [r for r in reports if r["matrix_key"] != "random"]
+    header = (
+        "| question_type | metric | "
+        + " | ".join(r["matrix_label"] for r in scored)
+        + " |"
+    )
+    sep = "| --- | --- | " + " | ".join("---:" for _ in scored) + " |"
+    lines = ["## By question type", "", header, sep]
+    for question_type in types:
+        groups = [r["by_question_type"].get(question_type, {}) for r in scored]
+        n = int(groups[0].get("n", 0)) if groups else 0
+        for metric, key in (("R@10", "recall@10"), ("MRR", "mrr")):
+            cells = [_fmt(g[key]) if g.get(key) is not None else "—" for g in groups]
+            label = f"`{question_type}` (n={n})" if metric == "R@10" else ""
+            lines.append(f"| {label} | {metric} | " + " | ".join(cells) + " |")
+    lines.append("")
+    return lines
+
+
+def _latency_table(reports: Sequence[dict[str, Any]]) -> list[str]:
+    """Per-configuration latency detail plus the cost note."""
+    lines = [
+        "## Latency and cost per query",
+        "",
+        "Per-query `retrieve()` wall-clock over the 117 scorable questions on "
+        "this machine, embedding + reranker caches warm.",
+        "",
+        "| configuration | n | p50 ms | p95 ms | mean ms |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for report in reports:
+        latency = report["latency_ms"]
+        lines.append(
+            f"| {report['matrix_label']} | {int(latency['n'])} "
+            f"| {latency['p50']:.1f} | {latency['p95']:.1f} "
+            f"| {latency['mean']:.1f} |"
+        )
+    lines += ["", _COST_NOTE, ""]
+    return lines
+
+
+def _config_stamp(reports: Sequence[dict[str, Any]]) -> list[str]:
+    """The exact config fingerprints behind every row (M3-08 DoD item 4)."""
+    lines = ["## Exact configuration per run", ""]
+    for report in reports:
+        config = report["config"]
+        parts = [
+            f"- **{report['matrix_label']}** (`{report['matrix_key']}`): "
+            f"retriever `{config['retriever_name']}`, "
+            f"filter `{config.get('filter_mode', 'none')}`"
+        ]
+        if config.get("fusion_strategy"):
+            parts.append(f", fusion `{config['fusion_strategy']}`")
+        if config.get("hybrid_config_fingerprint"):
+            parts.append(f", hybrid `{config['hybrid_config_fingerprint']}`")
+        if config.get("lexical_config_fingerprint"):
+            parts.append(f", lexical `{config['lexical_config_fingerprint']}`")
+        if config.get("embedding_config_fingerprint"):
+            parts.append(f", embedding `{config['embedding_config_fingerprint']}`")
+        if config.get("reranker_config_fingerprint"):
+            parts.append(
+                f", reranker `{config['reranker_config_fingerprint']}` "
+                f"(depth {config['rerank_candidate_depth']})"
+            )
+        if config.get("co_retrieval_config_fingerprint"):
+            parts.append(
+                f", co-retrieval `{config['co_retrieval_config_fingerprint']}` "
+                f"({config['reserved_exclusion_slots']} slot)"
+            )
+        lines.append("".join(parts))
+    lines.append("")
+    return lines
+
+
+def render_matrix_report(report: dict[str, Any]) -> str:
+    """Render the whole matrix as Markdown; numbers copied into the committed doc."""
+    config = report["run_config"]
+    reports = report["configurations"]
+    scorable = next(
+        int(r["overall"]["n"]) for r in reports if r["matrix_key"] != "random"
+    )
+    lines = [
+        "# Retrieval benchmark matrix",
+        "",
+        "Generated by `scripts/benchmark_retrieval_matrix.py` "
+        "(`make eval-retrieval-matrix`) against the golden set in "
+        "`data/golden_set/`. Regenerable; the committed table, the "
+        "per-question-type analysis and the verdict live in "
+        "`docs/RETRIEVAL_BENCHMARK.md`. Every real configuration runs on the "
+        "`--filter default` SUSEP-process + CNPJ path; the 23 `unanswerable` "
+        "questions are excluded from every metric (empty reference set).",
+        "",
+        "## Run configuration",
+        "",
+        f"- Golden set: `{config['golden_set_dir']}` "
+        f"({config['golden_set_question_count']} questions, {scorable} scorable)",
+        f"- Corpus: `{config['corpus_path']}` "
+        f"({config['corpus_clause_count']} clauses)",
+        f"- Filter: `{config['filter_mode']}` (per-question SUSEP process + CNPJ)",
+        f"- Platform: {config['platform']}",
+        f"- Run at (UTC): {config['run_at_utc']}",
+        "",
+    ]
+    lines += _matrix_table(reports)
+    lines += _by_question_type_table(reports)
+    lines += _latency_table(reports)
+    lines += _config_stamp(reports)
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    return argparse.ArgumentParser(description=__doc__).parse_args()
+
+
+def main() -> None:
+    """Run every matrix configuration and write the report."""
+    _parse_args()
+    document_meta = load_document_metadata(MANIFEST_PATH)
+    corpus = load_corpus(JSONL_PATH)
+    clause_by_id = {record.clause_id: record for record in corpus}
+    questions = load_golden_questions(GOLDEN_SET_DIR)
+
+    reports: list[dict[str, Any]] = []
+    for matrix_config in MATRIX:
+        print(f"running {matrix_config.key} ...", flush=True)
+        report = score_configuration(
+            matrix_config, questions, corpus, document_meta, clause_by_id
+        )
+        overall = report["overall"]
+        print(
+            f"  R@10={_fmt(overall['recall@10'])} MRR={_fmt(overall['mrr'])} "
+            f"nDCG={_fmt(overall[f'ndcg@{NDCG_K}'])} "
+            f"latency p50={report['latency_ms']['p50']:.1f}ms",
+            flush=True,
+        )
+        reports.append(report)
+
+    run_config = MatrixRunConfig(
+        schema_version=SCHEMA_VERSION,
+        run_at_utc=datetime.now(UTC),
+        golden_set_dir=str(GOLDEN_SET_DIR),
+        golden_set_question_count=len(questions),
+        corpus_path=str(JSONL_PATH),
+        corpus_clause_count=len(corpus),
+        filter_mode="default",
+        configurations=[config.key for config in MATRIX],
+        platform=platform.platform(),
+    )
+    document = {
+        "run_config": run_config.model_dump(mode="json"),
+        "configurations": reports,
+    }
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_PATH.write_text(
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    MD_PATH.write_text(render_matrix_report(document), encoding="utf-8")
+    print(f"Wrote {JSON_PATH} and {MD_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_benchmark_ann_index.py
+++ b/tests/unit/scripts/test_benchmark_ann_index.py
@@ -13,6 +13,7 @@ from scripts.benchmark_ann_index import (
     AnnBenchmarkConfig,
     K,
     Partition,
+    _parse_args,
     _scan_summary,
     build_report,
     choose_partitions,
@@ -21,6 +22,7 @@ from scripts.benchmark_ann_index import (
     pseudo_random_unit_vector,
     recall_at_k,
     render_markdown_report,
+    render_real_report,
     summarise_latency,
     vector_literal,
 )
@@ -267,3 +269,48 @@ def test_render_markdown_report_has_every_section_and_the_caveat() -> None:
     assert "Synthetic vectors" in markdown
     assert "| --- | ---: | ---: | ---: | --- |" in markdown
     assert "9088 kB" in markdown
+
+
+@pytest.mark.unit
+def test_parse_args_exposes_the_real_embeddings_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.argv", ["benchmark_ann_index.py"])
+    assert _parse_args().real_embeddings is False
+    monkeypatch.setattr("sys.argv", ["benchmark_ann_index.py", "--real-embeddings"])
+    assert _parse_args().real_embeddings is True
+
+
+@pytest.mark.unit
+def test_render_real_report_states_the_recall_and_the_filtered_plan() -> None:
+    config = _config().model_dump(mode="json")
+    config["synthetic_vectors"] = False
+    report = {
+        "config": config,
+        "caveat": "**Real embeddings.** ... rolled back ...",
+        "embedding_config_fingerprint": "7ea39a621eaee88e",
+        "build": {
+            "build_seconds": 0.81,
+            "index_bytes": 9306112,
+            "index_size_pretty": "9088 kB",
+            "table_bytes": 13533184,
+            "index_to_table_ratio": 0.688,
+        },
+        "latency": {
+            "exact_full": _latency_entry(),
+            "exact_partition": _latency_entry(),
+            "indexed_full": _latency_entry(),
+            "indexed_partition": _latency_entry(),
+        },
+        "ann_recall_at_k_full_corpus": 0.9631,
+        "filtered_path_plan": "Index Scan using ix_chunk_susep_process_cnpj",
+    }
+
+    markdown = render_real_report(report)
+
+    assert "# ANN index benchmark -- real embeddings" in markdown
+    assert "## ANN recall vs. exact" in markdown
+    assert "0.9631" in markdown
+    assert "ix_chunk_susep_process_cnpj" in markdown
+    assert "recall 1.0 by construction" in markdown
+    assert "7ea39a621eaee88e" in markdown

--- a/tests/unit/scripts/test_benchmark_retrieval_matrix.py
+++ b/tests/unit/scripts/test_benchmark_retrieval_matrix.py
@@ -1,0 +1,164 @@
+"""Unit tests for the [M3-08] retrieval benchmark matrix runner.
+
+Pure functions and the timing proxy only -- the database-backed matrix is run by
+hand via ``make eval-retrieval-matrix`` and every configuration it drives is
+already covered by ``tests/eval/test_*_retrieval_baseline.py``.
+"""
+
+import pytest
+from scripts.benchmark_retrieval_matrix import (
+    MATRIX,
+    MatrixConfig,
+    _TimingRetriever,
+    render_matrix_report,
+)
+
+from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+@pytest.mark.unit
+def test_matrix_covers_the_dod_configurations_plus_the_settled_extras() -> None:
+    keys = [config.key for config in MATRIX]
+    assert keys == [
+        "random",
+        "lexical",
+        "dense",
+        "hybrid_rrf",
+        "hybrid_rrf_rerank",
+        "hybrid_rrf_rerank_co_retrieval",
+        "hybrid_weighted_rerank_co_retrieval",
+    ]
+    # Every real configuration runs on the filtered default path; only the
+    # random self-test row is unfiltered.
+    for config in MATRIX:
+        expected = "none" if config.key == "random" else "default"
+        assert config.filter_mode == expected
+
+
+@pytest.mark.unit
+def test_namespace_carries_every_field_the_harness_helpers_read() -> None:
+    namespace = MatrixConfig(
+        "hybrid_weighted_rerank_co_retrieval",
+        "hybrid weighted + rerank + co-retrieval",
+        "hybrid",
+        "weighted",
+        True,
+        True,
+        "default",
+    ).namespace()
+    assert namespace.retriever == "hybrid"
+    assert namespace.fusion == "weighted"
+    assert namespace.filter_mode == "default"
+    assert namespace.rerank is True
+    assert namespace.co_retrieval is True
+    assert isinstance(namespace.seed, int)
+
+
+class _FakeRetriever:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, bool]] = []
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: RetrievalFilter | None = None,
+    ) -> list[str]:
+        self.calls.append((question, k, metadata_filter is not None))
+        return ["1:a", "1:b"][:k]
+
+
+@pytest.mark.unit
+def test_timing_retriever_delegates_and_records_one_sample_per_call() -> None:
+    inner = _FakeRetriever()
+    timed = _TimingRetriever(inner)
+
+    assert timed.retrieve("q1", k=1) == ["1:a"]
+    assert timed.retrieve(
+        "q2", k=2, metadata_filter=RetrievalFilter(susep_process="p", cnpj="c")
+    ) == ["1:a", "1:b"]
+
+    assert inner.calls == [("q1", 1, False), ("q2", 2, True)]
+    assert len(timed.samples_ms) == 2
+    assert all(sample >= 0.0 for sample in timed.samples_ms)
+
+
+def _report(key: str, label: str, **overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "matrix_key": key,
+        "matrix_label": label,
+        "config": {"retriever_name": key, "filter_mode": "default"},
+        "overall": {
+            "n": 117.0,
+            "recall@1": 0.65,
+            "recall@5": 0.87,
+            "recall@10": 0.92,
+            "mrr": 0.80,
+            "ndcg@10": 0.82,
+        },
+        "by_question_type": {
+            "direct_lookup": {"n": 64, "recall@10": 0.95, "mrr": 0.85},
+            "coverage_with_exclusion": {"n": 19, "recall@10": 0.84, "mrr": 0.65},
+            "cross_document": {"n": 16, "recall@10": 0.94, "mrr": 0.80},
+            "definition": {"n": 18, "recall@10": 0.89, "mrr": 0.81},
+        },
+        "exclusion_clause_recall": {"recall": 1.0, "hits": 27, "total": 27},
+        "foreign_document_rate": {"rate": 0.0},
+        "latency_ms": {"n": 117, "p50": 12.0, "p95": 40.0, "mean": 15.0},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+def test_render_matrix_report_has_every_section_and_the_best_row() -> None:
+    document = {
+        "run_config": {
+            "golden_set_dir": "data/golden_set",
+            "golden_set_question_count": 140,
+            "corpus_path": "build/parsed_clauses.jsonl",
+            "corpus_clause_count": 4925,
+            "filter_mode": "default",
+            "platform": "Linux",
+            "run_at_utc": "2026-08-30T00:00:00+00:00",
+        },
+        "configurations": [
+            _report(
+                "random",
+                "random (self-test)",
+                overall={
+                    "n": 117.0,
+                    "recall@1": 0.0,
+                    "recall@5": 0.0,
+                    "recall@10": 0.0,
+                    "mrr": 0.0,
+                    "ndcg@10": 0.0,
+                },
+                exclusion_clause_recall={"recall": 0.0, "hits": 0, "total": 27},
+                foreign_document_rate={"rate": 0.95},
+                by_question_type={},
+            ),
+            _report("lexical", "lexical"),
+            _report(
+                "hybrid_rrf_rerank_co_retrieval",
+                "hybrid RRF + rerank + co-retrieval",
+            ),
+        ],
+    }
+
+    markdown = render_matrix_report(document)
+
+    for header in (
+        "# Retrieval benchmark matrix",
+        "## The matrix",
+        "## By question type",
+        "## Latency and cost per query",
+        "## Exact configuration per run",
+    ):
+        assert header in markdown
+    assert "hybrid RRF + rerank + co-retrieval" in markdown
+    assert "100.0% (27/27)" in markdown  # exclusion recall cell
+    assert "$0.00" in markdown
+    assert "12.0 / 15.0" in markdown  # latency p50 / mean cell
+    assert "117 scorable" in markdown


### PR DESCRIPTION
## Summary

The M3-08 consolidation and M3's capstone — one committed comparison of every retrieval configuration, plus make build-index.

- scripts/benchmark_retrieval_matrix.py (make eval-retrieval-matrix) drives the [M2-06] harness over all configurations in one pass on the --filter default SUSEP-process + CNPJ path, with per-query latency. Committed table, per-question-type analysis and verdict in docs/RETRIEVAL_BENCHMARK.md.
- Best configuration — hybrid RRF + cross-encoder rerank (depth 10) + exclusion co-retrieval (1 slot): Recall@10 92.3%, MRR 80.6%, exclusion-clause recall 100% (27/27), foreign-doc 0.0% — both M3 exit bars cleared. The four core rows reproduce their M3-03/04/05 numbers exactly, byte-identical across three runs.
- RRF vs weighted fusion, re-opened with the reranker in the loop: RRF wins every metric (R@10 92.3 vs 89.3). The reranker erased weighted's fusion-stage MRR edge; DEFAULT_FUSION_STRATEGY unchanged — the M3-04 stated deviation is now a measured result. My pre-registered "weighted keeps a small MRR edge" prediction missed and is published.
- Real-embedding ANN A/B (scripts/benchmark_ann_index.py --real-embeddings, make benchmark-ann-index-real): HNSW recall@10 vs exact is 0.9932 (vs 0.448 synthetic), but the planner still reads the btree partition for the filtered default path, so make build-index does not create the index. Second dated measurement in docs/EMBEDDINGS.md; closes the M3-02 deferred item.
- make build-index chains parse → build-chunks → migrate → load-chunks → embed-chunks; a build/parsed_clauses.jsonl file-target skips the parse stage when the corpus is already present.
- Deviation (stated in the doc and MILESTONES.md): the DoD's make eval-retrieval is the [M2-06] random self-test, so the matrix is realised as the new target make eval-retrieval-matrix.
- MILESTONES.md: M3 → done.

Zero new .env keys, no new dependencies.

## Related issue

[M3-08] — closes milestone M3.

## Checklist

- [x] Tests added/updated — tests/unit/scripts/test_benchmark_retrieval_matrix.py (new); test_benchmark_ann_index.py extended for the --real-embeddings path and render_real_report.
- [x] Docs updated — new docs/RETRIEVAL_BENCHMARK.md; docs/EMBEDDINGS.md (dated second ANN measurement), docs/HYBRID_RETRIEVAL.md (RRF-vs-weighted resolved), docs/RERANKING.md / docs/LEXICAL_RETRIEVAL.md / docs/EXCLUSION_CO_RETRIEVAL.md / docs/INSUFFICIENT_CONTEXT_GATE.md (Deferred sections marked done), README.md, MILESTONES.md.
- [x] Evaluation impact — this PR is the evaluation: it publishes the committed retrieval benchmark. No retriever behaviour changed; every number reproduces the per-stage docs exactly. DEFAULT_FUSION_STRATEGY stays RRF (now confirmed against weighted with the full pipeline).
- [x] make check passes locally (ruff, format, mypy, 808 unit tests). Integration (23) and eval-baseline (6) suites also pass.

Local verification note. The matrix (×3, byte-identical), the ANN A/B (dev DB verified untouched afterward), and build-index's DB half (check-embedding-input-length → load-chunks → embed-chunks) all ran here. A full make build-index from raw was not run in this session — parse/build-chunks need the LLM_* env for the clause classifier — but M3-08 changes neither of those scripts, and make -n build-index produces the correct step sequence. The from-raw clean-machine run is the M6 dry-run.
