### PR TITLE
feat(application): define assessment ports and use cases with the orc…

### DIFF
--- a/app/src/application/__init__.py
+++ b/app/src/application/__init__.py
@@ -3,4 +3,13 @@
 Use cases and ports (interfaces) that orchestrate domain rules. Depends
 only on domain. Has no knowledge of infrastructure details (LangGraph,
 database, HTTP) — only the ports that represent them.
+
+M5-02 adds the claim-assessment surface: the ``ClauseRepository``,
+``AssessmentRepository``, ``ClaimAssessmentOrchestrator``, ``UnitOfWork``
+and ``Clock`` ports, the ``SubmitClaim`` / ``GetAssessment`` /
+``SubmitHumanDecision`` / ``ListAssessments`` use cases, and the
+``AssessmentRecord`` / ``OrchestratorResult`` DTOs the layer speaks in.
+``ClaimAssessmentOrchestrator`` hides LangGraph completely — nothing here
+knows a graph produces the assessment. Enforced by
+tests/architecture/test_layer_boundaries.py.
 """

--- a/app/src/application/assessment_record.py
+++ b/app/src/application/assessment_record.py
@@ -1,0 +1,160 @@
+"""The assessment as the service stores and serves it [M5-02].
+
+``domain.assessment.Assessment`` is the *grounded* assessment: its >=1-citation
+invariant is unconditional, by design (``docs/ARCHITECTURE.md``, M5-01). But the
+graph can finish an insufficient-context or clarification-exhausted run with a
+recommendation that cites nothing, and ``GET /v1/assessments/{id}`` /
+``ListAssessments`` must still serve those -- after the LangGraph thread, and its
+checkpoint, may be long gone.
+
+So the unit the ``AssessmentRepository`` persists and the read use cases return
+is this application aggregate, not the domain entity. It carries the full
+lifecycle: the system's opinion (verdict, prose, citations -- possibly empty),
+the retrieval/clarification signals a reviewer needs to judge it, its status,
+and -- once settled -- the analyst's ``HumanDecision`` recorded *beside* it,
+never over it.
+
+``as_domain_assessment()`` is the bridge back: it builds the domain
+``Assessment`` and therefore raises ``CitationRequiredError`` for an abstain
+record. That is the invariant doing its job, not a bug -- an abstain is
+deliberately not a grounded assessment.
+
+Standard library and domain/application types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from application.consistency_flag import ConsistencyFlag
+from application.orchestrator_result import OrchestratorResult
+from domain.assessment import Assessment
+from domain.citation import Citation
+from domain.human_decision import HumanDecision
+from domain.verdict import Verdict
+
+
+class AssessmentStatus(Enum):
+    """Where an assessment sits in the review lifecycle."""
+
+    AWAITING_REVIEW = "awaiting_review"
+    DECIDED = "decided"
+
+
+@dataclass(frozen=True)
+class AssessmentRecord:
+    """One claim's assessment across its whole lifecycle -- the persisted unit."""
+
+    assessment_id: str
+    claim_id: str
+    verdict: Verdict
+    reasoning: str
+    recommended_action: str
+    citations: tuple[Citation, ...]
+    confidence: float
+    consistency_flags: tuple[ConsistencyFlag, ...]
+    context_sufficient: bool | None
+    clarification_exhausted: bool
+    missing_information: tuple[str, ...]
+    status: AssessmentStatus
+    created_at: datetime
+    decision: HumanDecision | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the non-empty fields, the types, and the status/decision pairing."""
+        for name in ("assessment_id", "claim_id", "reasoning", "recommended_action"):
+            if not getattr(self, name):
+                raise ValueError(f"AssessmentRecord.{name} must not be empty")
+        if not isinstance(self.verdict, Verdict):
+            raise ValueError(
+                f"AssessmentRecord.verdict must be a domain.verdict.Verdict, "
+                f"got {self.verdict!r}"
+            )
+        if not isinstance(self.status, AssessmentStatus):
+            raise ValueError(
+                f"AssessmentRecord.status must be an AssessmentStatus, "
+                f"got {self.status!r}"
+            )
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"AssessmentRecord.confidence must be in [0, 1], got {self.confidence}"
+            )
+        if not all(isinstance(c, Citation) for c in self.citations):
+            raise ValueError(
+                "AssessmentRecord.citations must all be Citation instances"
+            )
+        if self.created_at.tzinfo is None or self.created_at.utcoffset() is None:
+            raise ValueError("AssessmentRecord.created_at must be timezone-aware")
+
+        is_decided = self.status is AssessmentStatus.DECIDED
+        if is_decided and self.decision is None:
+            raise ValueError("a DECIDED record must carry a decision")
+        if not is_decided and self.decision is not None:
+            raise ValueError(
+                f"a {self.status.value!r} record must not carry a decision"
+            )
+        if (
+            self.decision is not None
+            and self.decision.assessment_id != self.assessment_id
+        ):
+            raise ValueError(
+                "the decision must reference the assessment it settled "
+                f"({self.assessment_id!r})"
+            )
+
+    @property
+    def is_grounded(self) -> bool:
+        """Whether this cites >=1 clause -- i.e. projects to a domain ``Assessment``."""
+        return len(self.citations) >= 1
+
+    def as_domain_assessment(self) -> Assessment:
+        """The grounded projection.
+
+        Raises ``domain.errors.CitationRequiredError`` when ``citations`` is
+        empty -- an abstain record is deliberately not a persistable
+        ``Assessment``.
+        """
+        return Assessment(
+            assessment_id=self.assessment_id,
+            claim_id=self.claim_id,
+            verdict=self.verdict,
+            reasoning=self.reasoning,
+            citations=self.citations,
+            confidence=self.confidence,
+            recommended_action=self.recommended_action,
+        )
+
+    @classmethod
+    def from_orchestrator_result(
+        cls,
+        result: OrchestratorResult,
+        *,
+        assessment_id: str,
+        claim_id: str,
+        created_at: datetime,
+        status: AssessmentStatus,
+        decision: HumanDecision | None = None,
+    ) -> "AssessmentRecord":
+        """Build a record from an orchestrator run, plus the identity/lifecycle fields.
+
+        The system's opinion (verdict, prose, citations, flags, signals) comes
+        straight from ``result``; the caller supplies the ids, the timestamp,
+        the status and -- on the resume path -- the analyst's decision.
+        """
+        return cls(
+            assessment_id=assessment_id,
+            claim_id=claim_id,
+            verdict=result.verdict,
+            reasoning=result.reasoning,
+            recommended_action=result.recommended_action,
+            citations=result.citations,
+            confidence=result.confidence,
+            consistency_flags=result.consistency_flags,
+            context_sufficient=result.context_sufficient,
+            clarification_exhausted=result.clarification_exhausted,
+            missing_information=result.missing_information,
+            status=status,
+            created_at=created_at,
+            decision=decision,
+        )

--- a/app/src/application/consistency_flag.py
+++ b/app/src/application/consistency_flag.py
@@ -1,0 +1,41 @@
+"""The consistency-flag DTO the application layer speaks in [M5-02].
+
+The application twin of ``infrastructure.graph.state.ConsistencySignal``: one
+thing the consistency node flagged for a reviewer's attention. The domain layer
+has no equivalent -- ``docs/DOMAIN.md`` defers persisting consistency signals to
+[M5-03], and no M5-01 invariant touches them -- so the shape lives here, framed
+in the same four fields the graph uses, for ``OrchestratorResult`` and
+``AssessmentRecord`` to carry.
+
+Standard library and typing only -- the application layer never imports
+Pydantic or ``infrastructure`` (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class ConsistencyFlag:
+    """One attention point raised while assessing a claim -- never a verdict."""
+
+    check: str
+    severity: Literal["info", "attention"]
+    detail: str
+    source: Literal["deterministic", "llm"]
+
+    def __post_init__(self) -> None:
+        """Reject an empty check name or an out-of-vocabulary severity/source."""
+        if not self.check:
+            raise ValueError("ConsistencyFlag.check must not be empty")
+        if self.severity not in ("info", "attention"):
+            raise ValueError(
+                f"ConsistencyFlag.severity must be 'info' or 'attention', "
+                f"got {self.severity!r}"
+            )
+        if self.source not in ("deterministic", "llm"):
+            raise ValueError(
+                f"ConsistencyFlag.source must be 'deterministic' or 'llm', "
+                f"got {self.source!r}"
+            )

--- a/app/src/application/edited_assessment_input.py
+++ b/app/src/application/edited_assessment_input.py
@@ -1,0 +1,49 @@
+"""The payload a reviewer submits when editing an assessment [M5-02].
+
+An ``edit`` decision at the human checkpoint replaces the system's opinion with
+the analyst's. This is the raw shape of that replacement as it enters
+``SubmitHumanDecision`` -- verdict, prose and the clauses the analyst grounds it
+in. The use case turns it into a domain ``Assessment`` (which enforces the
+>=1-citation rule and the permitted verdict set) and validates every cited
+clause against ``ClauseRepository`` before handing it to the orchestrator.
+
+Keeping a 0-citation abstain unchanged is an ``approve``, not an ``edit``: an
+``EditedAssessmentInput`` always names at least one clause, because a domain
+``Assessment`` always does.
+
+Standard library only -- the application layer imports no ``infrastructure``
+(enforced by tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+
+from domain.citation import Citation
+from domain.verdict import Verdict
+
+
+@dataclass(frozen=True)
+class EditedAssessmentInput:
+    """A reviewer's revised assessment, before it becomes a domain ``Assessment``."""
+
+    verdict: Verdict
+    reasoning: str
+    recommended_action: str
+    citations: tuple[Citation, ...]
+    confidence: float
+
+    def __post_init__(self) -> None:
+        """Reject empty prose or a non-``Verdict`` verdict (citations: domain's job).
+
+        The >=1-citation and ``[0, 1]`` confidence rules are left to
+        ``domain.assessment.Assessment`` so there is exactly one definition of
+        each; this guard only covers the fields the use case reads before
+        constructing that entity.
+        """
+        for name in ("reasoning", "recommended_action"):
+            if not getattr(self, name):
+                raise ValueError(f"EditedAssessmentInput.{name} must not be empty")
+        if not isinstance(self.verdict, Verdict):
+            raise ValueError(
+                f"EditedAssessmentInput.verdict must be a domain.verdict.Verdict, "
+                f"got {self.verdict!r}"
+            )

--- a/app/src/application/errors.py
+++ b/app/src/application/errors.py
@@ -1,0 +1,66 @@
+"""The application layer's exception hierarchy [M5-02].
+
+One module for every error a use case raises that is not a domain-invariant
+violation (those live in ``domain.errors`` and stay there). These are the
+failures the use cases detect *around* the domain rules -- an id that does not
+resolve, a decision on an already-settled assessment, an edit that cites a
+clause the corpus does not have, an orchestrator that broke its own contract.
+[M5-04] maps each to an HTTP status with a stable error code; keeping them in
+one place, mirroring ``domain.errors``, is what makes that mapping a single
+``except`` group rather than a scattered set.
+
+Standard library only -- the application layer imports no ``infrastructure``
+(enforced by tests/architecture/test_layer_boundaries.py).
+"""
+
+from collections.abc import Iterable
+
+
+class ApplicationError(Exception):
+    """Base for every error the application layer raises."""
+
+
+class AssessmentNotFoundError(ApplicationError):
+    """No assessment exists for the given id.
+
+    Carries the offending ``assessment_id`` so [M5-04] can report which id
+    failed, mirroring ``domain.errors.CitationRequiredError``.
+    """
+
+    def __init__(self, assessment_id: str) -> None:
+        """Build the message from the id that did not resolve."""
+        self.assessment_id = assessment_id
+        super().__init__(f"no assessment found for id {assessment_id!r}")
+
+
+class AssessmentAlreadyDecidedError(ApplicationError):
+    """A human decision was submitted for an assessment already settled."""
+
+    def __init__(self, assessment_id: str) -> None:
+        """Build the message from the id that already carries a decision."""
+        self.assessment_id = assessment_id
+        super().__init__(f"assessment {assessment_id!r} has already been decided")
+
+
+class UnknownClauseError(ApplicationError):
+    """An edited assessment cited one or more clauses absent from the corpus.
+
+    Carries the missing ``clause_ids`` -- the reviewer's edit references
+    something ``ClauseRepository`` cannot resolve.
+    """
+
+    def __init__(self, clause_ids: Iterable[str]) -> None:
+        """Build the message from the clause ids that did not resolve."""
+        self.clause_ids = tuple(clause_ids)
+        joined = ", ".join(repr(cid) for cid in self.clause_ids)
+        super().__init__(f"edited assessment cites unknown clause(s): {joined}")
+
+
+class OrchestratorContractError(ApplicationError):
+    """The orchestrator returned a result its port forbids.
+
+    ``start`` must pause at the human checkpoint (``awaiting_review is True``);
+    ``resume`` must run to completion (``awaiting_review is False``). A result
+    that breaks either is an adapter bug, surfaced here rather than silently
+    persisted.
+    """

--- a/app/src/application/orchestrator_result.py
+++ b/app/src/application/orchestrator_result.py
@@ -1,0 +1,61 @@
+"""What ``ClaimAssessmentOrchestrator`` hands back to a use case [M5-02].
+
+The orchestrator port hides LangGraph entirely, so its result cannot be the
+graph's ``ClaimState`` or its Pydantic ``Recommendation`` -- both live in
+``infrastructure`` and the application layer must not import them. This is the
+graph-free projection the use cases and ``AssessmentRecord`` work in: the
+verdict and prose a reviewer sees, the clauses it is grounded in, the
+consistency flags kept beside it, the two retrieval/clarification signals the
+[M5-04] read model needs, and whether the run paused at the human checkpoint.
+
+``verdict`` is a required field here even though the graph's ``Recommendation``
+has none -- deriving it (from the recommendation node's audit record) is the
+adapter's job, done once at the boundary so the application layer never re-reads
+graph internals.
+
+``citations`` may be empty: the insufficient-context and clarification-exhausted
+paths produce a recommendation with no clauses. That is a valid
+``OrchestratorResult`` and a valid ``AssessmentRecord``; it is only not a
+persistable domain ``Assessment``.
+
+Standard library and domain types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+
+from application.consistency_flag import ConsistencyFlag
+from domain.citation import Citation
+from domain.verdict import Verdict
+
+
+@dataclass(frozen=True)
+class OrchestratorResult:
+    """One assessment run's outcome, with no trace of the graph that produced it."""
+
+    verdict: Verdict
+    reasoning: str
+    recommended_action: str
+    citations: tuple[Citation, ...]
+    confidence: float
+    consistency_flags: tuple[ConsistencyFlag, ...]
+    context_sufficient: bool | None
+    clarification_exhausted: bool
+    missing_information: tuple[str, ...]
+    awaiting_review: bool
+
+    def __post_init__(self) -> None:
+        """Reject empty prose, a non-``Verdict`` verdict or a bad confidence."""
+        for name in ("reasoning", "recommended_action"):
+            if not getattr(self, name):
+                raise ValueError(f"OrchestratorResult.{name} must not be empty")
+        if not isinstance(self.verdict, Verdict):
+            raise ValueError(
+                f"OrchestratorResult.verdict must be a domain.verdict.Verdict, "
+                f"got {self.verdict!r}"
+            )
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"OrchestratorResult.confidence must be in [0, 1], "
+                f"got {self.confidence}"
+            )

