### PR TITLE
feat(agents): establish LangGraph node-authoring conventions (M4-01b)

### DIFF
--- a/app/src/infrastructure/graph/context.py
+++ b/app/src/infrastructure/graph/context.py
@@ -1,0 +1,62 @@
+"""Run-scoped dependencies injected into every graph node -- [M4-01b].
+
+``GraphContext`` is built once outside this package (the composition root, a
+later issue) and handed to the graph as
+``graph.invoke(state, context=GraphContext(...))``. Each node receives it as
+``runtime.context`` by declaring a ``runtime: Runtime[GraphContext]`` parameter.
+This is the only channel for the chat models, the retrieval port and the model
+config -- a node holds no module-level client and takes no constructor. See
+``docs/ARCHITECTURE.md`` ([M4-01b]).
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from infrastructure.config.settings import LlmSettings
+
+if TYPE_CHECKING:
+    from infrastructure.rag.retrieval_filter import RetrievalFilter
+
+
+class RetrievalPort(Protocol):
+    """The retrieval capability a node depends on, owned by the graph layer.
+
+    The signature mirrors the M3 retrievers
+    (``infrastructure.evaluation.retriever.FilterableRetriever``) so a concrete
+    hybrid/rerank retriever satisfies it structurally, without the graph
+    importing a concrete implementation or the evaluation harness's interface
+    ([M4-04]). ``retrieve`` returns ranked clause-id strings only -- the
+    retrieval node hydrates ``Citation`` objects itself. [M4-04] owns any
+    change to this shape.
+    """
+
+    def retrieve(
+        self,
+        question: str,
+        *,
+        k: int,
+        metadata_filter: "RetrievalFilter | None" = None,
+    ) -> list[str]:
+        """Return up to ``k`` clause ids, ranked best-match first."""
+        ...
+
+
+@dataclass(frozen=True)
+class GraphContext:
+    """Run-scoped dependencies for the agent graph -- [M4-01b].
+
+    Frozen: a node reads these, it does not swap them. The two chat models are
+    pre-built so a unit test passes fakes directly. ``llm_settings`` is the
+    model config -- a node records ``llm_settings.llm_model_reasoning`` (or
+    ``.llm_model_fast``) as the ``AuditEvent.model`` for a call it makes,
+    rather than introspecting the model object. The OpenRouter provider pins
+    are applied by ``build_chat_model`` at the composition root, never read by
+    a node.
+    """
+
+    fast_model: BaseChatModel
+    reasoning_model: BaseChatModel
+    retriever: RetrievalPort
+    llm_settings: LlmSettings

--- a/app/src/infrastructure/graph/nodes/__init__.py
+++ b/app/src/infrastructure/graph/nodes/__init__.py
@@ -1,0 +1,15 @@
+"""One module per graph node -- [M4-02] onward.
+
+A node is a module-level function
+
+    def <name>(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, object]
+
+that reads ``state``, never mutates it, and returns only the keys it changed
+(a partial ``ClaimState`` update) including at least one ``AuditEvent`` for
+``audit_trail``. Any other function in a node module is a private ``_``-prefixed
+helper. No class-based nodes.
+
+The full authoring convention -- structured-output schemas, prompt builders,
+"how to add a node" -- is in ``docs/ARCHITECTURE.md`` ([M4-01b]);
+``tests/architecture/test_graph_node_conventions.py`` enforces the shape.
+"""

--- a/app/src/infrastructure/graph/prompts/scope_preamble.py
+++ b/app/src/infrastructure/graph/prompts/scope_preamble.py
@@ -25,3 +25,13 @@ incompatible, insufficient_information. Use insufficient_information \
 whenever the retrieved context does not settle the question, rather than \
 guessing.\
 """
+
+
+def with_scope_preamble(body: str) -> str:
+    """Prepend ``SCOPE_PREAMBLE`` to a node prompt body.
+
+    The one machine-checked way to satisfy this package's rule that every node
+    prompt carries the scope constraint: ``build_<node>_prompt`` returns
+    ``with_scope_preamble(...)`` rather than its own concatenation.
+    """
+    return f"{SCOPE_PREAMBLE}\n\n{body}"

