### PR TITLE
feat(domain): model business entities and invariants with no framewor…

### DIFF
--- a/app/src/domain/__init__.py
+++ b/app/src/domain/__init__.py
@@ -1,7 +1,13 @@
 """Domain layer.
 
-Pure business entities, value objects, and invariants (Policy, Clause,
-Claim, Assessment, HumanDecision, Verdict). Depends only on the standard
-library. Must never import FastAPI, SQLAlchemy, Pydantic, LangGraph, or
-LangChain.
+Pure business entities, value objects, and invariants (Policy,
+PolicyClause, Claim, Assessment, HumanDecision, Citation, Verdict,
+DecisionOutcome; the SusepProcess and Cnpj value objects). Depends only on
+the standard library. Must never import FastAPI, SQLAlchemy, Pydantic,
+LangGraph, or LangChain.
+
+M5-01 note: the DoD names the clause entity ``Clause``; it ships as
+``PolicyClause`` (domain/policy_clause.py) so it does not shadow the
+existing parse-tree ``Clause`` (domain/clause_tree.py). See
+docs/ARCHITECTURE.md.
 """

--- a/app/src/domain/assessment.py
+++ b/app/src/domain/assessment.py
@@ -1,0 +1,62 @@
+"""The assessment entity [M5-01].
+
+The settled compatibility assessment for one claim against a registered
+product -- the stdlib-dataclass twin of
+``infrastructure.graph.state.CompatibilityAssessment``, plus the
+``recommended_action`` the reviewer acts on (so ``GET /v1/assessments/{id}``
+has one entity to return, not two).
+
+Invariants, all checked at construction:
+
+* **at least one citation, always** -- including for an
+  ``insufficient_information`` verdict. The graph's abstain-on-empty-
+  retrieval path produces a verdict with no citations; that state is *not*
+  a persistable ``Assessment`` (it lives in claim state + the audit trail),
+  a fact [M5-02]/[M5-03] must account for.
+* **the verdict is a ``domain.verdict.Verdict`` member** -- a plain
+  dataclass does not type-check its fields, so a bare string would slip
+  through without this guard.
+
+Consistency signals are deliberately out of scope: no M5-01 invariant
+touches them, and persisting ``ConsistencyReport`` is [M5-03]'s call.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+
+from domain.citation import Citation
+from domain.errors import CitationRequiredError, VerdictNotPermittedError
+from domain.verdict import Verdict
+
+
+@dataclass(frozen=True)
+class Assessment:
+    """A compatibility verdict for a claim, grounded in one or more citations."""
+
+    assessment_id: str
+    claim_id: str
+    verdict: Verdict
+    reasoning: str
+    citations: tuple[Citation, ...]
+    confidence: float
+    recommended_action: str
+
+    def __post_init__(self) -> None:
+        """Enforce the non-empty fields, the verdict type and the >=1-citation rule."""
+        for name in ("assessment_id", "claim_id", "reasoning", "recommended_action"):
+            if not getattr(self, name):
+                raise ValueError(f"Assessment.{name} must not be empty")
+        if not isinstance(self.verdict, Verdict):
+            raise VerdictNotPermittedError(
+                f"verdict must be a domain.verdict.Verdict, got {self.verdict!r}"
+            )
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"Assessment.confidence must be in [0, 1], got {self.confidence}"
+            )
+        if len(self.citations) < 1:
+            raise CitationRequiredError(self.assessment_id)
+        if not all(isinstance(c, Citation) for c in self.citations):
+            raise ValueError("Assessment.citations must all be Citation instances")

--- a/app/src/domain/citation.py
+++ b/app/src/domain/citation.py
@@ -1,0 +1,47 @@
+"""The citation value object [M5-01].
+
+The stdlib-dataclass twin of ``infrastructure.graph.state.Citation``: one
+clause an assertion is traceable to. The graph produces the Pydantic
+version inside a run; this is the shape the domain entities
+([domain.assessment.Assessment]) and the application ports ([M5-02]) speak
+in, with the mapper between the two owned by [M5-03].
+
+``excerpt`` is a quoted span of the clause as a human reads it.
+``relevance_score`` is the ranker's score for this clause against the
+query; a structurally co-retrieved exclusion the ranking itself missed
+carries ``0.0`` (``docs/ARCHITECTURE.md``, M3-06).
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+
+from domain.clause_classification import ClauseType
+from domain.susep_process import SusepProcess
+
+
+@dataclass(frozen=True)
+class Citation:
+    """One clause an assessment's reasoning is grounded in."""
+
+    clause_id: str
+    document_id: str
+    susep_process: SusepProcess
+    clause_type: ClauseType
+    excerpt: str
+    relevance_score: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Reject empty identifiers or excerpt, a negative score, or a bad type."""
+        for name in ("clause_id", "document_id", "excerpt"):
+            if not getattr(self, name):
+                raise ValueError(f"Citation.{name} must not be empty")
+        if self.relevance_score < 0.0:
+            raise ValueError(
+                f"Citation.relevance_score must be >= 0, got {self.relevance_score}"
+            )
+        if not isinstance(self.clause_type, ClauseType):
+            raise ValueError(
+                f"Citation.clause_type must be a ClauseType, got {self.clause_type!r}"
+            )

--- a/app/src/domain/claim.py
+++ b/app/src/domain/claim.py
@@ -1,0 +1,39 @@
+"""The claim entity [M5-01].
+
+The free-text loss narrative a policyholder submits, before the graph makes
+any structured sense of it. ``raw_text`` is ``ClaimState.raw_claim_text``;
+the structured read the intake node produces (``ExtractedEntities``) stays
+in ``infrastructure.graph.state`` -- it is graph working state, not a
+business entity the DoD names.
+
+``policy_ref`` is the registered product the claim is filed against.
+``None`` is the honest default today: intake *extracts* the SUSEP process
+from the narrative, so it is not known at submission. [M5-04] makes it a
+first-class field of the submission API.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.susep_process import SusepProcess
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A submitted claim narrative awaiting or carrying an assessment."""
+
+    claim_id: str
+    raw_text: str
+    submitted_at: datetime
+    policy_ref: SusepProcess | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an empty id or narrative, or a naive ``submitted_at``."""
+        for name in ("claim_id", "raw_text"):
+            if not getattr(self, name):
+                raise ValueError(f"Claim.{name} must not be empty")
+        if self.submitted_at.tzinfo is None or self.submitted_at.utcoffset() is None:
+            raise ValueError("Claim.submitted_at must be timezone-aware")