--- a/app/src/application/ports/__init__.py
+++ b/app/src/application/ports/__init__.py
@@ -1,1 +1,8 @@
-"""Ports (interfaces) that infrastructure adapters implement."""
+"""Ports (interfaces) that infrastructure adapters implement.
+
+M5-02: ``clause_repository``, ``assessment_repository``,
+``claim_assessment_orchestrator``, ``unit_of_work`` and ``clock`` -- the
+contracts the assessment use cases depend on. Each speaks domain (or
+application DTO) types only; ``claim_assessment_orchestrator`` in particular
+exposes nothing of the LangGraph run behind it.
+"""

--- a/app/src/application/ports/assessment_repository.py
+++ b/app/src/application/ports/assessment_repository.py
@@ -1,0 +1,46 @@
+"""Port for persisting and querying assessments [M5-02].
+
+The stored unit is ``application.assessment_record.AssessmentRecord`` -- the
+full-lifecycle aggregate, not the domain ``Assessment`` -- because an abstain
+outcome (no citations) must be persisted and served, and a domain ``Assessment``
+cannot represent one.
+
+Writes (``add`` / ``update``) run inside a ``UnitOfWork``; reads (``get`` /
+``list``) do not need a transaction and the use cases call them on a bare
+repository. [M5-03] implements both against Postgres.
+"""
+
+from typing import Protocol
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+
+
+class AssessmentRepository(Protocol):
+    """Store assessment records and query them by claim or status."""
+
+    def add(self, record: AssessmentRecord) -> None:
+        """Persist a new record. The ``assessment_id`` is assumed unused."""
+        ...
+
+    def update(self, record: AssessmentRecord) -> None:
+        """Replace the stored record with the same ``assessment_id``."""
+        ...
+
+    def get(self, assessment_id: str) -> AssessmentRecord | None:
+        """Return the record for ``assessment_id``, or ``None`` if there is none."""
+        ...
+
+    def list(
+        self,
+        *,
+        claim_id: str | None = None,
+        status: AssessmentStatus | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[AssessmentRecord, ...]:
+        """Return records newest first (by ``created_at``, then ``assessment_id``).
+
+        ``claim_id`` and ``status`` narrow the result when set; ``limit`` and
+        ``offset`` page it.
+        """
+        ...

--- a/app/src/application/ports/claim_assessment_orchestrator.py
+++ b/app/src/application/ports/claim_assessment_orchestrator.py
@@ -1,0 +1,49 @@
+"""Port for running a claim through assessment -- LangGraph fully hidden [M5-02].
+
+This is the contract that lets the application layer commission an assessment
+without knowing one is produced by a LangGraph state machine. Nothing about the
+graph crosses it: no ``ClaimState``, no ``Command``, no ``interrupt``, no
+``thread_id``, none of the ``infrastructure.graph`` Pydantic models. In, a
+domain ``Claim`` or ``HumanDecision``; out, an
+``application.orchestrator_result.OrchestratorResult``.
+
+``assessment_id`` is the sole run key. The implementation ([M5-04]) uses it as
+the graph's ``thread_id``, so resuming a specific paused run needs nothing more.
+``SubmitClaim`` mints a fresh ``assessment_id`` per submission, so re-submitting
+a claim is simply a new run -- the "one claim, a second thread" case
+``docs/HUMAN_CHECKPOINT.md`` describes falls out for free.
+
+Both methods raise on an infrastructure failure (the graph, the model, the
+database); the use case lets that propagate. A *contract* breach -- ``start``
+not pausing, ``resume`` not finishing -- is caught by the use case as
+``OrchestratorContractError``.
+"""
+
+from typing import Protocol
+
+from application.orchestrator_result import OrchestratorResult
+from domain.claim import Claim
+from domain.human_decision import HumanDecision
+
+
+class ClaimAssessmentOrchestrator(Protocol):
+    """Commission and resume claim assessments."""
+
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        """Assess ``claim`` from scratch, up to the human checkpoint.
+
+        Returns the system's recommendation with ``awaiting_review is True`` --
+        the run is paused, waiting for a decision keyed by ``assessment_id``.
+        """
+        ...
+
+    def resume(
+        self, *, assessment_id: str, decision: HumanDecision
+    ) -> OrchestratorResult:
+        """Resume the paused run ``assessment_id`` with the analyst's decision.
+
+        Runs to completion and returns the final result with
+        ``awaiting_review is False``. The system's recommendation is unchanged
+        from ``start``; an edit rides in ``decision``, recorded beside it.
+        """
+        ...

--- a/app/src/application/ports/clause_repository.py
+++ b/app/src/application/ports/clause_repository.py
@@ -1,0 +1,38 @@
+"""Port for reading clauses of registered products [M5-02].
+
+Read-only. The clause corpus is reference data -- SUSEP's registered *condições
+gerais* -- built by the M1 parsing pipeline and never written by the assessment
+use cases, so this repository stands apart from the transactional
+``UnitOfWork`` (which owns only ``AssessmentRepository``).
+
+Its one M5-02 caller is ``SubmitHumanDecision``: when a reviewer edits an
+assessment, every clause the edit cites must resolve to a real
+``PolicyClause`` here, or the decision is rejected before the graph is resumed.
+[M5-03] backs it with the ``chunk`` table; [M5-04] may grow it a read endpoint.
+"""
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from domain.policy_clause import PolicyClause
+from domain.susep_process import SusepProcess
+
+
+class ClauseRepository(Protocol):
+    """Look up clauses of registered products by id or by product."""
+
+    def get(self, clause_id: str) -> PolicyClause | None:
+        """Return the clause with ``clause_id``, or ``None`` if the corpus has none."""
+        ...
+
+    def get_many(self, clause_ids: Sequence[str]) -> tuple[PolicyClause, ...]:
+        """Return the clauses that exist, in the order their ids were given.
+
+        Ids with no matching clause are omitted -- the caller compares the
+        returned count (or ids) against the request to find the gaps.
+        """
+        ...
+
+    def list_for_policy(self, policy: SusepProcess) -> tuple[PolicyClause, ...]:
+        """Return every clause of the product identified by ``policy``."""
+        ...

--- a/app/src/application/ports/clock.py
+++ b/app/src/application/ports/clock.py
@@ -1,0 +1,24 @@
+"""Port for reading the current time [M5-02].
+
+The use cases stamp a ``Claim.submitted_at`` and a ``HumanDecision.decided_at``,
+both of which the domain requires to be timezone-aware. Taking the clock as a
+port rather than calling ``datetime.now`` directly is what makes those
+timestamps assertable in a unit test (a ``FixedClock``) and keeps the use cases
+free of a hidden dependency on wall-clock time -- the same reason
+``infrastructure.graph.consistency_checks`` already takes ``now=`` as a
+parameter.
+
+The real implementation (a one-line ``datetime.now(UTC)`` wrapper) is the
+composition root's to provide -- [M5-04].
+"""
+
+from datetime import datetime
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """A source of the current instant."""
+
+    def now(self) -> datetime:
+        """Return the current instant as a timezone-aware UTC ``datetime``."""
+        ...

--- a/app/src/application/ports/unit_of_work.py
+++ b/app/src/application/ports/unit_of_work.py
@@ -1,0 +1,53 @@
+"""Port for the transactional boundary around assessment writes [M5-02].
+
+A ``UnitOfWork`` is one transaction. It exposes the single repository the use
+cases write through -- ``assessments`` -- and nothing else: the clause corpus is
+read-only reference data with its own lifecycle, so ``ClauseRepository`` is not
+part of it.
+
+The use cases take a ``UnitOfWorkFactory`` (``Callable[[], UnitOfWork]``), not a
+``UnitOfWork``, so each call opens its own transaction -- which is what
+[M5-03]'s session-per-transaction implementation needs, and what lets a test's
+in-memory fake give every call an isolated view.
+
+Contract: entering the context begins the unit; ``commit()`` makes its writes
+durable; leaving the context without a ``commit()`` -- normally or by exception
+-- rolls everything back.
+"""
+
+from collections.abc import Callable
+from types import TracebackType
+from typing import Protocol
+
+from application.ports.assessment_repository import AssessmentRepository
+
+
+class UnitOfWork(Protocol):
+    """One transaction over the assessment store."""
+
+    assessments: AssessmentRepository
+
+    def __enter__(self) -> "UnitOfWork":
+        """Begin the unit and return it."""
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        """Roll back if the block did not ``commit()``; never suppress an exception."""
+        ...
+
+    def commit(self) -> None:
+        """Make every write in this unit durable."""
+        ...
+
+    def rollback(self) -> None:
+        """Discard every write in this unit."""
+        ...
+
+
+UnitOfWorkFactory = Callable[[], UnitOfWork]
+"""Opens a fresh ``UnitOfWork`` -- one per use-case invocation."""

--- a/app/src/application/use_cases/__init__.py
+++ b/app/src/application/use_cases/__init__.py
@@ -1,1 +1,7 @@
-"""Use cases that orchestrate domain rules through ports."""
+"""Use cases that orchestrate domain rules through ports.
+
+M5-02: ``submit_claim``, ``get_assessment``, ``submit_human_decision`` and
+``list_assessments`` -- the assessment lifecycle. These are frozen-dataclass
+interactors (ports injected as fields, one ``__call__``), unlike the earlier
+pure-function pipeline use cases, because they carry dependencies.
+"""

--- a/app/src/application/use_cases/get_assessment.py
+++ b/app/src/application/use_cases/get_assessment.py
@@ -1,0 +1,34 @@
+"""Use case: fetch one assessment by id [M5-02].
+
+The read behind ``GET /v1/assessments/{id}`` ([M5-04]). It returns the stored
+``AssessmentRecord`` -- system verdict, recommendation, citations, the
+retrieval/clarification signals and, once settled, the analyst's decision -- so
+the API never re-enters the graph to answer a read.
+
+An abstain record (no citations) is returned like any other; only an unknown id
+is an error.
+"""
+
+from dataclasses import dataclass
+
+from application.assessment_record import AssessmentRecord
+from application.errors import AssessmentNotFoundError
+from application.ports.assessment_repository import AssessmentRepository
+
+
+@dataclass(frozen=True)
+class GetAssessment:
+    """Return the assessment record for an id, or raise if there is none."""
+
+    assessments: AssessmentRepository
+
+    def __call__(self, assessment_id: str) -> AssessmentRecord:
+        """Fetch the record for ``assessment_id``.
+
+        Raises:
+            AssessmentNotFoundError: no record exists for the id.
+        """
+        record = self.assessments.get(assessment_id)
+        if record is None:
+            raise AssessmentNotFoundError(assessment_id)
+        return record

--- a/app/src/application/use_cases/list_assessments.py
+++ b/app/src/application/use_cases/list_assessments.py
@@ -1,0 +1,45 @@
+"""Use case: list assessments, newest first [M5-02].
+
+The read behind a future ``GET /v1/assessments`` collection endpoint. A thin
+pass-through to ``AssessmentRepository.list`` -- the ordering (newest
+``created_at`` first, ``assessment_id`` as the tie-break), the optional
+``claim_id`` / ``status`` filters and the ``limit`` / ``offset`` paging are the
+repository's contract. Kept as a use case so the presentation layer depends on a
+port, not on a repository method directly, and so a later access-control or
+projection rule has one place to live.
+"""
+
+from dataclasses import dataclass
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.ports.assessment_repository import AssessmentRepository
+
+_DEFAULT_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class ListAssessments:
+    """Return a page of assessment records, most recent first."""
+
+    assessments: AssessmentRepository
+
+    def __call__(
+        self,
+        *,
+        claim_id: str | None = None,
+        status: AssessmentStatus | None = None,
+        limit: int = _DEFAULT_LIMIT,
+        offset: int = 0,
+    ) -> tuple[AssessmentRecord, ...]:
+        """List records, optionally filtered by claim or status.
+
+        Raises:
+            ValueError: ``limit`` is not positive or ``offset`` is negative.
+        """
+        if limit <= 0:
+            raise ValueError(f"limit must be positive, got {limit}")
+        if offset < 0:
+            raise ValueError(f"offset must not be negative, got {offset}")
+        return self.assessments.list(
+            claim_id=claim_id, status=status, limit=limit, offset=offset
+        )

--- a/app/src/application/use_cases/submit_claim.py
+++ b/app/src/application/use_cases/submit_claim.py
@@ -1,0 +1,86 @@
+"""Use case: submit a claim for assessment [M5-02].
+
+Behind ``POST /v1/assessments`` ([M5-04]). It mints the identifiers, builds the
+domain ``Claim`` (whose construction validates the narrative and the
+timestamp), runs it through the orchestrator up to the human checkpoint, and
+persists the result as an ``AssessmentRecord`` in status ``AWAITING_REVIEW``.
+
+Two identifiers, minted separately: a ``claim_id`` (the narrative) and an
+``assessment_id`` (this run of it). Re-submitting the same claim is a fresh
+``assessment_id`` -- a second run, a second record.
+
+The orchestrator runs *before* the transaction opens: the graph is a long call
+and must not hold a database transaction open, and it must pause at the
+checkpoint before there is anything worth persisting. A failure to persist after
+the graph has paused leaves the run recoverable from its checkpoint but without
+a record -- a narrow window [M5-03] closes by writing the record in the same
+transaction as the audit trail.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.errors import OrchestratorContractError
+from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.ports.clock import Clock
+from application.ports.unit_of_work import UnitOfWorkFactory
+from domain.claim import Claim
+from domain.susep_process import SusepProcess
+
+
+@dataclass(frozen=True)
+class SubmitClaim:
+    """Assess a submitted claim and persist the pending result."""
+
+    clock: Clock
+    orchestrator: ClaimAssessmentOrchestrator
+    uow_factory: UnitOfWorkFactory
+    new_id: Callable[[], str]
+
+    def __call__(
+        self,
+        *,
+        raw_text: str,
+        policy_ref: SusepProcess | None = None,
+        claim_id: str | None = None,
+    ) -> AssessmentRecord:
+        """Run the claim through assessment and store the awaiting-review record.
+
+        Raises:
+            ValueError: the narrative is empty or the clock returned a naive
+                datetime (both surface from ``Claim`` construction).
+            OrchestratorContractError: the orchestrator did not pause at the
+                human checkpoint.
+        """
+        submitted_at = self.clock.now()
+        resolved_claim_id = claim_id or self.new_id()
+        assessment_id = self.new_id()
+
+        claim = Claim(
+            claim_id=resolved_claim_id,
+            raw_text=raw_text,
+            submitted_at=submitted_at,
+            policy_ref=policy_ref,
+        )
+
+        result = self.orchestrator.start(assessment_id=assessment_id, claim=claim)
+        if not result.awaiting_review:
+            raise OrchestratorContractError(
+                f"start did not pause at the human checkpoint for "
+                f"assessment {assessment_id!r}"
+            )
+
+        record = AssessmentRecord.from_orchestrator_result(
+            result,
+            assessment_id=assessment_id,
+            claim_id=resolved_claim_id,
+            created_at=submitted_at,
+            status=AssessmentStatus.AWAITING_REVIEW,
+        )
+
+        with self.uow_factory() as uow:
+            uow.assessments.add(record)
+            uow.commit()
+
+        return record

--- a/app/src/application/use_cases/submit_human_decision.py
+++ b/app/src/application/use_cases/submit_human_decision.py
@@ -1,0 +1,157 @@
+"""Use case: record the analyst's decision and finish the run [M5-02].
+
+Behind ``POST /v1/assessments/{id}/decision`` ([M5-04]). It validates the
+decision payload against the domain rules, resumes the paused graph run past its
+human checkpoint, and updates the stored record to ``DECIDED`` with the
+``HumanDecision`` recorded *beside* the system's opinion -- never overwriting
+it.
+
+The system's verdict, prose and citations on the updated record are exactly what
+``start`` produced; an ``edit`` lives entirely inside
+``record.decision.edited_assessment``. Keeping a 0-citation abstain unchanged is
+an ``approve``: an ``edit`` always supplies an ``EditedAssessmentInput``, which
+becomes a domain ``Assessment`` and therefore always cites at least one clause
+-- and every cited clause is checked against ``ClauseRepository`` before the
+graph is resumed.
+
+Ordering mirrors ``SubmitClaim``: the read and the validation happen first, the
+orchestrator resume (a long call) runs outside any transaction, and only the
+record update is transactional.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.edited_assessment_input import EditedAssessmentInput
+from application.errors import (
+    AssessmentAlreadyDecidedError,
+    AssessmentNotFoundError,
+    OrchestratorContractError,
+    UnknownClauseError,
+)
+from application.ports.assessment_repository import AssessmentRepository
+from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.ports.clause_repository import ClauseRepository
+from application.ports.clock import Clock
+from application.ports.unit_of_work import UnitOfWorkFactory
+from domain.assessment import Assessment
+from domain.citation import Citation
+from domain.human_decision import DecisionOutcome, HumanDecision
+
+
+@dataclass(frozen=True)
+class SubmitHumanDecision:
+    """Settle an awaiting-review assessment with the analyst's decision."""
+
+    clock: Clock
+    orchestrator: ClaimAssessmentOrchestrator
+    assessments: AssessmentRepository
+    clauses: ClauseRepository
+    uow_factory: UnitOfWorkFactory
+
+    def __call__(
+        self,
+        *,
+        assessment_id: str,
+        decision: DecisionOutcome,
+        notes: str = "",
+        edited: EditedAssessmentInput | None = None,
+    ) -> AssessmentRecord:
+        """Validate the decision, resume the run, and persist the settled record.
+
+        Raises:
+            AssessmentNotFoundError: no record exists for ``assessment_id``.
+            AssessmentAlreadyDecidedError: the record is already ``DECIDED``.
+            ValueError: an ``edit`` without an ``EditedAssessmentInput``, a
+                non-``edit`` carrying one, or a decision the domain rejects.
+            domain.errors.CitationRequiredError: an ``edit`` that cites nothing.
+            UnknownClauseError: an ``edit`` citing a clause the corpus lacks.
+            OrchestratorContractError: the run did not complete on resume.
+        """
+        record = self.assessments.get(assessment_id)
+        if record is None:
+            raise AssessmentNotFoundError(assessment_id)
+        if record.status is AssessmentStatus.DECIDED:
+            raise AssessmentAlreadyDecidedError(assessment_id)
+
+        decided_at = self.clock.now()
+        edited_assessment = self._build_edited_assessment(
+            assessment_id=assessment_id,
+            claim_id=record.claim_id,
+            decision=decision,
+            edited=edited,
+        )
+        human_decision = HumanDecision(
+            assessment_id=assessment_id,
+            decision=decision,
+            decided_at=decided_at,
+            notes=notes,
+            edited_assessment=edited_assessment,
+        )
+
+        result = self.orchestrator.resume(
+            assessment_id=assessment_id, decision=human_decision
+        )
+        if result.awaiting_review:
+            raise OrchestratorContractError(
+                f"resume did not complete the run for assessment {assessment_id!r}"
+            )
+
+        updated = AssessmentRecord.from_orchestrator_result(
+            result,
+            assessment_id=assessment_id,
+            claim_id=record.claim_id,
+            created_at=record.created_at,
+            status=AssessmentStatus.DECIDED,
+            decision=human_decision,
+        )
+
+        with self.uow_factory() as uow:
+            uow.assessments.update(updated)
+            uow.commit()
+
+        return updated
+
+    def _build_edited_assessment(
+        self,
+        *,
+        assessment_id: str,
+        claim_id: str,
+        decision: DecisionOutcome,
+        edited: EditedAssessmentInput | None,
+    ) -> Assessment | None:
+        """Turn an ``EditedAssessmentInput`` into a domain ``Assessment``, or ``None``.
+
+        Enforces the edit/payload pairing here (a friendlier message than the
+        one ``HumanDecision`` would give) and defers the >=1-citation and
+        verdict rules to ``Assessment`` itself.
+        """
+        if decision is not DecisionOutcome.EDIT:
+            if edited is not None:
+                raise ValueError(
+                    f"decision {getattr(decision, 'value', decision)!r} must not "
+                    "carry an edited assessment"
+                )
+            return None
+        if edited is None:
+            raise ValueError("an edit decision requires an edited assessment")
+
+        self._reject_unknown_clauses(edited.citations)
+        return Assessment(
+            assessment_id=assessment_id,
+            claim_id=claim_id,
+            verdict=edited.verdict,
+            reasoning=edited.reasoning,
+            citations=edited.citations,
+            confidence=edited.confidence,
+            recommended_action=edited.recommended_action,
+        )
+
+    def _reject_unknown_clauses(self, citations: Sequence[Citation]) -> None:
+        """Raise ``UnknownClauseError`` if any cited clause is not in the corpus."""
+        requested = [citation.clause_id for citation in citations]
+        found = {clause.clause_id for clause in self.clauses.get_many(requested)}
+        missing = [clause_id for clause_id in requested if clause_id not in found]
+        if missing:
+            raise UnknownClauseError(missing)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -638,3 +638,93 @@ package, not just `verdict.py`.
 
 Full field tables, the invariant list and the relationship to `state.py`:
 `docs/DOMAIN.md`.
+
+---
+
+## The application layer is ports + use cases; the orchestrator hides LangGraph — [M5-02]
+
+**Decision.** `app/src/application/` gains the claim-assessment surface: five
+ports (`app/src/application/ports/`), four use-case interactors
+(`app/src/application/use_cases/`), and the DTOs they speak in
+(`app/src/application/{assessment_record,orchestrator_result,consistency_flag,edited_assessment_input,errors}.py`).
+
+- `ClauseRepository` — read-only lookup over the registered-product clause
+  corpus. Stands apart from the transaction: the corpus is reference data the
+  assessment use cases never write.
+- `AssessmentRepository` — persists and queries `AssessmentRecord`. Its writes
+  run inside a `UnitOfWork`; its reads do not.
+- `UnitOfWork` — one transaction, exposing only `assessments`. The use cases
+  take a `UnitOfWorkFactory` (`Callable[[], UnitOfWork]`), so each call opens
+  its own unit — the session-per-transaction shape [M5-03] needs.
+- `Clock` — `now() -> datetime` (tz-aware UTC). Formalises the
+  `now=datetime.now(UTC)` parameter injection `consistency_checks.py` already
+  uses, so the use cases' timestamps are assertable.
+- `ClaimAssessmentOrchestrator` — `start(*, assessment_id, claim)` and
+  `resume(*, assessment_id, decision)`, returning an `OrchestratorResult`.
+  **No graph type crosses it**: no `ClaimState`, `Command`, `interrupt`,
+  `thread_id`, or `infrastructure.graph` model. `assessment_id` is the sole run
+  key (the implementation uses it as the LangGraph `thread_id`), so
+  re-submitting a claim is simply a fresh `assessment_id` — the "one claim, a
+  second thread" case `docs/HUMAN_CHECKPOINT.md` describes.
+
+The use cases (`SubmitClaim`, `GetAssessment`, `SubmitHumanDecision`,
+`ListAssessments`) are frozen-dataclass interactors — ports injected as fields,
+one `__call__` — unlike the earlier pure-function pipeline use cases, because
+they carry dependencies.
+
+**Why `AssessmentRecord`, not `domain.Assessment`, is the stored unit.**
+`Assessment`'s ≥1-citation invariant is unconditional by design (M5-01, above).
+But the graph can finish an insufficient-context or clarification-exhausted run
+with a recommendation that cites nothing, and `GET /v1/assessments/{id}` /
+`ListAssessments` must still serve those — after the LangGraph thread, and its
+checkpoint, may be gone. So the persisted/servable aggregate is
+`application.assessment_record.AssessmentRecord`: the full lifecycle (system
+verdict, prose, citations — possibly empty; the retrieval/clarification signals;
+status; and, once settled, the analyst's `HumanDecision` recorded *beside* the
+system's opinion). `AssessmentRecord.as_domain_assessment()` is the grounded
+projection back — and it raises `CitationRequiredError` for an abstain record,
+which is the invariant doing its job.
+
+**Deviation on record.**
+(a) `RetrievalService` is **not** delivered. No M5-02 use case consumes semantic
+retrieval — the assessment use cases never search, and `Citation.excerpt`
+already carries the hydrated clause text — so a `RetrievalService` port would be
+a contract with no caller. This codebase lands a port with its first real
+consumer (M4-04's `RetrievalPort`/`GraphRetrievalAdapter`, M4-09's
+`AuditTrailSink`/`SqlAlchemyAuditTrailSink`), never ahead of one. Retrieval
+stays internal to the graph (`infrastructure.graph.context.RetrievalPort`,
+satisfied by `GraphRetrievalAdapter`), reached only through
+`ClaimAssessmentOrchestrator`.
+(b) The concrete `ClaimAssessmentOrchestrator` adapter (wrapping
+`build_claim_graph`) and the real `Clock` (`SystemClock`) are **M5-04's**
+composition root — M5-02 is fakes-only per its DoD ("contracts first, adapters
+after"). The port shape is proven sufficient for that adapter: every
+`OrchestratorResult` field maps to a concrete graph source, and both methods
+reduce to one `compiled.invoke(...)` keyed by `assessment_id` (the verdict —
+which `Recommendation` has no field for — is read from the recommendation
+node's audit event).
+(c) An `edit` decision always produces a *grounded* `Assessment` (≥1 citation,
+every cited clause validated against `ClauseRepository` before the graph is
+resumed). Keeping a 0-citation abstain unchanged is an `approve`, not an `edit`.
+(d) The application import check
+(`tests/architecture/test_layer_boundaries.py::test_application_imports_no_infrastructure_or_llm_sdk`)
+adds `infrastructure`, `langchain_core` and `langchain_openai` to a
+layer-scoped forbidden set — `_top_level_module` does not fold the latter two
+into the existing `langchain` root, and LangGraph re-exports `langchain_core`
+types, so "the orchestrator hides LangGraph entirely" needs all three barred.
+
+**Enforcement.** `tests/unit/application/**` — every use case with its rejection
+cases, driven through in-memory fakes (`tests/unit/application/fakes.py`), no
+LLM, no database, no graph; `test_assessment_record.py` on the projection and
+the status/decision pairing;
+`tests/architecture/test_layer_boundaries.py::test_application_imports_no_infrastructure_or_llm_sdk`.
+
+**Downstream.** [M5-03] implements the SQLAlchemy `AssessmentRepository` (two
+bindings — a read adapter on a fresh session, a write adapter bound to the
+`UnitOfWork` session), the `UnitOfWork`, the assessment/decision migrations, the
+append-only audit enforcement, and folds the record write into the audit-sink
+transaction (closing the narrow window where a persist failure after a
+successful resume diverges the record from the checkpoint). [M5-04] adds the
+FastAPI endpoints, the LangGraph orchestrator adapter, `SystemClock`, the
+`policy_ref` → retrieval-filter path, and the domain/application-error → HTTP
+status mapping.

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -198,7 +198,18 @@ the rest of `domain/`.
 ## Deferred
 
 - **Consistency signals on `Assessment`** — until a use case needs
-  `ConsistencyReport` persisted ([M5-03]).
+  `ConsistencyReport` persisted ([M5-03]). [M5-02] carries them as
+  `application.consistency_flag.ConsistencyFlag` on the `AssessmentRecord`
+  aggregate, not on the domain entity.
+- **The abstain outcome** — a verdict with no citations is not a domain
+  `Assessment` (the ≥1-citation rule is unconditional). [M5-02] models it as
+  `application.assessment_record.AssessmentRecord`, the servable/persistable
+  aggregate; `AssessmentRecord.as_domain_assessment()` is the grounded
+  projection and raises `CitationRequiredError` on an abstain.
+- **Editing an assessment** — an `edit` `HumanDecision` always carries a
+  *grounded* `Assessment` ([M5-02]'s `SubmitHumanDecision` builds it from the
+  reviewer's payload and validates every cited clause); the domain rule is
+  unchanged.
 - **`ExtractedEntities`** — stays graph working state in `infrastructure/graph/
   state.py`; not a DoD entity.
 - **Mappers** — domain ↔ ORM row, and domain ↔ `state.py` Pydantic — are [M5-03].

--- a/docs/END_TO_END_EVALUATION.md
+++ b/docs/END_TO_END_EVALUATION.md
@@ -456,6 +456,12 @@ item is answered by arms 1 and 2.
   worth is exactly what arm 3 was for, and it has not run — so the size of the
   cost is still unmeasured, while its existence is not in doubt: without the
   policy the mismatch cohort is unanswerable by construction.
+  *Update ([M5-02]):* `SubmitClaim` now takes `policy_ref: SusepProcess | None`
+  and threads it onto the domain `Claim`, so the port carries the policy as a
+  field. `ClaimState` still has no policy input, so *how* the [M5-04]
+  orchestrator adapter feeds it to retrieval (a header line like this harness,
+  or a new `ClaimState` field) is [M5-04]'s call — the port does not constrain
+  it. `Claim.policy_ref` stays optional until [M5-04] makes it required.
 - **[M6]'s README results table** takes its end-to-end accuracy, and the
   per-cohort figures, from this document — with the `n` beside each, per the
   Limitations above.

--- a/docs/HUMAN_CHECKPOINT.md
+++ b/docs/HUMAN_CHECKPOINT.md
@@ -257,10 +257,19 @@ Integration (`make test-integration`, real Postgres):
 
 - **[M4-10]** measures end-to-end verdict accuracy. It runs the graph, so it
   supplies a checkpointer and resumes past the checkpoint like any other caller.
-- **[M5-02]/[M5-04]** put a use case and an endpoint in front of this: the
-  payload above is what `GetAssessment` returns and `SubmitHumanDecision`
-  resumes. Validating the decision payload belongs there too — the node
-  re-validates defensively, but a 422 to the client is better than a re-ask.
+- **[M5-02]** defines the contract: `ClaimAssessmentOrchestrator.resume(*,
+  assessment_id, decision)` hides this node entirely (no `Command`, no
+  `thread_id`, no interrupt payload crosses the port), and `SubmitHumanDecision`
+  validates the decision — building a domain `HumanDecision`, and for an `edit`
+  a grounded `Assessment` with every clause checked against `ClauseRepository` —
+  before the run is resumed. `GetAssessment` returns an `AssessmentRecord` that
+  already carries what a reviewer needs, so the read never re-enters the graph.
+  The fields the interrupt payload above exposes (`recommendation`,
+  `context_sufficient`, `clarification_exhausted`, `missing_information`) are
+  all on that record.
+- **[M5-04]** builds the concrete LangGraph-backed orchestrator adapter and the
+  HTTP endpoints on top: `POST .../decision` maps a 422 to a payload the domain
+  rejects, and resumes the run through the port.
 - **[M5-03]** takes the connection story further. `open_claim_checkpointer` opens
   a single connection, which is right for a script or a test and not for a
   service handling concurrent requests; a `ConnectionPool` is the M5 shape. It

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -41,6 +41,19 @@ FORBIDDEN_ROOTS = frozenset(
     }
 )
 
+# [M5-02] adds a stricter, application-only check. The application layer talks
+# to infrastructure only through the ports it defines, so `infrastructure` is
+# off-limits as an import. `langchain_core` / `langchain_openai` are separate
+# top-level roots that `_top_level_module` does not fold into `langchain`, and
+# LangGraph re-exports `langchain_core` types -- "the orchestrator hides
+# LangGraph entirely" (M5-02 DoD) means barring those too. Scoped here rather
+# than added to FORBIDDEN_ROOTS so the domain check is untouched.
+APPLICATION_FORBIDDEN_ROOTS = FORBIDDEN_ROOTS | {
+    "infrastructure",
+    "langchain_core",
+    "langchain_openai",
+}
+
 
 @pytest.mark.unit
 def test_domain_has_no_forbidden_imports() -> None:
@@ -57,6 +70,15 @@ def test_application_has_no_forbidden_imports() -> None:
     assert not violations, (
         "application layer must depend only on domain, "
         f"found:\n{format_violations(violations)}"
+    )
+
+
+@pytest.mark.unit
+def test_application_imports_no_infrastructure_or_llm_sdk() -> None:
+    violations = find_forbidden_imports(APPLICATION_DIR, APPLICATION_FORBIDDEN_ROOTS)
+    assert not violations, (
+        "application layer must not import infrastructure or an LLM SDK -- "
+        f"depend on a port instead. Found:\n{format_violations(violations)}"
     )
 
 

--- a/tests/unit/application/fakes.py
+++ b/tests/unit/application/fakes.py
@@ -1,0 +1,294 @@
+"""In-memory fakes and builders for the M5-02 application-layer tests.
+
+No mock library, no LLM, no database, no graph. Every use-case test in
+``tests/unit/application`` drives the interactors through these.
+"""
+
+from collections.abc import Iterable, Sequence
+from datetime import UTC, datetime, timedelta
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.consistency_flag import ConsistencyFlag
+from application.orchestrator_result import OrchestratorResult
+from application.ports.assessment_repository import AssessmentRepository
+from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
+from domain.citation import Citation
+from domain.claim import Claim
+from domain.clause_classification import ClauseType
+from domain.human_decision import HumanDecision
+from domain.policy_clause import PolicyClause
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+
+SUSEP = SusepProcess("15414.610650/2024-59")
+FIXED_NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# builders
+# --------------------------------------------------------------------------- #
+def make_citation(
+    clause_id: str = "15414610650202459:2.1", **overrides: object
+) -> Citation:
+    fields: dict[str, object] = {
+        "clause_id": clause_id,
+        "document_id": "15414610650202459",
+        "susep_process": SUSEP,
+        "clause_type": ClauseType.COVERAGE,
+        "excerpt": "A cobertura compreende colisao, incendio e roubo.",
+        "relevance_score": 0.83,
+    }
+    fields.update(overrides)
+    return Citation(**fields)  # type: ignore[arg-type]
+
+
+def make_policy_clause(
+    clause_id: str = "15414610650202459:2.1", **overrides: object
+) -> PolicyClause:
+    fields: dict[str, object] = {
+        "clause_id": clause_id,
+        "susep_process": SUSEP,
+        "document_id": "15414610650202459",
+        "clause_type": ClauseType.COVERAGE,
+        "text": "A cobertura compreende colisao, incendio e roubo.",
+        "heading": "2.1 Coberturas",
+    }
+    fields.update(overrides)
+    return PolicyClause(**fields)  # type: ignore[arg-type]
+
+
+def make_consistency_flag(**overrides: object) -> ConsistencyFlag:
+    fields: dict[str, object] = {
+        "check": "event_date_within_policy_period",
+        "severity": "attention",
+        "detail": "A data do evento antecede o inicio de vigencia.",
+        "source": "deterministic",
+    }
+    fields.update(overrides)
+    return ConsistencyFlag(**fields)  # type: ignore[arg-type]
+
+
+def make_orchestrator_result(**overrides: object) -> OrchestratorResult:
+    fields: dict[str, object] = {
+        "verdict": Verdict.COMPATIBLE,
+        "reasoning": "O evento descrito e uma colisao, coberta pela clausula 2.1.",
+        "recommended_action": "Encaminhar para analise humana.",
+        "citations": (make_citation(),),
+        "confidence": 0.72,
+        "consistency_flags": (),
+        "context_sufficient": True,
+        "clarification_exhausted": False,
+        "missing_information": (),
+        "awaiting_review": True,
+    }
+    fields.update(overrides)
+    return OrchestratorResult(**fields)  # type: ignore[arg-type]
+
+
+def abstain_result(**overrides: object) -> OrchestratorResult:
+    """An insufficient-context run: a recommendation grounded in nothing."""
+    fields: dict[str, object] = {
+        "verdict": Verdict.INSUFFICIENT_INFORMATION,
+        "reasoning": "O contexto recuperado nao permite decidir.",
+        "recommended_action": "Solicitar documentacao adicional ao segurado.",
+        "citations": (),
+        "confidence": 0.2,
+        "context_sufficient": False,
+        "missing_information": ("data_evento_vigencia",),
+    }
+    fields.update(overrides)
+    return make_orchestrator_result(**fields)
+
+
+def make_record(**overrides: object) -> AssessmentRecord:
+    fields: dict[str, object] = {
+        "assessment_id": "assessment-1",
+        "claim_id": "claim-1",
+        "verdict": Verdict.COMPATIBLE,
+        "reasoning": "O evento descrito e uma colisao, coberta pela clausula 2.1.",
+        "recommended_action": "Encaminhar para analise humana.",
+        "citations": (make_citation(),),
+        "confidence": 0.72,
+        "consistency_flags": (),
+        "context_sufficient": True,
+        "clarification_exhausted": False,
+        "missing_information": (),
+        "status": AssessmentStatus.AWAITING_REVIEW,
+        "created_at": FIXED_NOW,
+        "decision": None,
+    }
+    fields.update(overrides)
+    return AssessmentRecord(**fields)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+class FixedClock:
+    """A clock stuck at one instant, nudgeable with ``advance``."""
+
+    def __init__(self, moment: datetime = FIXED_NOW) -> None:
+        self._moment = moment
+
+    def now(self) -> datetime:
+        return self._moment
+
+    def advance(self, delta: timedelta) -> None:
+        self._moment = self._moment + delta
+
+    def set(self, moment: datetime) -> None:
+        self._moment = moment
+
+
+class NaiveClock:
+    """A misconfigured clock: returns a naive datetime, which the domain rejects."""
+
+    def now(self) -> datetime:
+        return FIXED_NOW.replace(tzinfo=None)
+
+
+class SequentialIds:
+    """A deterministic ``new_id`` -- ``prefix-1``, ``prefix-2``, ..."""
+
+    def __init__(self, prefix: str = "id") -> None:
+        self._prefix = prefix
+        self._n = 0
+        self.issued: list[str] = []
+
+    def __call__(self) -> str:
+        self._n += 1
+        value = f"{self._prefix}-{self._n}"
+        self.issued.append(value)
+        return value
+
+
+class InMemoryClauseRepository:
+    """A clause corpus backed by a dict, keyed by ``clause_id``."""
+
+    def __init__(self, clauses: Iterable[PolicyClause] = ()) -> None:
+        self._by_id = {clause.clause_id: clause for clause in clauses}
+
+    def get(self, clause_id: str) -> PolicyClause | None:
+        return self._by_id.get(clause_id)
+
+    def get_many(self, clause_ids: Sequence[str]) -> tuple[PolicyClause, ...]:
+        return tuple(
+            self._by_id[clause_id]
+            for clause_id in clause_ids
+            if clause_id in self._by_id
+        )
+
+    def list_for_policy(self, policy: SusepProcess) -> tuple[PolicyClause, ...]:
+        return tuple(
+            clause for clause in self._by_id.values() if clause.susep_process == policy
+        )
+
+
+class InMemoryAssessmentRepository:
+    """An assessment store over a shared dict (so a UoW can snapshot it)."""
+
+    def __init__(self, store: dict[str, AssessmentRecord]) -> None:
+        self._store = store
+
+    def add(self, record: AssessmentRecord) -> None:
+        if record.assessment_id in self._store:
+            raise KeyError(f"assessment {record.assessment_id!r} already exists")
+        self._store[record.assessment_id] = record
+
+    def update(self, record: AssessmentRecord) -> None:
+        if record.assessment_id not in self._store:
+            raise KeyError(f"assessment {record.assessment_id!r} does not exist")
+        self._store[record.assessment_id] = record
+
+    def get(self, assessment_id: str) -> AssessmentRecord | None:
+        return self._store.get(assessment_id)
+
+    def list(
+        self,
+        *,
+        claim_id: str | None = None,
+        status: AssessmentStatus | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[AssessmentRecord, ...]:
+        rows = [
+            record
+            for record in self._store.values()
+            if (claim_id is None or record.claim_id == claim_id)
+            and (status is None or record.status is status)
+        ]
+        rows.sort(key=lambda record: record.assessment_id)
+        rows.sort(key=lambda record: record.created_at, reverse=True)
+        return tuple(rows[offset : offset + limit])
+
+
+class InMemoryUnitOfWork:
+    """A transaction with real rollback: it snapshots the store on entry."""
+
+    def __init__(self, store: dict[str, AssessmentRecord]) -> None:
+        self._store = store
+        self.assessments: AssessmentRepository = InMemoryAssessmentRepository(store)
+        self._snapshot: dict[str, AssessmentRecord] | None = None
+        self.committed = False
+
+    def __enter__(self) -> "UnitOfWork":
+        self._snapshot = dict(self._store)
+        self.committed = False
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if not self.committed:
+            self.rollback()
+        self._snapshot = None
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        if self._snapshot is not None:
+            self._store.clear()
+            self._store.update(self._snapshot)
+
+
+def make_uow_factory(store: dict[str, AssessmentRecord]) -> UnitOfWorkFactory:
+    def _open() -> InMemoryUnitOfWork:
+        return InMemoryUnitOfWork(store)
+
+    return _open
+
+
+class FakeClaimAssessmentOrchestrator:
+    """Records every call; returns canned results or raises a canned error."""
+
+    def __init__(
+        self,
+        *,
+        start_result: OrchestratorResult | None = None,
+        resume_result: OrchestratorResult | None = None,
+        raise_on_start: Exception | None = None,
+        raise_on_resume: Exception | None = None,
+    ) -> None:
+        self._start_result = start_result or make_orchestrator_result(
+            awaiting_review=True
+        )
+        self._resume_result = resume_result or make_orchestrator_result(
+            awaiting_review=False
+        )
+        self._raise_on_start = raise_on_start
+        self._raise_on_resume = raise_on_resume
+        self.started: list[tuple[str, Claim]] = []
+        self.resumed: list[tuple[str, HumanDecision]] = []
+
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        self.started.append((assessment_id, claim))
+        if self._raise_on_start is not None:
+            raise self._raise_on_start
+        return self._start_result
+
+    def resume(
+        self, *, assessment_id: str, decision: HumanDecision
+    ) -> OrchestratorResult:
+        self.resumed.append((assessment_id, decision))
+        if self._raise_on_resume is not None:
+            raise self._raise_on_resume
+        return self._resume_result

--- a/tests/unit/application/test_assessment_record.py
+++ b/tests/unit/application/test_assessment_record.py
@@ -1,0 +1,145 @@
+"""The AssessmentRecord aggregate and its invariants [M5-02]."""
+
+from datetime import datetime
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from domain.assessment import Assessment
+from domain.errors import CitationRequiredError
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.verdict import Verdict
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    abstain_result,
+    make_orchestrator_result,
+    make_record,
+)
+
+
+def _decision(
+    assessment_id: str = "assessment-1", **overrides: object
+) -> HumanDecision:
+    fields: dict[str, object] = {
+        "assessment_id": assessment_id,
+        "decision": DecisionOutcome.APPROVE,
+        "decided_at": FIXED_NOW,
+        "notes": "",
+        "edited_assessment": None,
+    }
+    fields.update(overrides)
+    return HumanDecision(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_grounded_record_projects_to_a_domain_assessment() -> None:
+    record = make_record()
+
+    assessment = record.as_domain_assessment()
+
+    assert isinstance(assessment, Assessment)
+    assert assessment.assessment_id == record.assessment_id
+    assert assessment.claim_id == record.claim_id
+    assert assessment.verdict is record.verdict
+    assert assessment.citations == record.citations
+    assert record.is_grounded
+
+
+@pytest.mark.unit
+def test_abstain_record_constructs_but_does_not_project() -> None:
+    record = make_record(
+        verdict=Verdict.INSUFFICIENT_INFORMATION,
+        citations=(),
+        confidence=0.2,
+        context_sufficient=False,
+    )
+
+    assert not record.is_grounded
+    with pytest.raises(CitationRequiredError):
+        record.as_domain_assessment()
+
+
+@pytest.mark.unit
+def test_decided_record_requires_a_decision() -> None:
+    with pytest.raises(ValueError, match="DECIDED record must carry a decision"):
+        make_record(status=AssessmentStatus.DECIDED, decision=None)
+
+
+@pytest.mark.unit
+def test_awaiting_review_record_rejects_a_decision() -> None:
+    with pytest.raises(ValueError, match="must not carry a decision"):
+        make_record(status=AssessmentStatus.AWAITING_REVIEW, decision=_decision())
+
+
+@pytest.mark.unit
+def test_decision_must_reference_this_assessment() -> None:
+    with pytest.raises(ValueError, match="reference the assessment it settled"):
+        make_record(
+            assessment_id="assessment-1",
+            status=AssessmentStatus.DECIDED,
+            decision=_decision(assessment_id="assessment-2"),
+        )
+
+
+@pytest.mark.unit
+def test_rejects_a_naive_created_at() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        make_record(created_at=datetime(2026, 9, 3, 12, 0))
+
+
+@pytest.mark.unit
+def test_rejects_confidence_out_of_range() -> None:
+    with pytest.raises(ValueError, match="confidence must be in"):
+        make_record(confidence=1.5)
+
+
+@pytest.mark.unit
+def test_rejects_a_non_verdict_verdict() -> None:
+    with pytest.raises(ValueError, match="must be a domain.verdict.Verdict"):
+        make_record(verdict="compatible")
+
+
+@pytest.mark.unit
+def test_from_orchestrator_result_copies_the_system_opinion() -> None:
+    flag_result = make_orchestrator_result(
+        consistency_flags=(),
+        missing_information=("vehicle_info",),
+        context_sufficient=True,
+        awaiting_review=True,
+    )
+
+    record = AssessmentRecord.from_orchestrator_result(
+        flag_result,
+        assessment_id="assessment-9",
+        claim_id="claim-9",
+        created_at=FIXED_NOW,
+        status=AssessmentStatus.AWAITING_REVIEW,
+    )
+
+    assert record.assessment_id == "assessment-9"
+    assert record.claim_id == "claim-9"
+    assert record.verdict is flag_result.verdict
+    assert record.reasoning == flag_result.reasoning
+    assert record.recommended_action == flag_result.recommended_action
+    assert record.citations == flag_result.citations
+    assert record.confidence == flag_result.confidence
+    assert record.missing_information == ("vehicle_info",)
+    assert record.status is AssessmentStatus.AWAITING_REVIEW
+    assert record.decision is None
+
+
+@pytest.mark.unit
+def test_from_orchestrator_result_carries_a_decision_when_decided() -> None:
+    record = AssessmentRecord.from_orchestrator_result(
+        abstain_result(awaiting_review=False),
+        assessment_id="assessment-1",
+        claim_id="claim-1",
+        created_at=FIXED_NOW,
+        status=AssessmentStatus.DECIDED,
+        decision=_decision(decision=DecisionOutcome.REJECT, notes="fora de vigencia"),
+    )
+
+    assert record.status is AssessmentStatus.DECIDED
+    assert record.decision is not None
+    assert record.decision.decision is DecisionOutcome.REJECT
+    assert record.citations == ()

--- a/tests/unit/application/test_fakes_satisfy_ports.py
+++ b/tests/unit/application/test_fakes_satisfy_ports.py
@@ -1,0 +1,42 @@
+"""The in-memory fakes structurally satisfy the M5-02 ports.
+
+The real assertion is mypy ``--strict`` over this file (the typed bindings
+below); the runtime test only guards against a fake losing a method.
+"""
+
+import pytest
+
+from application.ports.assessment_repository import AssessmentRepository
+from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.ports.clause_repository import ClauseRepository
+from application.ports.clock import Clock
+from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
+from tests.unit.application.fakes import (
+    FakeClaimAssessmentOrchestrator,
+    FixedClock,
+    InMemoryAssessmentRepository,
+    InMemoryClauseRepository,
+    InMemoryUnitOfWork,
+    NaiveClock,
+    make_uow_factory,
+)
+
+_clock: Clock = FixedClock()
+_naive_clock: Clock = NaiveClock()
+_clauses: ClauseRepository = InMemoryClauseRepository()
+_assessments: AssessmentRepository = InMemoryAssessmentRepository({})
+_uow: UnitOfWork = InMemoryUnitOfWork({})
+_uow_factory: UnitOfWorkFactory = make_uow_factory({})
+_orchestrator: ClaimAssessmentOrchestrator = FakeClaimAssessmentOrchestrator()
+
+
+@pytest.mark.unit
+def test_fakes_expose_the_port_methods() -> None:
+    assert callable(_clock.now)
+    assert callable(_clauses.get_many)
+    assert callable(_assessments.list)
+    assert callable(_orchestrator.start)
+    assert callable(_orchestrator.resume)
+    with _uow_factory() as uow:
+        assert isinstance(uow.assessments, InMemoryAssessmentRepository)
+        uow.commit()

--- a/tests/unit/application/use_cases/test_get_assessment.py
+++ b/tests/unit/application/use_cases/test_get_assessment.py
@@ -1,0 +1,71 @@
+"""The GetAssessment use case [M5-02]."""
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.errors import AssessmentNotFoundError
+from application.use_cases.get_assessment import GetAssessment
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.verdict import Verdict
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    InMemoryAssessmentRepository,
+    make_record,
+)
+
+
+@pytest.mark.unit
+def test_returns_the_stored_record() -> None:
+    store = {"assessment-1": make_record(assessment_id="assessment-1")}
+    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+
+    record = get_assessment("assessment-1")
+
+    assert isinstance(record, AssessmentRecord)
+    assert record.assessment_id == "assessment-1"
+
+
+@pytest.mark.unit
+def test_unknown_id_raises_not_found_carrying_the_id() -> None:
+    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository({}))
+
+    with pytest.raises(AssessmentNotFoundError) as excinfo:
+        get_assessment("missing")
+
+    assert excinfo.value.assessment_id == "missing"
+
+
+@pytest.mark.unit
+def test_returns_a_decided_record_with_its_decision() -> None:
+    decision = HumanDecision(
+        assessment_id="assessment-1",
+        decision=DecisionOutcome.APPROVE,
+        decided_at=FIXED_NOW,
+    )
+    store = {
+        "assessment-1": make_record(status=AssessmentStatus.DECIDED, decision=decision)
+    }
+    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+
+    record = get_assessment("assessment-1")
+
+    assert record.status is AssessmentStatus.DECIDED
+    assert record.decision is decision
+
+
+@pytest.mark.unit
+def test_serves_an_abstain_record_without_raising() -> None:
+    store = {
+        "assessment-1": make_record(
+            verdict=Verdict.INSUFFICIENT_INFORMATION,
+            citations=(),
+            confidence=0.2,
+            context_sufficient=False,
+        )
+    }
+    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+
+    record = get_assessment("assessment-1")
+
+    assert record.citations == ()
+    assert not record.is_grounded

--- a/tests/unit/application/use_cases/test_list_assessments.py
+++ b/tests/unit/application/use_cases/test_list_assessments.py
@@ -1,0 +1,134 @@
+"""The ListAssessments use case [M5-02]."""
+
+from datetime import timedelta
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.use_cases.list_assessments import ListAssessments
+from domain.human_decision import DecisionOutcome, HumanDecision
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    InMemoryAssessmentRepository,
+    make_record,
+)
+
+
+def _decided(
+    assessment_id: str, claim_id: str, offset_minutes: int
+) -> AssessmentRecord:
+    decision = HumanDecision(
+        assessment_id=assessment_id,
+        decision=DecisionOutcome.APPROVE,
+        decided_at=FIXED_NOW,
+    )
+    return make_record(
+        assessment_id=assessment_id,
+        claim_id=claim_id,
+        created_at=FIXED_NOW + timedelta(minutes=offset_minutes),
+        status=AssessmentStatus.DECIDED,
+        decision=decision,
+    )
+
+
+def _awaiting(
+    assessment_id: str, claim_id: str, offset_minutes: int
+) -> AssessmentRecord:
+    return make_record(
+        assessment_id=assessment_id,
+        claim_id=claim_id,
+        created_at=FIXED_NOW + timedelta(minutes=offset_minutes),
+    )
+
+
+@pytest.mark.unit
+def test_empty_store_returns_empty_tuple() -> None:
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository({}))
+
+    assert list_assessments() == ()
+
+
+@pytest.mark.unit
+def test_returns_records_newest_first() -> None:
+    store = {
+        "a-1": _awaiting("a-1", "claim-1", 0),
+        "a-2": _awaiting("a-2", "claim-1", 30),
+        "a-3": _awaiting("a-3", "claim-2", 10),
+    }
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    ids = [record.assessment_id for record in list_assessments()]
+
+    assert ids == ["a-2", "a-3", "a-1"]
+
+
+@pytest.mark.unit
+def test_ties_broken_by_assessment_id() -> None:
+    store = {
+        "a-2": _awaiting("a-2", "claim-1", 0),
+        "a-1": _awaiting("a-1", "claim-1", 0),
+    }
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    ids = [record.assessment_id for record in list_assessments()]
+
+    assert ids == ["a-1", "a-2"]
+
+
+@pytest.mark.unit
+def test_filter_by_claim_id() -> None:
+    store = {
+        "a-1": _awaiting("a-1", "claim-1", 0),
+        "a-2": _awaiting("a-2", "claim-2", 10),
+    }
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    result = list_assessments(claim_id="claim-2")
+
+    assert [record.assessment_id for record in result] == ["a-2"]
+
+
+@pytest.mark.unit
+def test_filter_by_status() -> None:
+    store = {
+        "a-1": _awaiting("a-1", "claim-1", 0),
+        "a-2": _decided("a-2", "claim-1", 10),
+    }
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    result = list_assessments(status=AssessmentStatus.DECIDED)
+
+    assert [record.assessment_id for record in result] == ["a-2"]
+
+
+@pytest.mark.unit
+def test_limit_and_offset_page_the_result() -> None:
+    store = {f"a-{i}": _awaiting(f"a-{i}", "claim-1", i) for i in range(5)}
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    page = list_assessments(limit=2, offset=1)
+
+    # newest-first is a-4, a-3, a-2, a-1, a-0 -> offset 1, limit 2
+    assert [record.assessment_id for record in page] == ["a-3", "a-2"]
+
+
+@pytest.mark.unit
+def test_combined_claim_and_status_filter() -> None:
+    store = {
+        "a-1": _decided("a-1", "claim-1", 0),
+        "a-2": _decided("a-2", "claim-2", 10),
+        "a-3": _awaiting("a-3", "claim-1", 20),
+    }
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository(store))
+
+    result = list_assessments(claim_id="claim-1", status=AssessmentStatus.DECIDED)
+
+    assert [record.assessment_id for record in result] == ["a-1"]
+
+
+@pytest.mark.unit
+def test_rejects_a_non_positive_limit() -> None:
+    list_assessments = ListAssessments(assessments=InMemoryAssessmentRepository({}))
+
+    with pytest.raises(ValueError, match="limit must be positive"):
+        list_assessments(limit=0)