--- a/app/src/infrastructure/graph/schemas.py
+++ b/app/src/infrastructure/graph/schemas.py
@@ -1,0 +1,9 @@
+"""Structured-output schemas for graph nodes -- [M4-01b].
+
+One frozen Pydantic ``<Node>Output`` per LLM node -- the exact shape passed to
+``llm.with_structured_output(...)``. Kept separate from the state sub-models in
+``state.py``: the node maps its output schema onto the state model (for
+example, the model returns clause-id strings and the node hydrates ``Citation``
+objects with the retrieved clauses' provenance). Empty until the first node
+lands ([M4-02]).
+"""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,3 +57,69 @@ pure function of text the artifact already carries, so `extract_cross_references
 runs at graph-build time — the production formalisation of the helper
 `scripts/find_candidate_clauses.py` ([M2-08]) already uses for golden-set
 curation. Full rationale in `docs/EXCLUSION_CO_RETRIEVAL.md`.
+
+---
+
+## Graph nodes are plain functions with dependencies injected through the runtime — [M4-01b]
+
+**Decision.** A graph node is a module-level function
+`def <name>(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, object]`,
+one node per file under `app/src/infrastructure/graph/nodes/`. It reads `state`,
+never mutates it, and returns only the keys it changed — a partial `ClaimState`
+update — always including at least one `AuditEvent` appended to `audit_trail`.
+No class-based nodes, no `__call__` objects, no module-level model or retriever
+singletons. Run-scoped dependencies — the fast and reasoning chat models, the
+retrieval port, the model config — are fields of `GraphContext`
+(`app/src/infrastructure/graph/context.py`), a frozen dataclass registered with
+`StateGraph(ClaimState, context_schema=GraphContext)` and read inside a node as
+`runtime.context`. Each LLM node's structured-output schema is a frozen Pydantic
+`<Node>Output` in `app/src/infrastructure/graph/schemas.py`, kept distinct from
+the `state.py` sub-models. Each node's prompt is built by
+`build_<node>_prompt(...) -> str` in
+`app/src/infrastructure/graph/prompts/<node>.py`, wrapped in
+`with_scope_preamble(...)`; prompt text never appears inside a node function.
+
+**Why a function and not a class.** The node is then testable by calling it with
+a literal state dict and a `GraphContext` of fakes — no graph, no `compile()`,
+no framework in the test. It is LangGraph's documented v1 style, and it is the
+shape `tests/unit/infrastructure/graph/test_state_merges.py` already uses for
+its fan-in fixtures. A class holding its dependencies in `__init__` reintroduces
+the construction-order and shared-mutable-state problems `context_schema` exists
+to remove, and invites five M4 issues to settle on five different constructors.
+
+**Why dependencies arrive through `Runtime[GraphContext]`.** Nodes are
+registered as bare functions — there is no constructor to pass anything to. A
+module global couples every node to one process-wide client and makes the test
+suite fight over monkeypatches. `context_schema` is the single seam LangGraph
+provides, and `GraphContext` is the one object the composition root builds and
+hands to `graph.invoke(state, context=...)`. The API moved at v1: LangGraph
+1.2.11 uses `context_schema=` / `Runtime` / `get_runtime`, not the deprecated
+`config_schema=` / `config["configurable"]` of pre-1.0 tutorials. The return
+type is `dict[str, object]`, not `ClaimState` — a partial return typed
+`ClaimState` fails on its required `claim_id` / `raw_claim_text` keys.
+
+**How to add a node.**
+
+1. `schemas.py`: add `class <Node>Output(BaseModel)` (frozen) — the exact shape
+   passed to `.with_structured_output(...)`. Map it onto the `state.py`
+   sub-model inside the node (the model returns clause-id strings; the node
+   hydrates `Citation` objects from the retrieved clauses' provenance).
+2. `prompts/<node>.py`: add `build_<node>_prompt(...) -> str` returning
+   `with_scope_preamble(body)`.
+3. `nodes/<node>.py`: the function. Take `fast_model` / `reasoning_model` /
+   `retriever` / `llm_settings` off `runtime.context`; read optional state with
+   `state.get(...)`. Return the changed keys plus an `AuditEvent` — set `model`
+   and `token_usage` for an LLM call, leave them `None` for a deterministic one.
+   Any other function in the module is a private `_`-prefixed helper.
+4. `tests/unit/infrastructure/graph/test_<node>.py`, `@pytest.mark.unit`: a fake
+   `BaseChatModel` and a stub retriever, no network. Verdict accuracy against
+   the synthetic claims is a separate `eval`-marked test ([M4-10]).
+5. Edges, the parallel fan-in and the checkpointer are not the node's concern —
+   see [M4-07] and [M4-09].
+
+**Enforcement.** `tests/architecture/test_graph_node_conventions.py`
+(unit-marked, runs in CI) fails on any class under `nodes/` that defines
+`__call__` or subclasses a `Runnable*`, and on any exported node function whose
+first two parameters are not `(state, runtime)`.
+`tests/architecture/test_scope_vocabulary.py` already scans the same tree for
+verdict-vocabulary drift.

--- a/tests/architecture/test_graph_node_conventions.py
+++ b/tests/architecture/test_graph_node_conventions.py
@@ -1,0 +1,94 @@
+"""Enforce the [M4-01b] node-authoring conventions.
+
+A graph node is a module-level function ``(state, runtime) -> dict`` -- no
+class-based nodes, and the first two parameters are named ``state`` and
+``runtime`` (the name LangGraph's runtime injector binds by). Statically scans
+every module under ``infrastructure/graph/nodes/`` with ``ast`` -- it never
+imports them -- so the five M4 node issues cannot converge on five different
+node shapes. See ``docs/ARCHITECTURE.md`` for the convention this guards.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRAPH_DIR = REPO_ROOT / "app" / "src" / "infrastructure" / "graph"
+NODES_DIR = GRAPH_DIR / "nodes"
+
+_FUNCTION_DEFS = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _node_modules() -> list[Path]:
+    return sorted(p for p in NODES_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+def _base_names(class_def: ast.ClassDef) -> list[str]:
+    names: list[str] = []
+    for base in class_def.bases:
+        if isinstance(base, ast.Name):
+            names.append(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.append(base.attr)
+    return names
+
+
+def _class_based_node_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        method_names = {
+            child.name for child in node.body if isinstance(child, _FUNCTION_DEFS)
+        }
+        subclasses_runnable = any("Runnable" in name for name in _base_names(node))
+        if "__call__" in method_names or subclasses_runnable:
+            violations.append(
+                f"  {path}:{node.lineno} defines class-based node '{node.name}'"
+            )
+    return violations
+
+
+def _signature_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, _FUNCTION_DEFS) or node.name.startswith("_"):
+            continue
+        params = [arg.arg for arg in node.args.posonlyargs + node.args.args]
+        location = f"  {path}:{node.lineno} '{node.name}'"
+        if params[:1] != ["state"]:
+            violations.append(f"{location} first parameter is not 'state'")
+        elif len(params) >= 2 and params[1] != "runtime":
+            violations.append(f"{location} second parameter is not 'runtime'")
+    return violations
+
+
+@pytest.mark.unit
+def test_graph_scaffolding_exists() -> None:
+    # Guards against the scans below passing only because a path is missing.
+    assert NODES_DIR.is_dir(), f"expected the nodes package at {NODES_DIR}"
+    for name in ("schemas.py", "context.py"):
+        assert (GRAPH_DIR / name).is_file(), f"expected infrastructure/graph/{name}"
+
+
+@pytest.mark.unit
+def test_no_class_based_nodes() -> None:
+    violations: list[str] = []
+    for module in _node_modules():
+        violations.extend(_class_based_node_violations(module))
+    assert not violations, "class-based graph nodes are forbidden:\n" + "\n".join(
+        violations
+    )
+
+
+@pytest.mark.unit
+def test_exported_node_functions_take_state_and_runtime() -> None:
+    violations: list[str] = []
+    for module in _node_modules():
+        violations.extend(_signature_violations(module))
+    assert not violations, "graph node signature convention violated:\n" + "\n".join(
+        violations
+    )


### PR DESCRIPTION
## Summary

Decides once, before the first M4 node is written, what shape a graph node takes — so
[M4-02]…[M4-09] don't converge on five different shapes and [M6-02] only has to verify
the doc still matches reality.

The convention: a node is a plain module-level function
`def <name>(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, object]`,
one file per node under `infrastructure/graph/nodes/`, that reads `state`, never mutates
it, and returns a partial update. Run-scoped dependencies arrive through a frozen
`GraphContext` registered as `context_schema` and read as `runtime.context` — not a
constructor, not a global. Structured-output schemas live in `schemas.py` (separate from
the M4-01 state sub-models); prompt builders live in `prompts/`.

This PR is scaffolding + conventions only — **no node logic and no graph builder** (those
start at [M4-02]).

- `context.py` — `GraphContext` (frozen stdlib dataclass: pre-built `fast_model` /
  `reasoning_model`, `retriever: RetrievalPort`, `llm_settings`) and `RetrievalPort`, a
  graph-local `Protocol` mirroring `FilterableRetriever`'s signature rather than importing
  the evaluation-harness one. No `langgraph` import in the module.
- `nodes/__init__.py`, `schemas.py` — documented package marker and stub; first real
  content lands with the node issues.
- `prompts/scope_preamble.py` — adds `with_scope_preamble(body)` so every node prompt
  prepends `SCOPE_PREAMBLE` through one call.
- `tests/architecture/test_graph_node_conventions.py` — AST-based (never imports the node
  modules), unit-marked: fails on a class-based node (`__call__` or `Runnable*` base) and
  on an exported node function whose first two params aren't `(state, runtime)`.
- `docs/ARCHITECTURE.md` — new decision entry with a "how to add a node" checklist.

LangGraph 1.2.11's runtime/DI API (`context_schema=` / `Runtime` / `get_runtime`;
`config_schema=` deprecated) was verified against the installed package and current
LangChain docs.

## Related issue

[M4-01b]

## Checklist

- [x] Tests added/updated for the change — `test_graph_node_conventions.py` (3 unit checks)
- [x] Docs updated — new `docs/ARCHITECTURE.md` decision entry; `RetrievalPort` noted as
      owned by [M4-04] for any signature change
- [x] Evaluation impact considered — none; no parsing, retrieval, or evaluation code path
      is touched and no published metric moves
- [x] `make check` passes locally — plus `pytest -m unit` (the exact CI selector)