--- a/app/src/domain/cnpj.py
+++ b/app/src/domain/cnpj.py
@@ -1,0 +1,86 @@
+"""The CNPJ value object [M5-01].
+
+A CNPJ is the 14-digit Brazilian company registration number -- the
+reliable identity key for an insurer, since two companies can share a brand
+and differ only here (``data/README.md``; HDI Seguros vs HDI Global).
+
+Validated at construction: exactly 14 digits, and the two trailing digits
+must satisfy the standard mod-11 check-digit algorithm. :meth:`Cnpj.parse`
+additionally applies the **14-digit zero-padding rule**: SUSEP's open
+product catalogue publishes CNPJ as a number rather than a fixed-width
+string, so a value that has lost its leading zero and arrives with 13
+digits is left-padded before validation (``data/README.md``, "Known
+upstream defect: CNPJ leading zeros").
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+
+from domain.errors import InvalidCnpjError
+
+_PUNCTUATION = str.maketrans("", "", "./- ")
+_FIRST_WEIGHTS = (5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+_SECOND_WEIGHTS = (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)
+
+
+def _mod11_digit(digits: str, weights: tuple[int, ...]) -> str:
+    """One CNPJ check digit: weighted sum, mod 11, ``0`` when the remainder is <2."""
+    total = sum(int(d) * w for d, w in zip(digits, weights, strict=True))
+    remainder = total % 11
+    return "0" if remainder < 2 else str(11 - remainder)
+
+
+def _cnpj_check_digits(base12: str) -> str:
+    """The two check digits for a 12-digit CNPJ base, as a 2-character string."""
+    first = _mod11_digit(base12, _FIRST_WEIGHTS)
+    second = _mod11_digit(base12 + first, _SECOND_WEIGHTS)
+    return first + second
+
+
+@dataclass(frozen=True)
+class Cnpj:
+    """A Brazilian company registration number: exactly 14 ASCII digits.
+
+    Construct from an already-canonical 14-digit string, or use
+    :meth:`parse` for any other form (punctuated, or the 13-digit
+    leading-zero-stripped form the upstream catalogue emits).
+    """
+
+    value: str
+
+    def __post_init__(self) -> None:
+        """Reject a non-14-digit value or a value whose check digits do not verify."""
+        if len(self.value) != 14 or not (self.value.isascii() and self.value.isdigit()):
+            raise InvalidCnpjError(f"not a 14-digit CNPJ: {self.value!r}")
+        expected = _cnpj_check_digits(self.value[:12])
+        if self.value[12:] != expected:
+            raise InvalidCnpjError(
+                f"CNPJ check digits do not verify: {self.value!r} "
+                f"(expected ...{expected})"
+            )
+
+    @classmethod
+    def parse(cls, raw: str) -> "Cnpj":
+        """Normalise ``raw`` to 14 canonical digits, then validate.
+
+        Strips ``.``, ``/``, ``-`` and whitespace; left-pads a 13-digit
+        result with one zero (the upstream catalogue defect). A stripped
+        length other than 13 or 14 raises
+        :class:`domain.errors.InvalidCnpjError`.
+        """
+        digits = raw.translate(_PUNCTUATION)
+        if len(digits) == 13:
+            digits = "0" + digits
+        if len(digits) != 14:
+            raise InvalidCnpjError(
+                f"cannot normalise to 14 digits: {raw!r} -> {digits!r}"
+            )
+        return cls(digits)
+
+    @property
+    def formatted(self) -> str:
+        """The punctuated form ``NN.NNN.NNN/NNNN-NN``."""
+        v = self.value
+        return f"{v[:2]}.{v[2:5]}.{v[5:8]}/{v[8:12]}-{v[12:]}"

--- a/app/src/domain/errors.py
+++ b/app/src/domain/errors.py
@@ -1,0 +1,66 @@
+"""The domain layer's exception hierarchy [M5-01].
+
+One module for every error the business rules raise, rather than the
+per-module exceptions used elsewhere in ``domain/`` (``OrphanTextExceeds
+ThresholdError`` and friends): those are loud-failure guards for a single
+script path, whereas M5-01 introduces a *cluster* of construction
+invariants that the application layer ([M5-02]) needs to catch as one group
+at the API boundary and map to HTTP status codes. A scattered set makes
+that fragile.
+
+Standard library only, like the rest of ``domain/`` -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+
+class DomainError(Exception):
+    """Base for every error the domain layer raises."""
+
+
+class InvalidValueObjectError(DomainError, ValueError):
+    """A value object was constructed from a malformed value.
+
+    Also a :class:`ValueError` so a caller can ``except ValueError`` the way
+    Python code conventionally does for a bad constructor argument, while
+    still being able to catch the precise domain type.
+    """
+
+
+class InvalidSusepProcessError(InvalidValueObjectError):
+    """A SUSEP process number did not match ``NNNNN.NNNNNN/NNNN-NN``."""
+
+
+class InvalidCnpjError(InvalidValueObjectError):
+    """A CNPJ was not 14 digits, or its check digits did not verify."""
+
+
+class InvariantViolationError(DomainError):
+    """An entity was constructed in a state its business rules forbid."""
+
+
+class CitationRequiredError(InvariantViolationError):
+    """An assessment was built with no citations.
+
+    The one M5-01 invariant with a dedicated type: it carries the offending
+    ``assessment_id`` so [M5-02] can report *which* assessment failed,
+    mirroring ``domain.clause_classification.MissingProvenanceError``.
+    """
+
+    def __init__(self, assessment_id: str) -> None:
+        """Build the message from the citation-free assessment's id."""
+        self.assessment_id = assessment_id
+        super().__init__(
+            f"assessment {assessment_id!r} must carry at least one citation"
+        )
+
+
+class VerdictNotPermittedError(InvariantViolationError):
+    """An assessment's verdict was not a :class:`domain.verdict.Verdict` member."""
+
+
+class DecisionMustReferenceAssessmentError(InvariantViolationError):
+    """A human decision was recorded without the id of the assessment it acted on."""
+
+
+class PolicyYearMismatchError(InvariantViolationError):
+    """A policy's ``process_year`` disagreed with its SUSEP process number."""

--- a/app/src/domain/human_decision.py
+++ b/app/src/domain/human_decision.py
@@ -1,0 +1,74 @@
+"""The human-decision entity [M5-01].
+
+What the analyst decided at the checkpoint ([M4-09]) -- the stdlib-dataclass
+twin of ``infrastructure.graph.state.HumanDecision``. Recorded alongside,
+never overwriting, the system's ``Assessment``.
+
+The M5-01 invariant the graph's version lacks: a decision **always
+references the assessment it acted on** (``assessment_id``). ``edited_
+assessment`` carries the analyst's revised opinion and is present exactly
+when the decision is ``EDIT`` -- and, when present, must revise *that same*
+assessment.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from domain.assessment import Assessment
+from domain.errors import DecisionMustReferenceAssessmentError
+
+
+class DecisionOutcome(Enum):
+    """What the analyst did with the system's recommendation.
+
+    Values match ``infrastructure.graph.state.HumanDecision.decision``'s
+    ``Literal`` so [M5-03]'s mapper is a ``DecisionOutcome(value)`` round trip.
+    """
+
+    APPROVE = "approve"
+    EDIT = "edit"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class HumanDecision:
+    """The analyst's recorded decision on one assessment."""
+
+    assessment_id: str
+    decision: DecisionOutcome
+    decided_at: datetime
+    notes: str = ""
+    edited_assessment: Assessment | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the assessment reference, the timezone and edit consistency."""
+        if not self.assessment_id:
+            raise DecisionMustReferenceAssessmentError(
+                "HumanDecision.assessment_id must reference the assessment acted on"
+            )
+        if not isinstance(self.decision, DecisionOutcome):
+            raise ValueError(
+                f"HumanDecision.decision must be a DecisionOutcome, "
+                f"got {self.decision!r}"
+            )
+        if self.decided_at.tzinfo is None or self.decided_at.utcoffset() is None:
+            raise ValueError("HumanDecision.decided_at must be timezone-aware")
+        is_edit = self.decision is DecisionOutcome.EDIT
+        if is_edit and self.edited_assessment is None:
+            raise ValueError("decision EDIT requires an edited_assessment")
+        if not is_edit and self.edited_assessment is not None:
+            raise ValueError(
+                f"decision {self.decision.value!r} must not carry an edited_assessment"
+            )
+        if (
+            self.edited_assessment is not None
+            and self.edited_assessment.assessment_id != self.assessment_id
+        ):
+            raise ValueError(
+                "edited_assessment must revise the same assessment the decision "
+                f"references ({self.assessment_id!r})"
+            )

--- a/app/src/domain/policy.py
+++ b/app/src/domain/policy.py
@@ -1,0 +1,72 @@
+"""The policy entity: a registered insurance product [M5-01].
+
+"Policy" here is SUSEP's *condições gerais* -- the registered product a
+claim is assessed against -- not an insurance contract and not a single
+document (a product can have several filed versions; ``data/README.md``,
+"Version pinning"). It promotes the seven bare-string fields of
+``domain.clause_classification.ClauseProvenance`` into an entity, with the
+two identifiers as validated value objects.
+
+``ClauseProvenance`` is left untouched: the parsing pipeline is frozen and
+``Policy`` is additive. ``product_line`` and ``indemnity_regime`` stay
+plain strings -- ``data/README.md`` keeps the Portuguese SUSEP codes
+verbatim so the corpus still joins back to the catalogue.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+
+from domain.cnpj import Cnpj
+from domain.errors import PolicyYearMismatchError
+from domain.susep_process import SusepProcess
+
+
+@dataclass(frozen=True)
+class Policy:
+    """A registered motor-insurance product, keyed by its SUSEP process."""
+
+    susep_process: SusepProcess
+    cnpj: Cnpj
+    insurer: str
+    product_line: str
+    indemnity_regime: str
+    process_year: str
+
+    def __post_init__(self) -> None:
+        """Reject empty descriptive fields, or a year the process disagrees with."""
+        for name in ("insurer", "product_line", "indemnity_regime", "process_year"):
+            if not getattr(self, name):
+                raise ValueError(f"Policy.{name} must not be empty")
+        if self.process_year != self.susep_process.year:
+            raise PolicyYearMismatchError(
+                f"process_year {self.process_year!r} does not match "
+                f"{self.susep_process.value!r} (year {self.susep_process.year!r})"
+            )
+
+    @classmethod
+    def from_manifest_row(cls, row: dict[str, str]) -> "Policy":
+        """Build from a ``data/policies/manifest.csv`` record.
+
+        ``Cnpj.parse`` applies the 14-digit zero-padding rule and
+        ``SusepProcess.parse`` accepts either written form. Mirrors
+        ``infrastructure.rag.retrieval_filter.RetrievalFilter.from_manifest_row``.
+        """
+        return cls(
+            susep_process=SusepProcess.parse(row["susep_process"]),
+            cnpj=Cnpj.parse(row["cnpj"]),
+            insurer=row["insurer"],
+            product_line=row["product_line"],
+            indemnity_regime=row["indemnity_regime"],
+            process_year=row["process_year"],
+        )
+
+    @property
+    def identity(self) -> SusepProcess:
+        """The semantic key: the SUSEP process identifies the product.
+
+        ``__eq__`` still compares every field; this names the key the
+        repositories ([M5-02]) look a policy up by.
+        """
+        return self.susep_process