--- a/tests/unit/application/use_cases/test_submit_claim.py
+++ b/tests/unit/application/use_cases/test_submit_claim.py
@@ -1,0 +1,150 @@
+"""The SubmitClaim use case [M5-02]."""
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.errors import OrchestratorContractError
+from application.use_cases.submit_claim import SubmitClaim
+from domain.verdict import Verdict
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    SUSEP,
+    FakeClaimAssessmentOrchestrator,
+    FixedClock,
+    NaiveClock,
+    SequentialIds,
+    abstain_result,
+    make_orchestrator_result,
+    make_uow_factory,
+)
+
+_NARRATIVE = "Bati o carro em uma colisao na avenida no dia 05/01/2026."
+
+
+def _build(
+    *,
+    orchestrator: FakeClaimAssessmentOrchestrator | None = None,
+    store: dict[str, AssessmentRecord] | None = None,
+    clock: object | None = None,
+    ids: SequentialIds | None = None,
+) -> tuple[SubmitClaim, dict[str, AssessmentRecord], FakeClaimAssessmentOrchestrator]:
+    resolved_store = store if store is not None else {}
+    resolved_orch = orchestrator or FakeClaimAssessmentOrchestrator()
+    use_case = SubmitClaim(
+        clock=clock or FixedClock(),  # type: ignore[arg-type]
+        orchestrator=resolved_orch,
+        uow_factory=make_uow_factory(resolved_store),
+        new_id=ids or SequentialIds("id"),
+    )
+    return use_case, resolved_store, resolved_orch
+
+
+@pytest.mark.unit
+def test_happy_path_persists_an_awaiting_review_record() -> None:
+    submit_claim, store, _ = _build()
+
+    record = submit_claim(raw_text=_NARRATIVE)
+
+    assert isinstance(record, AssessmentRecord)
+    assert record.status is AssessmentStatus.AWAITING_REVIEW
+    assert record.verdict is Verdict.COMPATIBLE
+    assert store[record.assessment_id] == record
+    assert record.created_at == FIXED_NOW
+
+
+@pytest.mark.unit
+def test_mints_distinct_claim_and_assessment_ids_from_new_id() -> None:
+    ids = SequentialIds("id")
+    submit_claim, _, orchestrator = _build(ids=ids)
+
+    record = submit_claim(raw_text=_NARRATIVE)
+
+    assert ids.issued == ["id-1", "id-2"]
+    assert record.claim_id == "id-1"
+    assert record.assessment_id == "id-2"
+    assert orchestrator.started[0][0] == "id-2"
+    assert orchestrator.started[0][1].claim_id == "id-1"
+
+
+@pytest.mark.unit
+def test_honours_an_explicit_claim_id() -> None:
+    ids = SequentialIds("id")
+    submit_claim, _, _ = _build(ids=ids)
+
+    record = submit_claim(raw_text=_NARRATIVE, claim_id="claim-external-7")
+
+    assert record.claim_id == "claim-external-7"
+    assert record.assessment_id == "id-1"
+    assert ids.issued == ["id-1"]
+
+
+@pytest.mark.unit
+def test_policy_ref_reaches_the_orchestrator_claim() -> None:
+    submit_claim, _, orchestrator = _build()
+
+    submit_claim(raw_text=_NARRATIVE, policy_ref=SUSEP)
+
+    assert orchestrator.started[0][1].policy_ref == SUSEP
+
+
+@pytest.mark.unit
+def test_abstain_outcome_persists_with_no_citations() -> None:
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        start_result=abstain_result(awaiting_review=True)
+    )
+    submit_claim, store, _ = _build(orchestrator=orchestrator)
+
+    record = submit_claim(raw_text=_NARRATIVE)
+
+    assert record.verdict is Verdict.INSUFFICIENT_INFORMATION
+    assert record.citations == ()
+    assert record.status is AssessmentStatus.AWAITING_REVIEW
+    assert store[record.assessment_id].citations == ()
+
+
+@pytest.mark.unit
+def test_empty_narrative_is_rejected_and_nothing_is_persisted() -> None:
+    submit_claim, store, orchestrator = _build()
+
+    with pytest.raises(ValueError, match="raw_text must not be empty"):
+        submit_claim(raw_text="")
+
+    assert store == {}
+    assert orchestrator.started == []
+
+
+@pytest.mark.unit
+def test_a_naive_clock_is_rejected_before_persisting() -> None:
+    submit_claim, store, orchestrator = _build(clock=NaiveClock())
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        submit_claim(raw_text=_NARRATIVE)
+
+    assert store == {}
+    assert orchestrator.started == []
+
+
+@pytest.mark.unit
+def test_orchestrator_failure_leaves_nothing_persisted() -> None:
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        raise_on_start=RuntimeError("graph exploded")
+    )
+    submit_claim, store, _ = _build(orchestrator=orchestrator)
+
+    with pytest.raises(RuntimeError, match="graph exploded"):
+        submit_claim(raw_text=_NARRATIVE)
+
+    assert store == {}
+
+
+@pytest.mark.unit
+def test_a_run_that_does_not_pause_is_a_contract_error() -> None:
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        start_result=make_orchestrator_result(awaiting_review=False)
+    )
+    submit_claim, store, _ = _build(orchestrator=orchestrator)
+
+    with pytest.raises(OrchestratorContractError, match="did not pause"):
+        submit_claim(raw_text=_NARRATIVE)
+
+    assert store == {}

--- a/tests/unit/application/use_cases/test_submit_human_decision.py
+++ b/tests/unit/application/use_cases/test_submit_human_decision.py
@@ -1,0 +1,244 @@
+"""The SubmitHumanDecision use case [M5-02]."""
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.edited_assessment_input import EditedAssessmentInput
+from application.errors import (
+    AssessmentAlreadyDecidedError,
+    AssessmentNotFoundError,
+    OrchestratorContractError,
+    UnknownClauseError,
+)
+from application.use_cases.submit_human_decision import SubmitHumanDecision
+from domain.errors import CitationRequiredError
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.verdict import Verdict
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    FakeClaimAssessmentOrchestrator,
+    FixedClock,
+    InMemoryAssessmentRepository,
+    InMemoryClauseRepository,
+    make_citation,
+    make_orchestrator_result,
+    make_policy_clause,
+    make_record,
+    make_uow_factory,
+)
+
+_KNOWN_CLAUSE_ID = "15414610650202459:3.4"
+
+
+def _build(
+    *,
+    record: AssessmentRecord | None = None,
+    orchestrator: FakeClaimAssessmentOrchestrator | None = None,
+    clauses: InMemoryClauseRepository | None = None,
+) -> tuple[
+    SubmitHumanDecision, dict[str, AssessmentRecord], FakeClaimAssessmentOrchestrator
+]:
+    seed = record if record is not None else make_record(assessment_id="assessment-1")
+    store: dict[str, AssessmentRecord] = {seed.assessment_id: seed}
+    resolved_orch = orchestrator or FakeClaimAssessmentOrchestrator(
+        resume_result=make_orchestrator_result(awaiting_review=False)
+    )
+    use_case = SubmitHumanDecision(
+        clock=FixedClock(),
+        orchestrator=resolved_orch,
+        assessments=InMemoryAssessmentRepository(store),
+        clauses=clauses
+        or InMemoryClauseRepository([make_policy_clause(clause_id=_KNOWN_CLAUSE_ID)]),
+        uow_factory=make_uow_factory(store),
+    )
+    return use_case, store, resolved_orch
+
+
+def _edit(**overrides: object) -> EditedAssessmentInput:
+    fields: dict[str, object] = {
+        "verdict": Verdict.INCOMPATIBLE,
+        "reasoning": "A exclusao 3.4 se aplica ao evento descrito.",
+        "recommended_action": "Registrar recusa com fundamento na clausula 3.4.",
+        "citations": (make_citation(clause_id=_KNOWN_CLAUSE_ID),),
+        "confidence": 0.66,
+    }
+    fields.update(overrides)
+    return EditedAssessmentInput(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_approve_settles_and_resumes_with_a_domain_decision() -> None:
+    submit_decision, store, orchestrator = _build()
+
+    updated = submit_decision(
+        assessment_id="assessment-1", decision=DecisionOutcome.APPROVE
+    )
+
+    assert updated.status is AssessmentStatus.DECIDED
+    assert updated.decision is not None
+    assert updated.decision.decision is DecisionOutcome.APPROVE
+    assert updated.decision.edited_assessment is None
+    assert updated.decision.decided_at == FIXED_NOW
+    assert store["assessment-1"].status is AssessmentStatus.DECIDED
+
+    resumed_id, resumed_decision = orchestrator.resumed[0]
+    assert resumed_id == "assessment-1"
+    assert isinstance(resumed_decision, HumanDecision)
+    assert resumed_decision.assessment_id == "assessment-1"
+
+
+@pytest.mark.unit
+def test_reject_stores_the_notes() -> None:
+    submit_decision, store, _ = _build()
+
+    updated = submit_decision(
+        assessment_id="assessment-1",
+        decision=DecisionOutcome.REJECT,
+        notes="Evento fora do periodo de vigencia.",
+    )
+
+    assert updated.decision is not None
+    assert updated.decision.notes == "Evento fora do periodo de vigencia."
+
+
+@pytest.mark.unit
+def test_edit_builds_a_grounded_assessment_and_keeps_the_system_verdict() -> None:
+    submit_decision, store, _ = _build(
+        record=make_record(assessment_id="assessment-1", claim_id="claim-77")
+    )
+
+    updated = submit_decision(
+        assessment_id="assessment-1",
+        decision=DecisionOutcome.EDIT,
+        edited=_edit(),
+    )
+
+    assert updated.verdict is Verdict.COMPATIBLE  # system opinion, untouched
+    assert updated.decision is not None
+    edited = updated.decision.edited_assessment
+    assert edited is not None
+    assert edited.assessment_id == "assessment-1"
+    assert edited.claim_id == "claim-77"
+    assert edited.verdict is Verdict.INCOMPATIBLE
+    assert len(edited.citations) == 1
+
+
+@pytest.mark.unit
+def test_edit_without_a_payload_is_rejected() -> None:
+    submit_decision, store, orchestrator = _build()
+
+    with pytest.raises(ValueError, match="requires an edited assessment"):
+        submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.EDIT)
+
+    assert orchestrator.resumed == []
+    assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_non_edit_carrying_a_payload_is_rejected() -> None:
+    submit_decision, _, orchestrator = _build()
+
+    with pytest.raises(ValueError, match="must not carry an edited assessment"):
+        submit_decision(
+            assessment_id="assessment-1",
+            decision=DecisionOutcome.APPROVE,
+            edited=_edit(),
+        )
+
+    assert orchestrator.resumed == []
+
+
+@pytest.mark.unit
+def test_edit_citing_nothing_hits_the_citation_rule() -> None:
+    submit_decision, _, orchestrator = _build()
+
+    with pytest.raises(CitationRequiredError):
+        submit_decision(
+            assessment_id="assessment-1",
+            decision=DecisionOutcome.EDIT,
+            edited=_edit(citations=()),
+        )
+
+    assert orchestrator.resumed == []
+
+
+@pytest.mark.unit
+def test_edit_citing_an_unknown_clause_is_rejected_before_resume() -> None:
+    submit_decision, store, orchestrator = _build()
+
+    with pytest.raises(UnknownClauseError) as excinfo:
+        submit_decision(
+            assessment_id="assessment-1",
+            decision=DecisionOutcome.EDIT,
+            edited=_edit(citations=(make_citation(clause_id="15414610650202459:9.9"),)),
+        )
+
+    assert excinfo.value.clause_ids == ("15414610650202459:9.9",)
+    assert orchestrator.resumed == []
+    assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_unknown_assessment_id_raises_not_found() -> None:
+    submit_decision, _, orchestrator = _build()
+
+    with pytest.raises(AssessmentNotFoundError):
+        submit_decision(assessment_id="missing", decision=DecisionOutcome.APPROVE)
+
+    assert orchestrator.resumed == []
+
+
+@pytest.mark.unit
+def test_already_decided_assessment_is_rejected() -> None:
+    decided = make_record(
+        assessment_id="assessment-1",
+        status=AssessmentStatus.DECIDED,
+        decision=HumanDecision(
+            assessment_id="assessment-1",
+            decision=DecisionOutcome.APPROVE,
+            decided_at=FIXED_NOW,
+        ),
+    )
+    submit_decision, store, orchestrator = _build(record=decided)
+
+    with pytest.raises(AssessmentAlreadyDecidedError):
+        submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.REJECT)
+
+    assert orchestrator.resumed == []
+    assert store["assessment-1"] == decided
+
+
+@pytest.mark.unit
+def test_resume_failure_leaves_the_record_awaiting_review() -> None:
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        raise_on_resume=RuntimeError("checkpoint gone")
+    )
+    submit_decision, store, _ = _build(orchestrator=orchestrator)
+
+    with pytest.raises(RuntimeError, match="checkpoint gone"):
+        submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.APPROVE)
+
+    assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_resume_that_re_pauses_is_a_contract_error() -> None:
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        resume_result=make_orchestrator_result(awaiting_review=True)
+    )
+    submit_decision, store, _ = _build(orchestrator=orchestrator)
+
+    with pytest.raises(OrchestratorContractError, match="did not complete"):
+        submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.APPROVE)
+
+    assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_a_non_decision_outcome_value_is_rejected() -> None:
+    submit_decision, _, orchestrator = _build()
+
+    with pytest.raises(ValueError):
+        submit_decision(assessment_id="assessment-1", decision="approve")  # type: ignore[arg-type]
+
+    assert orchestrator.resumed == []