--- a/app/src/domain/policy_clause.py
+++ b/app/src/domain/policy_clause.py
@@ -1,0 +1,48 @@
+"""The policy-clause entity [M5-01].
+
+Distinct from ``domain.clause_tree.Clause`` on purpose. That type is an
+18-field node in a document's parse tree -- a build-time artifact with
+parent/child pointers, page spans and per-line page attribution, cached to
+Parquet and never persisted. ``PolicyClause`` is the lean, persistence- and
+citation-facing view the application layer works in: the clause of a
+*registered product*, identified by a stable id, carrying its business type
+and text. [M5-02]'s ``ClauseRepository`` returns these to hydrate and
+validate a [domain.citation.Citation]; [M5-03]'s mapper builds one from a
+``clause_tree.Clause`` plus its ``TypedClause`` classification and
+``ClauseProvenance``.
+
+The DoD names this entity ``Clause``; it is named ``PolicyClause`` here to
+avoid shadowing the existing ``Clause`` -- recorded in
+``docs/ARCHITECTURE.md``.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+from dataclasses import dataclass
+
+from domain.clause_classification import ClauseType
+from domain.susep_process import SusepProcess
+
+
+@dataclass(frozen=True)
+class PolicyClause:
+    """One clause of a registered product, as the service layer sees it."""
+
+    clause_id: str
+    susep_process: SusepProcess
+    document_id: str
+    clause_type: ClauseType
+    text: str
+    heading: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject empty identifiers or text, or a non-``ClauseType`` type."""
+        for name in ("clause_id", "document_id", "text"):
+            if not getattr(self, name):
+                raise ValueError(f"PolicyClause.{name} must not be empty")
+        if not isinstance(self.clause_type, ClauseType):
+            raise ValueError(
+                f"PolicyClause.clause_type must be a ClauseType, "
+                f"got {self.clause_type!r}"
+            )

--- a/app/src/domain/susep_process.py
+++ b/app/src/domain/susep_process.py
@@ -1,0 +1,76 @@
+"""The SUSEP process number value object [M5-01].
+
+A SUSEP process number identifies a *registered product* -- not a single
+document and not an insurance contract (``data/README.md``, "Version
+pinning"). Its canonical written form is ``NNNNN.NNNNNN/NNNN-NN``, e.g.
+``15414.610650/2024-59``; the corpus stores the same 17 digits with the
+punctuation stripped as each document's filename stem.
+
+Format is validated at construction. The trailing ``-NN`` is *not*
+check-digit verified: SUSEP's process check-digit algorithm is not a
+stable, published specification (unlike the CNPJ mod-11 in
+[domain.cnpj]), and a false rejection of a real filing is unrecoverable.
+The one regex in the codebase that touched this (``scripts/eval_intake.py``)
+is likewise format-only.
+
+Standard library only -- enforced by
+tests/architecture/test_layer_boundaries.py.
+"""
+
+import re
+from dataclasses import dataclass
+
+from domain.errors import InvalidSusepProcessError
+
+_CANONICAL = re.compile(r"\d{5}\.\d{6}/\d{4}-\d{2}")
+_SEVENTEEN_DIGITS = re.compile(r"\d{17}")
+
+
+@dataclass(frozen=True)
+class SusepProcess:
+    """A SUSEP process number in canonical ``NNNNN.NNNNNN/NNNN-NN`` form.
+
+    Construct from an already-canonical string, or use :meth:`parse` for any
+    other form (the 17-digit filename stem, or a value with surrounding
+    whitespace).
+    """
+
+    value: str
+
+    def __post_init__(self) -> None:
+        """Reject anything but the exact canonical format."""
+        if not _CANONICAL.fullmatch(self.value):
+            raise InvalidSusepProcessError(
+                f"not a SUSEP process number (expected NNNNN.NNNNNN/NNNN-NN): "
+                f"{self.value!r}"
+            )
+
+    @classmethod
+    def parse(cls, raw: str) -> "SusepProcess":
+        """Normalise ``raw`` to canonical form, then validate.
+
+        Accepts the canonical form unchanged, or 17 bare digits (the
+        manifest filename stem); trims surrounding whitespace first. Anything
+        else raises :class:`domain.errors.InvalidSusepProcessError`.
+        """
+        stripped = raw.strip()
+        if _SEVENTEEN_DIGITS.fullmatch(stripped):
+            stripped = (
+                f"{stripped[:5]}.{stripped[5:11]}/{stripped[11:15]}-{stripped[15:]}"
+            )
+        return cls(stripped)
+
+    @property
+    def digits(self) -> str:
+        """The 17 digits with no punctuation, e.g. ``"15414610650202459"``."""
+        return self.value.translate(str.maketrans("", "", "./-"))
+
+    @property
+    def filename_stem(self) -> str:
+        """The document filename without its ``.pdf`` suffix -- the same 17 digits."""
+        return self.digits
+
+    @property
+    def year(self) -> str:
+        """The four-digit year in the ``/NNNN`` group, e.g. ``"2024"``."""
+        return self.value[13:17]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -573,3 +573,68 @@ without passing the checkpoint); `tests/integration/test_human_checkpoint.py`
 paused run survives a restart).
 
 Full contract, the verified `interrupt()` semantics and the table: `docs/HUMAN_CHECKPOINT.md`.
+
+---
+
+## Domain entities are frozen dataclasses that validate on construction — [M5-01]
+
+**Decision.** The business layer (`app/src/domain/`) is `Policy`, `PolicyClause`,
+`Claim`, `Assessment`, `HumanDecision`, the `Citation` value object and the
+`SusepProcess` / `Cnpj` identifier value objects — every one a
+`@dataclass(frozen=True)` whose `__post_init__` raises if the invariant it owns
+is broken. Closed vocabularies are `enum.Enum` (`Verdict` reused unchanged from
+[M4-01], `DecisionOutcome` new). Value objects take a strict constructor
+(already-canonical input) plus a lenient `parse()` classmethod that normalises
+I/O forms — `Cnpj.parse` applies the 14-digit zero-pad the upstream SUSEP
+catalogue needs; `SusepProcess.parse` accepts the 17-digit filename stem. One
+`domain/errors.py` holds the exception hierarchy. Standard library and typing
+only — no Pydantic, no SQLAlchemy, no LangGraph.
+
+**Why validate in `__post_init__`, and why the enum field still needs a guard.**
+A frozen dataclass gives immutability and structural equality for free but does
+**not** check its field types at runtime, so `Assessment(verdict="compatible",
+…)` would construct happily and the DoD's "a verdict is one of the three
+permitted values" invariant would be unenforced. Each entity therefore
+`isinstance`-guards its enum fields explicitly (`VerdictNotPermittedError`) and
+checks its cross-field rules (an assessment has ≥1 citation always — including
+for `insufficient_information`; a `HumanDecision` always carries the
+`assessment_id` it acted on, and an `edited_assessment` must revise that same
+id). `Cnpj` verifies the real mod-11 check digits — a public, stable algorithm,
+and a wrong-length or transposed-digit CNPJ is exactly the upstream-data bug
+class the value object exists to catch; `SusepProcess` is format-only, because
+SUSEP's process check-digit algorithm is not a published spec and a false
+rejection of a real filing is unrecoverable.
+
+**Why a twin of `infrastructure/graph/state.py`, not a move.** `state.py` is
+Pydantic (LangGraph needs it) and forbidden in `domain/` by
+`tests/architecture/test_layer_boundaries.py`. The graph keeps producing its
+`CompatibilityAssessment` / `HumanDecision` inside a run; the domain dataclasses
+are what the application ports ([M5-02]) and repositories ([M5-03]) speak in,
+with the mappers between the two owned by [M5-03]. `Verdict` is the one type
+already shared across both.
+
+**Deviation on record.** (a) The DoD names the clause entity `Clause`; it ships
+as `PolicyClause` so it does not shadow the existing 18-field parse-tree
+`Clause` (`domain/clause_tree.py`) — the two are never imported together, and
+both module docstrings state the split. (b) `domain/errors.py` centralises the
+exception hierarchy, unlike the per-module `OrphanTextExceedsThresholdError`
+pattern elsewhere in `domain/`: M5-01's errors are a cluster the API boundary
+catches as one group. (c) `Assessment` omits consistency signals — no M5-01
+invariant touches them; persisting `ConsistencyReport` is [M5-03]'s call. (d)
+The ≥1-citation invariant is unconditional, so the compatibility node's
+abstain-on-empty-retrieval output is not a persistable `Assessment` — it stays
+in claim state and the audit trail, a fact [M5-02]/[M5-03] account for.
+`ClauseProvenance` is left untouched; `Policy` is additive.
+
+**Enforcement.** `tests/unit/domain/` — one `test_<module>.py` per entity, every
+invariant with its rejection case (`test_assessment.py` on the ≥1-citation and
+verdict-type rules, `test_human_decision.py` on the assessment reference and the
+edit-consistency rules, `test_cnpj.py` parametrized over all 30 manifest CNPJs).
+`tests/architecture/test_layer_boundaries.py` already AST-scans all of
+`app/src/domain/` for a forbidden import and needs no change — the new
+stdlib-only modules are covered automatically.
+`tests/architecture/test_scope_vocabulary.py` now scans the whole `domain/`
+package, not just `verdict.py`.
+
+Full field tables, the invariant list and the relationship to `state.py`:
+`docs/DOMAIN.md`.

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -1,0 +1,206 @@
+# Domain entities
+
+The [M5-01] business layer: the nouns the service is about and the rules they
+must always satisfy, modelled with **no framework in sight**. Everything here is
+in `app/src/domain/`, imports nothing but the standard library and `typing`, and
+is a `@dataclass(frozen=True)` or an `enum.Enum`. `tests/architecture/
+test_layer_boundaries.py` fails CI if a domain module ever imports Pydantic,
+SQLAlchemy, LangGraph or LangChain.
+
+**Why it exists as its own layer.** M5 wraps the agent graph in a service
+([M5-02] ports, [M5-03] persistence, [M5-04] API). The entities here are the
+currency those layers are written in — a repository returns an `Assessment`, a
+use case takes a `Claim`, the API serialises a `HumanDecision`. Keeping them
+framework-free means the business rules are testable by construction, in
+microseconds, with no graph, no database and no HTTP.
+
+**Relationship to the agent graph.** `infrastructure/graph/state.py` holds
+Pydantic *twins* of several of these types (`Citation`, `CompatibilityAssessment`,
+`HumanDecision`, …) — it has to, because LangGraph needs Pydantic and Pydantic is
+forbidden in `domain/`. The graph keeps producing those inside a run; the domain
+dataclasses are the persisted, API-facing shape. The mappers between the two are
+[M5-03]'s deliverable. `domain.verdict.Verdict` is the one type already shared by
+both, unchanged since [M4-01].
+
+---
+
+## Value objects
+
+### `SusepProcess` — `domain/susep_process.py`
+
+A SUSEP process number identifies a **registered product**, not a single document
+and not an insurance contract (`data/README.md`, "Version pinning"). Canonical
+written form `NNNNN.NNNNNN/NNNN-NN`, e.g. `15414.610650/2024-59`.
+
+| Member | Purpose |
+| --- | --- |
+| `value: str` | The canonical string. `__post_init__` rejects anything that is not an exact `re.fullmatch` of `\d{5}\.\d{6}/\d{4}-\d{2}` → `InvalidSusepProcessError`. |
+| `parse(raw) -> SusepProcess` | Normalises then validates: trims whitespace, and expands the 17-digit filename stem (`15414610650202459`) back to canonical form. |
+| `.digits` / `.filename_stem` | The 17 digits with no punctuation — equals the corpus filename minus `.pdf`. |
+| `.year` | The `/NNNN` group, e.g. `"2024"` — equals the manifest `process_year` column. |
+
+The trailing `-NN` is **not** check-digit verified. SUSEP's process check-digit
+algorithm is not a published, stable specification (unlike CNPJ's), and a false
+rejection of a real filing is unrecoverable. The only pre-existing SUSEP regex in
+the repo (`scripts/eval_intake.py`) is likewise format-only.
+
+### `Cnpj` — `domain/cnpj.py`
+
+The 14-digit Brazilian company registration number — the reliable identity key
+for an insurer, since two companies can share a brand and differ only here
+(`data/README.md`; HDI Seguros vs HDI Global).
+
+| Member | Purpose |
+| --- | --- |
+| `value: str` | Exactly 14 ASCII digits. `__post_init__` checks the length, that every character is a digit, **and** that the two trailing digits satisfy the standard mod-11 check-digit algorithm → `InvalidCnpjError`. |
+| `parse(raw) -> Cnpj` | Strips `.` `/` `-` and whitespace, then applies the **14-digit zero-padding rule** — left-pads a 13-digit value with one `0` — then validates. A stripped length other than 13 or 14 raises. |
+| `.formatted` | The punctuated form `NN.NNN.NNN/NNNN-NN`. |
+| `_cnpj_check_digits(base12)` | Module-private; the mod-11 helper, exposed so tests can synthesise valid values. |
+
+**The zero-padding rule.** SUSEP's open product catalogue publishes CNPJ as a
+number rather than a fixed-width string, so 41 of its 180 motor-line rows have
+lost a leading zero and carry 13 digits (`data/README.md`, "Known upstream
+defect"). `data/policies/manifest.csv` is already corrected; `Cnpj.parse` is what
+makes any *future* read from that catalogue correct too. All 30 corpus CNPJs pass
+the checksum — a parametrized test in `test_cnpj.py` asserts it.
+
+The checksum trade-off: a hand-rolled random 14-digit fixture will be rejected.
+That is the value object doing its job — fixtures use real corpus CNPJs or
+`_cnpj_check_digits` to build valid ones.
+
+---
+
+## Entities
+
+### `Policy` — `domain/policy.py`
+
+A registered motor-insurance product (SUSEP *condições gerais*). Promotes the
+seven bare-string fields of `domain.clause_classification.ClauseProvenance` into
+an entity with validated identifiers. `ClauseProvenance` is left untouched — the
+parsing pipeline is frozen and `Policy` is additive.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `susep_process` | `SusepProcess` | The identity (`.identity` returns it). "Identifies the registered product, not a single document." |
+| `cnpj` | `Cnpj` | The filing company. |
+| `insurer` | `str` | Non-empty; verbatim legal name. |
+| `product_line` | `str` | Non-empty; `CASCO` / `RCF-A` / `ASSIST` / `GAR.EST` / `CARTA VERDE`. Kept a string, not an enum — `data/README.md` keeps the Portuguese SUSEP codes verbatim so the corpus joins back to the catalogue. |
+| `indemnity_regime` | `str` | Non-empty; `VD` / `VMR` / `VD+VMR` / `n/a`. |
+| `process_year` | `str` | **Invariant:** must equal `susep_process.year` → `PolicyYearMismatchError`. |
+
+`Policy.from_manifest_row(row)` builds one from a `data/policies/manifest.csv`
+record (mirrors `RetrievalFilter.from_manifest_row`); `Cnpj.parse` applies the
+zero-pad there.
+
+### `PolicyClause` — `domain/policy_clause.py`
+
+One clause of a registered product, as the service layer sees it: a stable id,
+its business type, its text. **Distinct from `domain.clause_tree.Clause`** — that
+is an 18-field parse-tree node (parent/child pointers, page spans, per-line page
+attribution), a build-time artifact cached to Parquet and never persisted.
+[M5-02]'s `ClauseRepository` returns `PolicyClause`; [M5-03]'s mapper builds one
+from a `clause_tree.Clause` + its `TypedClause` classification + `ClauseProvenance`.
+
+The DoD names this entity `Clause`; it is `PolicyClause` to avoid shadowing the
+existing name (`docs/ARCHITECTURE.md` records the deviation).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `clause_id` | `str` | Non-empty; the `f"{document_id}:{path}"` convention. |
+| `susep_process` | `SusepProcess` | The registered product it belongs to. |
+| `document_id` | `str` | Non-empty; which parsed filing/version. |
+| `clause_type` | `ClauseType` | `isinstance`-guarded. |
+| `text` | `str` | Non-empty. |
+| `heading` | `str` | Optional (numbering label + title), for the API. |
+
+### `Citation` — `domain/citation.py`
+
+The stdlib twin of `state.Citation`: one clause an assessment's reasoning is
+grounded in. `clause_id`, `document_id`, `excerpt` non-empty; `susep_process` a
+`SusepProcess`; `clause_type` a `ClauseType`; `relevance_score` a float `>= 0.0`
+defaulting to `0.0` (a structurally co-retrieved exclusion the ranker missed
+carries `0.0` — `docs/ARCHITECTURE.md`, M3-06).
+
+### `Claim` — `domain/claim.py`
+
+The free-text loss narrative a policyholder submits, before the graph makes
+structured sense of it.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `claim_id` | `str` | Non-empty. |
+| `raw_text` | `str` | Non-empty; `ClaimState.raw_claim_text`. |
+| `submitted_at` | `datetime` | **Must be timezone-aware.** |
+| `policy_ref` | `SusepProcess \| None` | The registered product the claim is filed against. `None` is the honest default today — intake *extracts* it from the narrative; [M5-04] makes it a first-class submission field. |
+
+The structured read intake produces (`ExtractedEntities`) stays in
+`infrastructure/graph/state.py` — it is graph working state, not a business
+entity the DoD names.
+
+### `Assessment` — `domain/assessment.py`
+
+The settled compatibility assessment for one claim — the twin of
+`state.CompatibilityAssessment` plus the `recommended_action` the reviewer acts
+on (so `GET /v1/assessments/{id}` returns one entity, not two).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `assessment_id` | `str` | Non-empty; caller/DB supplied — the domain does not mint ids. |
+| `claim_id` | `str` | Non-empty; reference by id, never the `Claim` object. |
+| `verdict` | `Verdict` | **Invariant:** must be a `Verdict` member → `VerdictNotPermittedError`. |
+| `reasoning` | `str` | Non-empty; rendered prose. |
+| `citations` | `tuple[Citation, ...]` | **Invariant:** length `>= 1`, always → `CitationRequiredError(assessment_id)`. |
+| `confidence` | `float` | In `[0.0, 1.0]`. |
+| `recommended_action` | `str` | Non-empty. |
+
+Consistency signals are out of scope — no M5-01 invariant touches them.
+
+### `HumanDecision` — `domain/human_decision.py`
+
+What the analyst decided at the checkpoint ([M4-09]), recorded alongside — never
+overwriting — the system's `Assessment`. `DecisionOutcome` is the enum
+(`APPROVE` / `EDIT` / `REJECT`; values match `state.HumanDecision.decision`'s
+`Literal` so [M5-03]'s mapper is a one-liner).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `assessment_id` | `str` | **Invariant:** non-empty — a decision always references the assessment it acted on → `DecisionMustReferenceAssessmentError`. |
+| `decision` | `DecisionOutcome` | `isinstance`-guarded. |
+| `decided_at` | `datetime` | **Must be timezone-aware.** |
+| `notes` | `str` | Optional. |
+| `edited_assessment` | `Assessment \| None` | **Invariant:** present iff `decision is EDIT`; when present, its `assessment_id` must equal this decision's. Mirrors `state.py`'s `_check_edit_carries_a_revision`. |
+
+---
+
+## Invariants and their errors
+
+`domain/errors.py` holds the hierarchy. `InvalidValueObjectError` is also a
+`ValueError` (so `except ValueError` works on a bad constructor argument the
+conventional way); `InvariantViolationError` is a `DomainError` only.
+
+| Invariant | Where | Error |
+| --- | --- | --- |
+| A verdict is one of the three permitted values | `Assessment` | `VerdictNotPermittedError` |
+| An assessment always has ≥1 citation | `Assessment` | `CitationRequiredError` (carries `assessment_id`) |
+| A decision always references the assessment it acted on | `HumanDecision` | `DecisionMustReferenceAssessmentError` |
+| An edit revises the same assessment it references | `HumanDecision` | `ValueError` |
+| A SUSEP process matches the canonical format | `SusepProcess` | `InvalidSusepProcessError` |
+| A CNPJ is 14 digits with valid check digits | `Cnpj` | `InvalidCnpjError` |
+| A policy's `process_year` agrees with its process number | `Policy` | `PolicyYearMismatchError` |
+| Timestamps are timezone-aware | `Claim`, `HumanDecision` | `ValueError` |
+
+Bare `ValueError` (not a domain type) is used for field-level checks — an empty
+string, a score below zero, a non-enum passed where an enum belongs — matching
+the rest of `domain/`.
+
+---
+
+## Deferred
+
+- **Consistency signals on `Assessment`** — until a use case needs
+  `ConsistencyReport` persisted ([M5-03]).
+- **`ExtractedEntities`** — stays graph working state in `infrastructure/graph/
+  state.py`; not a DoD entity.
+- **Mappers** — domain ↔ ORM row, and domain ↔ `state.py` Pydantic — are [M5-03].
+- **`Claim.policy_ref` as a required field** — [M5-04], when the submission API
+  takes it explicitly.

--- a/tests/architecture/test_scope_vocabulary.py
+++ b/tests/architecture/test_scope_vocabulary.py
@@ -17,7 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PROMPTS_DIR = REPO_ROOT / "app" / "src" / "infrastructure" / "graph" / "prompts"
 GRAPH_DIR = REPO_ROOT / "app" / "src" / "infrastructure" / "graph"
 ENUMS_FILE = REPO_ROOT / "app" / "src" / "infrastructure" / "config" / "enums.py"
-VERDICT_FILE = REPO_ROOT / "app" / "src" / "domain" / "verdict.py"
+DOMAIN_DIR = REPO_ROOT / "app" / "src" / "domain"
 
 FORBIDDEN_PATTERN = re.compile(
     r"\b(covered|uncovered|denied|denial|coverage decision)\b", re.IGNORECASE
@@ -53,11 +53,14 @@ def test_no_forbidden_verdict_vocabulary_in_graph() -> None:
 
 
 @pytest.mark.unit
-def test_no_forbidden_verdict_vocabulary_in_verdict_and_enums() -> None:
-    violations = []
-    for enum_file in (ENUMS_FILE, VERDICT_FILE):
-        if enum_file.exists():
-            violations.extend(_scan_file(enum_file))
-    assert not violations, "forbidden verdict vocabulary found in enums:\n" + "\n".join(
-        violations
+def test_no_forbidden_verdict_vocabulary_in_domain_and_enums() -> None:
+    # The whole domain package, not just verdict.py: [M5-01]'s entities carry
+    # the verdict enum reference, the citation types and free-text
+    # ``reasoning`` / ``recommended_action`` semantics on ``Assessment`` -- a
+    # covered/denied literal must not drift into any of them either.
+    violations = _scan_file(ENUMS_FILE) if ENUMS_FILE.exists() else []
+    for py_file in sorted(DOMAIN_DIR.rglob("*.py")):
+        violations.extend(_scan_file(py_file))
+    assert not violations, "forbidden verdict vocabulary found in domain/enums:\n" + (
+        "\n".join(violations)
     )

--- a/tests/unit/domain/test_assessment.py
+++ b/tests/unit/domain/test_assessment.py
@@ -1,0 +1,93 @@
+"""The Assessment entity and its invariants [M5-01]."""
+
+import dataclasses
+
+import pytest
+
+from domain.assessment import Assessment
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.errors import CitationRequiredError, VerdictNotPermittedError
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+
+
+def _citation() -> Citation:
+    return Citation(
+        clause_id="15414610650202459:2.1",
+        document_id="1",
+        susep_process=SusepProcess("15414.610650/2024-59"),
+        clause_type=ClauseType.COVERAGE,
+        excerpt="A cobertura compreende colisao, incendio e roubo.",
+        relevance_score=0.83,
+    )
+
+
+def _assessment(**overrides: object) -> Assessment:
+    fields: dict[str, object] = {
+        "assessment_id": "assessment-1",
+        "claim_id": "claim-1",
+        "verdict": Verdict.COMPATIBLE,
+        "reasoning": "O evento descrito e uma colisao, coberta pela clausula 2.1.",
+        "citations": (_citation(),),
+        "confidence": 0.72,
+        "recommended_action": "Encaminhar para analise humana.",
+    }
+    fields.update(overrides)
+    return Assessment(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_accepts_a_full_assessment() -> None:
+    assessment = _assessment()
+
+    assert assessment.verdict is Verdict.COMPATIBLE
+    assert len(assessment.citations) == 1
+
+
+@pytest.mark.unit
+def test_rejects_an_assessment_with_no_citations() -> None:
+    with pytest.raises(CitationRequiredError) as excinfo:
+        _assessment(citations=())
+
+    assert excinfo.value.assessment_id == "assessment-1"
+
+
+@pytest.mark.unit
+def test_the_at_least_one_citation_rule_is_unconditional() -> None:
+    # Even an insufficient_information verdict must carry a citation; the
+    # graph's abstain-on-empty-retrieval output is not a persistable
+    # Assessment.
+    assessment = _assessment(verdict=Verdict.INSUFFICIENT_INFORMATION)
+
+    assert assessment.verdict is Verdict.INSUFFICIENT_INFORMATION
+    with pytest.raises(CitationRequiredError):
+        _assessment(verdict=Verdict.INSUFFICIENT_INFORMATION, citations=())
+
+
+@pytest.mark.unit
+def test_rejects_a_verdict_that_is_not_a_verdict_member() -> None:
+    with pytest.raises(VerdictNotPermittedError):
+        _assessment(verdict="compatible")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("confidence", [-0.1, 1.1])
+def test_rejects_a_confidence_outside_the_unit_interval(confidence: float) -> None:
+    with pytest.raises(ValueError):
+        _assessment(confidence=confidence)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field", ["assessment_id", "claim_id", "reasoning", "recommended_action"]
+)
+def test_rejects_an_empty_string_field(field: str) -> None:
+    with pytest.raises(ValueError):
+        _assessment(**{field: ""})
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _assessment().confidence = 0.9  # type: ignore[misc]

--- a/tests/unit/domain/test_citation.py
+++ b/tests/unit/domain/test_citation.py
@@ -1,0 +1,69 @@
+"""The Citation value object [M5-01]."""
+
+import dataclasses
+
+import pytest
+
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.susep_process import SusepProcess
+
+
+def _citation(**overrides: object) -> Citation:
+    fields: dict[str, object] = {
+        "clause_id": "15414610650202459:2.1",
+        "document_id": "1",
+        "susep_process": SusepProcess("15414.610650/2024-59"),
+        "clause_type": ClauseType.COVERAGE,
+        "excerpt": "A cobertura compreende colisao, incendio e roubo.",
+        "relevance_score": 0.83,
+    }
+    fields.update(overrides)
+    return Citation(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_accepts_a_full_citation() -> None:
+    citation = _citation()
+
+    assert citation.clause_type is ClauseType.COVERAGE
+    assert citation.relevance_score == 0.83
+
+
+@pytest.mark.unit
+def test_relevance_score_defaults_to_zero() -> None:
+    # A structurally co-retrieved exclusion the ranker missed carries 0.0.
+    citation = Citation(
+        clause_id="c1",
+        document_id="1",
+        susep_process=SusepProcess("15414.610650/2024-59"),
+        clause_type=ClauseType.EXCLUSION,
+        excerpt="Estao excluidos os eventos decorrentes de...",
+    )
+
+    assert citation.relevance_score == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["clause_id", "document_id", "excerpt"])
+def test_rejects_an_empty_string_field(field: str) -> None:
+    with pytest.raises(ValueError):
+        _citation(**{field: ""})
+
+
+@pytest.mark.unit
+def test_rejects_a_negative_relevance_score() -> None:
+    with pytest.raises(ValueError):
+        _citation(relevance_score=-0.1)
+
+
+@pytest.mark.unit
+def test_rejects_a_bare_string_clause_type() -> None:
+    with pytest.raises(ValueError):
+        _citation(clause_type="coverage")
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _citation().relevance_score = 0.9  # type: ignore[misc]

--- a/tests/unit/domain/test_claim.py
+++ b/tests/unit/domain/test_claim.py
@@ -1,0 +1,54 @@
+"""The Claim entity [M5-01]."""
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.claim import Claim
+from domain.susep_process import SusepProcess
+
+
+def _claim(**overrides: object) -> Claim:
+    fields: dict[str, object] = {
+        "claim_id": "claim-1",
+        "raw_text": "Bati o carro na traseira de outro veiculo ontem a noite.",
+        "submitted_at": datetime(2026, 9, 3, 9, 30, tzinfo=UTC),
+        "policy_ref": None,
+    }
+    fields.update(overrides)
+    return Claim(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_accepts_a_minimal_claim() -> None:
+    claim = _claim()
+
+    assert claim.policy_ref is None
+
+
+@pytest.mark.unit
+def test_accepts_a_known_policy_reference() -> None:
+    process = SusepProcess("15414.610650/2024-59")
+    claim = _claim(policy_ref=process)
+
+    assert claim.policy_ref == process
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["claim_id", "raw_text"])
+def test_rejects_an_empty_string_field(field: str) -> None:
+    with pytest.raises(ValueError):
+        _claim(**{field: ""})
+
+
+@pytest.mark.unit
+def test_rejects_a_naive_submitted_at() -> None:
+    with pytest.raises(ValueError):
+        _claim(submitted_at=datetime(2026, 1, 1))  # noqa: DTZ001
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _claim().raw_text = "x"  # type: ignore[misc]

--- a/tests/unit/domain/test_cnpj.py
+++ b/tests/unit/domain/test_cnpj.py
@@ -1,0 +1,73 @@
+"""The Cnpj value object [M5-01]."""
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from domain.cnpj import Cnpj, _cnpj_check_digits
+from domain.errors import InvalidCnpjError
+from infrastructure.parsing.manifest import read_manifest
+
+# Porto Seguro, manifest row 1 -- a real, valid CNPJ.
+_VALID = "61198164000160"
+_MANIFEST_CNPJS = [
+    row["cnpj"] for row in read_manifest(Path("data/policies/manifest.csv"))
+]
+
+
+@pytest.mark.unit
+def test_accepts_a_valid_fourteen_digit_cnpj() -> None:
+    assert Cnpj(_VALID).value == _VALID
+
+
+@pytest.mark.unit
+def test_parse_left_pads_the_thirteen_digit_catalogue_defect() -> None:
+    # SUSEP's open catalogue drops the leading zero; the corpus stores the
+    # corrected 14-digit form (manifest row 26, USEBENS Seguros).
+    assert Cnpj.parse("9180505000150") == Cnpj("09180505000150")
+
+
+@pytest.mark.unit
+def test_parse_strips_punctuation() -> None:
+    assert Cnpj.parse("61.198.164/0001-60") == Cnpj(_VALID)
+
+
+@pytest.mark.unit
+def test_formatted_renders_the_punctuated_form() -> None:
+    assert Cnpj(_VALID).formatted == "61.198.164/0001-60"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "12345",  # too short, cannot pad
+        "611981640001600",  # 15 digits
+        "6119816400016X",  # non-numeric
+        "611981640001",  # 12 digits -- parse only pads 13 -> 14
+    ],
+)
+def test_parse_rejects_a_value_it_cannot_normalise(raw: str) -> None:
+    with pytest.raises(InvalidCnpjError):
+        Cnpj.parse(raw)
+
+
+@pytest.mark.unit
+def test_constructor_rejects_valid_length_wrong_check_digits() -> None:
+    with pytest.raises(InvalidCnpjError):
+        Cnpj("61198164000161")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", _MANIFEST_CNPJS)
+def test_every_manifest_cnpj_has_correct_check_digits(value: str) -> None:
+    assert _cnpj_check_digits(value[:12]) == value[12:]
+    assert Cnpj(value).value == value
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        Cnpj(_VALID).value = "x"  # type: ignore[misc]

--- a/tests/unit/domain/test_errors.py
+++ b/tests/unit/domain/test_errors.py
@@ -1,0 +1,35 @@
+"""The domain exception hierarchy [M5-01]."""
+
+import pytest
+
+from domain.errors import (
+    CitationRequiredError,
+    DomainError,
+    InvalidCnpjError,
+    InvalidValueObjectError,
+    InvariantViolationError,
+)
+
+
+@pytest.mark.unit
+def test_value_object_errors_are_also_value_errors() -> None:
+    # A caller can `except ValueError` a bad constructor argument the
+    # conventional way, or catch the precise domain type.
+    assert issubclass(InvalidCnpjError, ValueError)
+    assert issubclass(InvalidCnpjError, InvalidValueObjectError)
+    assert issubclass(InvalidValueObjectError, DomainError)
+
+
+@pytest.mark.unit
+def test_invariant_errors_are_domain_errors_but_not_value_errors() -> None:
+    assert issubclass(InvariantViolationError, DomainError)
+    assert not issubclass(InvariantViolationError, ValueError)
+
+
+@pytest.mark.unit
+def test_citation_required_error_carries_the_assessment_id() -> None:
+    error = CitationRequiredError("assessment-42")
+
+    assert isinstance(error, InvariantViolationError)
+    assert error.assessment_id == "assessment-42"
+    assert "assessment-42" in str(error)

--- a/tests/unit/domain/test_human_decision.py
+++ b/tests/unit/domain/test_human_decision.py
@@ -1,0 +1,118 @@
+"""The HumanDecision entity and its invariants [M5-01]."""
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.assessment import Assessment
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.errors import DecisionMustReferenceAssessmentError
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+
+_ASSESSMENT_ID = "assessment-1"
+
+
+def _assessment(assessment_id: str = _ASSESSMENT_ID, **overrides: object) -> Assessment:
+    fields: dict[str, object] = {
+        "assessment_id": assessment_id,
+        "claim_id": "claim-1",
+        "verdict": Verdict.INCOMPATIBLE,
+        "reasoning": "O evento e uma colisao; a apolice cobre apenas roubo.",
+        "citations": (
+            Citation(
+                clause_id="15414610650202459:3.2",
+                document_id="1",
+                susep_process=SusepProcess("15414.610650/2024-59"),
+                clause_type=ClauseType.EXCLUSION,
+                excerpt="Estao excluidos os danos por colisao.",
+            ),
+        ),
+        "confidence": 0.6,
+        "recommended_action": "Recusar o sinistro.",
+    }
+    fields.update(overrides)
+    return Assessment(**fields)  # type: ignore[arg-type]
+
+
+def _decision(**overrides: object) -> HumanDecision:
+    fields: dict[str, object] = {
+        "assessment_id": _ASSESSMENT_ID,
+        "decision": DecisionOutcome.APPROVE,
+        "decided_at": datetime(2026, 9, 3, 12, 0, tzinfo=UTC),
+        "notes": "",
+        "edited_assessment": None,
+    }
+    fields.update(overrides)
+    return HumanDecision(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("outcome", [DecisionOutcome.APPROVE, DecisionOutcome.REJECT])
+def test_accepts_approve_and_reject_without_an_edit(outcome: DecisionOutcome) -> None:
+    decision = _decision(decision=outcome)
+
+    assert decision.decision is outcome
+    assert decision.edited_assessment is None
+
+
+@pytest.mark.unit
+def test_rejects_a_decision_with_no_assessment_reference() -> None:
+    with pytest.raises(DecisionMustReferenceAssessmentError):
+        _decision(assessment_id="")
+
+
+@pytest.mark.unit
+def test_edit_requires_an_edited_assessment() -> None:
+    with pytest.raises(ValueError):
+        _decision(decision=DecisionOutcome.EDIT)
+
+
+@pytest.mark.unit
+def test_non_edit_must_not_carry_an_edited_assessment() -> None:
+    with pytest.raises(ValueError):
+        _decision(decision=DecisionOutcome.APPROVE, edited_assessment=_assessment())
+
+
+@pytest.mark.unit
+def test_rejects_a_bare_string_decision() -> None:
+    with pytest.raises(ValueError):
+        _decision(decision="approve")
+
+
+@pytest.mark.unit
+def test_rejects_a_naive_decided_at() -> None:
+    with pytest.raises(ValueError):
+        _decision(decided_at=datetime(2026, 1, 1))  # noqa: DTZ001
+
+
+@pytest.mark.unit
+def test_edited_assessment_must_revise_the_referenced_assessment() -> None:
+    with pytest.raises(ValueError):
+        _decision(
+            decision=DecisionOutcome.EDIT,
+            edited_assessment=_assessment(assessment_id="a-different-one"),
+        )
+
+
+@pytest.mark.unit
+def test_edit_round_trips_the_revised_verdict() -> None:
+    revised = _assessment(verdict=Verdict.COMPATIBLE, recommended_action="Aprovar.")
+    decision = _decision(decision=DecisionOutcome.EDIT, edited_assessment=revised)
+
+    assert decision.edited_assessment is not None
+    assert decision.edited_assessment.verdict is Verdict.COMPATIBLE
+
+
+@pytest.mark.unit
+def test_decision_outcome_values_match_the_graph_literal() -> None:
+    assert {o.value for o in DecisionOutcome} == {"approve", "edit", "reject"}
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _decision().notes = "x"  # type: ignore[misc]

--- a/tests/unit/domain/test_policy.py
+++ b/tests/unit/domain/test_policy.py
@@ -1,0 +1,79 @@
+"""The Policy entity [M5-01]."""
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from domain.cnpj import Cnpj
+from domain.errors import InvalidValueObjectError, PolicyYearMismatchError
+from domain.policy import Policy
+from domain.susep_process import SusepProcess
+from infrastructure.parsing.manifest import read_manifest
+
+_MANIFEST = read_manifest(Path("data/policies/manifest.csv"))
+_ROW_1 = _MANIFEST[0]
+_ROW_26 = next(row for row in _MANIFEST if row["id"] == "26")
+
+
+def _policy(**overrides: object) -> Policy:
+    fields: dict[str, object] = {
+        "susep_process": SusepProcess("15414.610650/2024-59"),
+        "cnpj": Cnpj("61198164000160"),
+        "insurer": "PORTO SEGURO COMPANHIA DE SEGUROS GERAIS",
+        "product_line": "CASCO",
+        "indemnity_regime": "VD",
+        "process_year": "2024",
+    }
+    fields.update(overrides)
+    return Policy(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_accepts_a_full_policy() -> None:
+    policy = _policy()
+
+    assert policy.identity == SusepProcess("15414.610650/2024-59")
+    assert isinstance(policy.identity, SusepProcess)
+
+
+@pytest.mark.unit
+def test_from_manifest_row_applies_the_cnpj_zero_pad() -> None:
+    policy = Policy.from_manifest_row(_ROW_26)
+
+    assert policy.cnpj.value == "09180505000150"
+    assert len(policy.cnpj.value) == 14
+
+
+@pytest.mark.unit
+def test_from_manifest_row_round_trips_every_corpus_row() -> None:
+    for row in _MANIFEST:
+        policy = Policy.from_manifest_row(row)
+        assert policy.susep_process.value == row["susep_process"]
+        assert policy.process_year == row["process_year"]
+
+
+@pytest.mark.unit
+def test_rejects_a_year_that_disagrees_with_the_process() -> None:
+    with pytest.raises(PolicyYearMismatchError):
+        _policy(process_year="2023")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["insurer", "product_line", "indemnity_regime"])
+def test_rejects_an_empty_descriptive_field(field: str) -> None:
+    with pytest.raises(ValueError):
+        _policy(**{field: ""})
+
+
+@pytest.mark.unit
+def test_from_manifest_row_surfaces_a_malformed_identifier() -> None:
+    bad = {**_ROW_1, "cnpj": "not-a-cnpj"}
+    with pytest.raises(InvalidValueObjectError):
+        Policy.from_manifest_row(bad)
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _policy().insurer = "x"  # type: ignore[misc]

--- a/tests/unit/domain/test_policy_clause.py
+++ b/tests/unit/domain/test_policy_clause.py
@@ -1,0 +1,54 @@
+"""The PolicyClause entity [M5-01]."""
+
+import dataclasses
+
+import pytest
+
+from domain.clause_classification import ClauseType
+from domain.policy_clause import PolicyClause
+from domain.susep_process import SusepProcess
+
+
+def _clause(**overrides: object) -> PolicyClause:
+    fields: dict[str, object] = {
+        "clause_id": "15414610650202459:2.1",
+        "susep_process": SusepProcess("15414.610650/2024-59"),
+        "document_id": "1",
+        "clause_type": ClauseType.COVERAGE,
+        "text": "A cobertura compreende colisao, incendio e roubo.",
+        "heading": "2.1 Coberturas",
+    }
+    fields.update(overrides)
+    return PolicyClause(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_accepts_a_full_clause() -> None:
+    clause = _clause()
+
+    assert clause.clause_type is ClauseType.COVERAGE
+    assert clause.heading == "2.1 Coberturas"
+
+
+@pytest.mark.unit
+def test_heading_is_optional() -> None:
+    assert _clause(heading="").heading == ""
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["clause_id", "document_id", "text"])
+def test_rejects_an_empty_string_field(field: str) -> None:
+    with pytest.raises(ValueError):
+        _clause(**{field: ""})
+
+
+@pytest.mark.unit
+def test_rejects_a_bare_string_clause_type() -> None:
+    with pytest.raises(ValueError):
+        _clause(clause_type="coverage")
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _clause().text = "x"  # type: ignore[misc]

--- a/tests/unit/domain/test_susep_process.py
+++ b/tests/unit/domain/test_susep_process.py
@@ -1,0 +1,80 @@
+"""The SusepProcess value object [M5-01]."""
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from domain.errors import InvalidSusepProcessError
+from domain.susep_process import SusepProcess
+from infrastructure.parsing.manifest import read_manifest
+
+_CANONICAL = "15414.610650/2024-59"
+_STEM = "15414610650202459"
+
+
+@pytest.mark.unit
+def test_accepts_the_canonical_written_form() -> None:
+    process = SusepProcess(_CANONICAL)
+
+    assert process.value == _CANONICAL
+
+
+@pytest.mark.unit
+def test_parse_accepts_the_seventeen_digit_filename_stem() -> None:
+    assert SusepProcess.parse(_STEM) == SusepProcess(_CANONICAL)
+
+
+@pytest.mark.unit
+def test_parse_strips_surrounding_whitespace() -> None:
+    assert SusepProcess.parse(f"  {_CANONICAL}\n") == SusepProcess(_CANONICAL)
+
+
+@pytest.mark.unit
+def test_decomposition_properties() -> None:
+    process = SusepProcess(_CANONICAL)
+
+    assert process.digits == _STEM
+    assert process.filename_stem == _STEM
+    assert process.year == "2024"
+
+
+@pytest.mark.unit
+def test_filename_stem_matches_the_manifest_filename() -> None:
+    rows = read_manifest(Path("data/policies/manifest.csv"))
+    for row in rows:
+        process = SusepProcess.parse(row["susep_process"])
+        assert f"{process.filename_stem}.pdf" == row["filename"]
+        assert process.year == row["process_year"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "15414.610650/2024",  # no check group
+        "1541.610650/2024-59",  # 4-digit prefix
+        "15414-610650/2024-59",  # wrong separator
+        "15414.610650/2024-5",  # 1-digit check group
+        "1541X.610650/2024-59",  # letter in the number
+        "15414.610650/2024-59 ",  # trailing space, bare constructor
+        " 15414.610650/2024-59",  # leading space, bare constructor
+    ],
+)
+def test_constructor_rejects_a_malformed_value(raw: str) -> None:
+    with pytest.raises(InvalidSusepProcessError):
+        SusepProcess(raw)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw", ["1541461065020245", "154146106502024590"])
+def test_parse_rejects_a_wrong_length_digit_string(raw: str) -> None:
+    with pytest.raises(InvalidSusepProcessError):
+        SusepProcess.parse(raw)
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        SusepProcess(_CANONICAL).value = "x"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Adds the M5 domain layer: the business nouns and their rules, modelled as
frozen stdlib dataclasses and enums that validate at construction. This is the
innermost ring of the Clean Architecture M5 builds — the currency M5-02's ports
and M5-03's persistence adapters will be written in.

**Value objects** (`app/src/domain/`):
- `susep_process.py` — `SusepProcess`: canonical `NNNNN.NNNNNN/NNNN-NN` format
  validated at construction; `.parse()` also accepts the 17-digit filename
  stem. Format-only, no check-digit (SUSEP's process check-digit algorithm is
  not a published spec, and a false rejection of a real filing is
  unrecoverable).
- `cnpj.py` — `Cnpj`: 14 digits + the real Brazilian mod-11 check-digit
  verification; `.parse()` applies the **14-digit zero-padding rule** the
  upstream SUSEP catalogue violates (13 digits → left-pad one zero). All 30
  corpus CNPJs pass the checksum.

**Entities** — frozen dataclasses, invariants enforced in `__post_init__`:
- `policy.py` — `Policy` (registered product): promotes `ClauseProvenance`'s
  fields with the two identifiers as value objects; `process_year` must agree
  with the SUSEP process → `PolicyYearMismatchError`; `from_manifest_row()`.
- `policy_clause.py` — `PolicyClause`: the DoD's `Clause` entity, named
  `PolicyClause` to avoid shadowing the existing 18-field parse-tree
  `domain.clause_tree.Clause` (the two are never imported together).
- `claim.py` — `Claim`: the free-text submission; timezone-aware `submitted_at`.
- `assessment.py` — `Assessment`: **≥1 citation, always** (including for an
  `insufficient_information` verdict) → `CitationRequiredError`; **verdict must
  be a `domain.verdict.Verdict` member** → `VerdictNotPermittedError` (a plain
  dataclass does not type-check its fields, so the guard is explicit).
- `human_decision.py` — `DecisionOutcome` enum + `HumanDecision`: **always
  references the `assessment_id` it acted on** →
  `DecisionMustReferenceAssessmentError`; an `edited_assessment` is present iff
  the decision is `EDIT` and must revise that same id.
- `errors.py` — one exception hierarchy (`InvalidValueObjectError` is also a
  `ValueError`; `InvariantViolationError` is a `DomainError` only).

`domain.verdict.Verdict` is reused unchanged. `ClauseProvenance` and
`infrastructure/graph/state.py` are left untouched — this layer is additive, and
the mappers between the domain dataclasses and the Pydantic graph twins are
M5-03's deliverable.

**Decisions recorded in `docs/ARCHITECTURE.md`** (they bind later M5 issues):
- The ≥1-citation invariant is unconditional, so the compatibility node's
  abstain-on-empty-retrieval output is not a persistable `Assessment` — it
  stays in claim state + the audit trail. M5-03's mapper must not synthesise a
  row there.
- `Assessment` omits consistency signals (no M5-01 invariant touches them);
  persisting `ConsistencyReport` is M5-03's call.
- `DecisionOutcome` values match `state.HumanDecision.decision`'s `Literal` so
  M5-03's mapper is a round-trip.

**Docs:** new `docs/DOMAIN.md` (field tables, the invariant table, the
relationship to `state.py`) and a new decision section in `docs/ARCHITECTURE.md`.

**Enforcement:** `tests/architecture/test_layer_boundaries.py` already AST-scans
all of `app/src/domain/` for forbidden imports (Pydantic, SQLAlchemy, LangGraph,
LangChain) and needs no change — the new stdlib-only modules are covered
automatically. `tests/architecture/test_scope_vocabulary.py` now scans the whole
`domain/` package, not just `verdict.py`.

## Related issue

[M5-01]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) —
      `tests/unit/domain/`, one `test_<module>.py` per entity, every invariant
      with its rejection case; `test_cnpj.py` parametrized over all 30 manifest
      CNPJs; `test_susep_process.py` / `test_policy.py` round-trip the whole
      corpus manifest.
- [x] Docs updated — new `docs/DOMAIN.md`; new decision section in
      `docs/ARCHITECTURE.md`; `domain/__init__.py` docstring refreshed.
- [x] Evaluation impact considered — none. Pure domain layer with no LLM call,
      no retrieval, no eval target; not wired into the graph. `make check` runs
      the new unit tests; no evaluation numbers are affected.
- [x] `make check` passes locally — ruff, ruff format, mypy --strict, 1172 unit
      tests.