### PR DESCRIPTION
## Summary

Adds the application layer's claim-assessment surface: the ports the service
depends on and the use-case interactors that drive the assessment lifecycle
through them. This is the seam that lets M5-04 build an HTTP API and M5-03 build
a real database without either knowing about the other.

**Ports** (`app/src/application/ports/`, one `Protocol` per file):
- `ClauseRepository` — read-only lookup over the registered-product clause
  corpus; standalone (not part of the transaction — reference data the use
  cases never write).
- `AssessmentRepository` — persists/queries `AssessmentRecord`; writes run in a
  `UnitOfWork`, reads do not.
- `ClaimAssessmentOrchestrator` — `start(*, assessment_id, claim)` /
  `resume(*, assessment_id, decision)` → `OrchestratorResult`. **No graph type
  crosses it** (no `ClaimState`, `Command`, `interrupt`, `thread_id`, or
  `infrastructure.graph` model). `assessment_id` is the sole run key.
- `UnitOfWork` (+ `UnitOfWorkFactory`) — one transaction, exposes only
  `assessments`.
- `Clock` — `now() -> datetime` (tz-aware UTC).

**Use cases** (`app/src/application/use_cases/`, frozen-dataclass interactors):
`SubmitClaim`, `GetAssessment`, `SubmitHumanDecision`, `ListAssessments`.

**DTOs** (`app/src/application/`): `AssessmentRecord` / `AssessmentStatus`,
`OrchestratorResult`, `ConsistencyFlag`, `EditedAssessmentInput`, `errors.py`.

**Import test**: `test_layer_boundaries.py::test_application_imports_no_infrastructure_or_llm_sdk`
bars `infrastructure`, `langchain_core` and `langchain_openai` from the
application layer (the latter two are separate top-level roots that
`_top_level_module` does not fold into `langchain`).

### Design decisions

- **`AssessmentRecord`, not `domain.Assessment`, is the persisted/servable
  unit.** `Assessment`'s ≥1-citation invariant is unconditional, but the graph
  can finish an insufficient-context / clarification-exhausted run citing
  nothing, and those must still be served after the LangGraph checkpoint is
  gone. `AssessmentRecord.as_domain_assessment()` is the grounded projection
  back — and raises `CitationRequiredError` on an abstain, which is the
  invariant doing its job.
- **`assessment_id` == the graph `thread_id`.** `SubmitClaim` mints a fresh one
  per submission, so re-submitting a claim is a new run for free.
- **`edit` decisions always produce a grounded `Assessment`** (≥1 citation,
  every cited clause validated against `ClauseRepository` before the graph is
  resumed). Keeping a 0-citation abstain unchanged is an `approve`.

### Deviations from the DoD (recorded in `docs/ARCHITECTURE.md`)

- **`RetrievalService` is not delivered.** No M5-02 use case consumes semantic
  retrieval — `Citation.excerpt` already carries hydrated clause text — so the
  port would have no caller. This codebase lands a port with its first consumer
  (M4-04's `RetrievalPort`, M4-09's `AuditTrailSink`), never ahead of one.
  Retrieval stays internal to the graph, reached only through
  `ClaimAssessmentOrchestrator`.
- **The concrete LangGraph orchestrator adapter and the real `Clock`
  (`SystemClock`) are deferred to M5-04's composition root** — "contracts
  first, adapters after". M5-02 ships the port + in-memory fake; the plan
  documents a field-by-field proof that the port shape is sufficient for that
  adapter.

## Related issue

[M5-02]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) — 46 new
      unit tests in `tests/unit/application/` (every use case with its rejection
      cases, driven through in-memory fakes; no LLM, no DB, no graph) plus the
      new architecture import test.
- [x] Docs updated — new `docs/ARCHITECTURE.md` section; clarifying edits to
      `docs/DOMAIN.md`, `docs/HUMAN_CHECKPOINT.md`, `docs/END_TO_END_EVALUATION.md`.
- [x] Evaluation impact considered — none. This layer sits above parsing,
      retrieval and the graph; no evaluation number changes.
- [x] `make check` passes locally (`lint`, `format-check`, `mypy --strict`,
      `pytest -m unit` — 1206 passed).