### PR TITLE
feat(infrastructure): put a real Postgres database behind the persist…

### DIFF
--- a/alembic/versions/20260903_01_create_assessment_and_decision_tables.py
+++ b/alembic/versions/20260903_01_create_assessment_and_decision_tables.py
@@ -1,0 +1,105 @@
+"""Create the assessment and human_decision tables.
+
+[M5-03]'s domain tables: the persistence side of
+[application.assessment_record.AssessmentRecord] (the servable aggregate, which
+unlike a grounded [domain.assessment.Assessment] can carry zero citations) and
+the analyst's [domain.human_decision.HumanDecision] recorded beside it.
+
+`citations` and `consistency_flags` are `JSONB` arrays of objects, not child
+tables: both are frozen value-object tuples with no identity, always read whole
+with the record and never queried by field -- the same call as
+`audit_event.payload`. `missing_information` is a plain `TEXT[]`.
+
+`human_decision.assessment_id` is both the primary key and a foreign key to
+`assessment` -- "a decision always references the assessment it acted on" (M5-01)
+made structural. The `edited_assessment` JSONB is present exactly when
+`decision = 'edit'`, enforced by a CHECK that mirrors `HumanDecision`'s own
+validator.
+
+The enum value lists are plain literals here (like `20260827_02`) so the
+migration imports no app code that could move under it;
+`tests/unit/infrastructure/database/test_models.py` ties the model's CHECKs back
+to the domain enums, and any divergence surfaces as an `alembic check` diff.
+
+Revision ID: 20260903_01
+Revises: 20260902_01
+Create Date: 2026-09-03 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260903_01"
+down_revision: str | None = "20260902_01"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_VERDICT_VALUES = ("compatible", "incompatible", "insufficient_information")
+_STATUS_VALUES = ("awaiting_review", "decided")
+_DECISION_VALUES = ("approve", "edit", "reject")
+
+
+def _in_check(column: str, values: Sequence[str]) -> str:
+    """Render ``column IN ('a', 'b', ...)`` for a CHECK constraint."""
+    rendered = ", ".join(f"'{value}'" for value in values)
+    return f"{column} IN ({rendered})"
+
+
+def upgrade() -> None:
+    """Create `assessment`, `human_decision`, and the query indexes."""
+    op.create_table(
+        "assessment",
+        sa.Column("assessment_id", sa.Text(), nullable=False),
+        sa.Column("claim_id", sa.Text(), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("reasoning", sa.Text(), nullable=False),
+        sa.Column("recommended_action", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("context_sufficient", sa.Boolean(), nullable=True),
+        sa.Column("clarification_exhausted", sa.Boolean(), nullable=False),
+        sa.Column("missing_information", postgresql.ARRAY(sa.Text()), nullable=False),
+        sa.Column("citations", postgresql.JSONB(), nullable=False),
+        sa.Column("consistency_flags", postgresql.JSONB(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        # Bare constraint names: `Base.metadata`'s naming_convention -- which
+        # Alembic's op context also applies -- expands these to
+        # `ck_assessment_<name>` / `pk_assessment`, matching the model.
+        sa.CheckConstraint(_in_check("verdict", _VERDICT_VALUES), name="verdict_valid"),
+        sa.CheckConstraint(_in_check("status", _STATUS_VALUES), name="status_valid"),
+        sa.PrimaryKeyConstraint("assessment_id"),
+    )
+    op.create_index("ix_assessment_claim_id", "assessment", ["claim_id"])
+    op.create_index("ix_assessment_status", "assessment", ["status"])
+    op.create_index("ix_assessment_created_at", "assessment", ["created_at"])
+
+    op.create_table(
+        "human_decision",
+        sa.Column("assessment_id", sa.Text(), nullable=False),
+        sa.Column("decision", sa.Text(), nullable=False),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=False),
+        sa.Column("edited_assessment", postgresql.JSONB(), nullable=True),
+        sa.CheckConstraint(
+            _in_check("decision", _DECISION_VALUES), name="decision_valid"
+        ),
+        sa.CheckConstraint(
+            "(decision = 'edit') = (edited_assessment IS NOT NULL)",
+            name="edited_assessment_iff_edit",
+        ),
+        # Unnamed FK: the naming_convention builds
+        # `fk_human_decision_assessment_id_assessment` on both sides.
+        sa.ForeignKeyConstraint(["assessment_id"], ["assessment.assessment_id"]),
+        sa.PrimaryKeyConstraint("assessment_id"),
+    )
+
+
+def downgrade() -> None:
+    """Drop `human_decision` first (it references `assessment`), then `assessment`."""
+    op.drop_table("human_decision")
+    op.drop_table("assessment")

--- a/alembic/versions/20260903_02_audit_event_append_only.py
+++ b/alembic/versions/20260903_02_audit_event_append_only.py
@@ -1,0 +1,59 @@
+"""Make audit_event append-only at the database.
+
+[M5-03]'s DoD: "the audit trail is append-only ... add a test asserting it
+cannot be updated." Until now the property held only by construction --
+[infrastructure.database.audit_repository] offers an insert and nothing else.
+This adds the database-level guarantee: a `BEFORE UPDATE OR DELETE` trigger on
+`audit_event` that raises.
+
+A trigger, not an `ON UPDATE ... DO INSTEAD NOTHING` rule: a rule would swallow
+the write silently, so a bug (or a compromised connection) that tries to rewrite
+history would look like it succeeded. The trigger fails loudly, which is also
+what makes the DoD's "cannot be updated" test possible.
+
+The insert path is untouched: `append_audit_events` uses
+`INSERT ... ON CONFLICT (thread_id, sequence) DO NOTHING`, which never fires an
+UPDATE, so the checkpoint node's idempotent re-write on resume still works.
+
+Revision ID: 20260903_02
+Revises: 20260903_01
+Create Date: 2026-09-03 00:00:01
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260903_02"
+down_revision: str | None = "20260903_01"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_CREATE_FUNCTION = """
+CREATE FUNCTION audit_event_reject_mutation() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_event is append-only: % is not permitted', TG_OP
+        USING ERRCODE = 'restrict_violation';
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_CREATE_TRIGGER = """
+CREATE TRIGGER audit_event_append_only
+    BEFORE UPDATE OR DELETE ON audit_event
+    FOR EACH ROW EXECUTE FUNCTION audit_event_reject_mutation();
+"""
+
+
+def upgrade() -> None:
+    """Install the reject-mutation function and the audit_event trigger."""
+    op.execute(_CREATE_FUNCTION)
+    op.execute(_CREATE_TRIGGER)
+
+
+def downgrade() -> None:
+    """Remove the trigger and its function."""
+    op.execute("DROP TRIGGER audit_event_append_only ON audit_event")
+    op.execute("DROP FUNCTION audit_event_reject_mutation()")

--- a/app/src/infrastructure/database/__init__.py
+++ b/app/src/infrastructure/database/__init__.py
@@ -4,6 +4,13 @@ SQLAlchemy models, repositories, session management, and the pgvector
 integration.
 """
 
+from infrastructure.database.assessment_mapper import (
+    record_to_rows,
+    rows_to_record,
+)
+from infrastructure.database.assessment_repository import (
+    SqlAlchemyAssessmentRepository,
+)
 from infrastructure.database.audit_repository import append_audit_events
 from infrastructure.database.base import Base
 from infrastructure.database.chunk_repository import (
@@ -12,20 +19,35 @@ from infrastructure.database.chunk_repository import (
     upsert_chunks,
     write_chunk_embeddings,
 )
+from infrastructure.database.clause_repository import SqlAlchemyClauseRepository
 from infrastructure.database.graph_audit_sink import SqlAlchemyAuditTrailSink
-from infrastructure.database.models import AuditEventRow, ChunkRow
+from infrastructure.database.models import (
+    AssessmentRow,
+    AuditEventRow,
+    ChunkRow,
+    HumanDecisionRow,
+)
 from infrastructure.database.session import (
     create_engine_from_database_url,
     create_engine_from_settings,
     create_session_factory,
     is_database_reachable,
 )
+from infrastructure.database.unit_of_work import (
+    SqlAlchemyUnitOfWork,
+    sqlalchemy_unit_of_work_factory,
+)
 
 __all__ = [
+    "AssessmentRow",
     "AuditEventRow",
     "Base",
     "ChunkRow",
+    "HumanDecisionRow",
+    "SqlAlchemyAssessmentRepository",
     "SqlAlchemyAuditTrailSink",
+    "SqlAlchemyClauseRepository",
+    "SqlAlchemyUnitOfWork",
     "append_audit_events",
     "assert_chunk_table_ready",
     "create_engine_from_database_url",
@@ -33,6 +55,9 @@ __all__ = [
     "create_session_factory",
     "fetch_chunks_missing_embedding",
     "is_database_reachable",
+    "record_to_rows",
+    "rows_to_record",
+    "sqlalchemy_unit_of_work_factory",
     "upsert_chunks",
     "write_chunk_embeddings",
 ]

--- a/app/src/infrastructure/database/assessment_mapper.py
+++ b/app/src/infrastructure/database/assessment_mapper.py
@@ -1,0 +1,221 @@
+"""Map the assessment aggregate to and from its database rows -- [M5-03].
+
+``docs/DOMAIN.md`` names "domain <-> ORM row" mappers as [M5-03]'s deliverable.
+This module is that mapper for the assessment surface: pure functions, no
+session, between [application.assessment_record.AssessmentRecord] (plus the
+[domain.human_decision.HumanDecision] recorded beside it) and the
+[infrastructure.database.models.AssessmentRow] /
+[infrastructure.database.models.HumanDecisionRow] pair.
+
+``citations`` / ``consistency_flags`` / ``edited_assessment`` are stored as
+``JSONB``; the ``_*_to_json`` / ``_*_from_json`` helpers are the one place their
+wire shape is defined. Value objects that carry a stricter type than JSON can
+(``SusepProcess``, the ``ClauseType`` / ``Verdict`` / ``DecisionOutcome`` /
+``AssessmentStatus`` enums) are written as their canonical string and rebuilt on
+read -- the domain constructors re-validate, so a corrupted row fails loudly
+rather than flowing through.
+
+The graph's Pydantic ``state.py`` twin is deliberately *not* handled here: the
+only consumer of a ``state`` <-> domain mapper is the LangGraph orchestrator
+adapter, which is [M5-04]'s. ``AssessmentRecord.from_orchestrator_result``
+already bridges the graph-free DTO.
+"""
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Literal, cast
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.consistency_flag import ConsistencyFlag
+from domain.assessment import Assessment
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+from infrastructure.database.models import AssessmentRow, HumanDecisionRow
+
+
+def _require_str(data: Mapping[str, object], key: str) -> str:
+    """Read a required string field from a JSON object, or raise."""
+    value = data.get(key)
+    if not isinstance(value, str):
+        raise TypeError(f"expected a string for {key!r}, got {value!r}")
+    return value
+
+
+def _require_number(data: Mapping[str, object], key: str) -> float:
+    """Read a required numeric field from a JSON object, or raise."""
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"expected a number for {key!r}, got {value!r}")
+    return float(value)
+
+
+# --------------------------------------------------------------------------- #
+# citations
+# --------------------------------------------------------------------------- #
+def _citation_to_json(citation: Citation) -> dict[str, object]:
+    return {
+        "clause_id": citation.clause_id,
+        "document_id": citation.document_id,
+        "susep_process": citation.susep_process.value,
+        "clause_type": citation.clause_type.value,
+        "excerpt": citation.excerpt,
+        "relevance_score": citation.relevance_score,
+    }
+
+
+def _citation_from_json(data: Mapping[str, object]) -> Citation:
+    return Citation(
+        clause_id=_require_str(data, "clause_id"),
+        document_id=_require_str(data, "document_id"),
+        susep_process=SusepProcess(_require_str(data, "susep_process")),
+        clause_type=ClauseType(_require_str(data, "clause_type")),
+        excerpt=_require_str(data, "excerpt"),
+        relevance_score=_require_number(data, "relevance_score"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# consistency flags
+# --------------------------------------------------------------------------- #
+def _flag_to_json(flag: ConsistencyFlag) -> dict[str, object]:
+    return {
+        "check": flag.check,
+        "severity": flag.severity,
+        "detail": flag.detail,
+        "source": flag.source,
+    }
+
+
+def _flag_from_json(data: Mapping[str, object]) -> ConsistencyFlag:
+    # `ConsistencyFlag.__post_init__` re-validates the closed vocabularies; the
+    # casts only satisfy the Literal annotations.
+    return ConsistencyFlag(
+        check=_require_str(data, "check"),
+        severity=cast(Literal["info", "attention"], _require_str(data, "severity")),
+        detail=_require_str(data, "detail"),
+        source=cast(Literal["deterministic", "llm"], _require_str(data, "source")),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the edited assessment nested in an `edit` decision
+# --------------------------------------------------------------------------- #
+def _assessment_to_json(assessment: Assessment) -> dict[str, object]:
+    return {
+        "assessment_id": assessment.assessment_id,
+        "claim_id": assessment.claim_id,
+        "verdict": assessment.verdict.value,
+        "reasoning": assessment.reasoning,
+        "citations": [_citation_to_json(c) for c in assessment.citations],
+        "confidence": assessment.confidence,
+        "recommended_action": assessment.recommended_action,
+    }
+
+
+def _assessment_from_json(data: Mapping[str, object]) -> Assessment:
+    raw_citations = data.get("citations")
+    if not isinstance(raw_citations, list):
+        raise TypeError(f"expected a list for 'citations', got {raw_citations!r}")
+    return Assessment(
+        assessment_id=_require_str(data, "assessment_id"),
+        claim_id=_require_str(data, "claim_id"),
+        verdict=Verdict(_require_str(data, "verdict")),
+        reasoning=_require_str(data, "reasoning"),
+        citations=tuple(_citation_from_json(item) for item in raw_citations),
+        confidence=_require_number(data, "confidence"),
+        recommended_action=_require_str(data, "recommended_action"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the human decision
+# --------------------------------------------------------------------------- #
+def _decision_to_row(decision: HumanDecision) -> HumanDecisionRow:
+    edited = decision.edited_assessment
+    return HumanDecisionRow(
+        assessment_id=decision.assessment_id,
+        decision=decision.decision.value,
+        decided_at=decision.decided_at,
+        notes=decision.notes,
+        edited_assessment=(_assessment_to_json(edited) if edited is not None else None),
+    )
+
+
+def _decision_from_row(row: HumanDecisionRow) -> HumanDecision:
+    edited = row.edited_assessment
+    return HumanDecision(
+        assessment_id=row.assessment_id,
+        decision=DecisionOutcome(row.decision),
+        decided_at=_as_aware(row.decided_at),
+        notes=row.notes,
+        edited_assessment=(
+            _assessment_from_json(edited) if edited is not None else None
+        ),
+    )
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Guard: a ``timestamptz`` column must never hand back a naive datetime.
+
+    psycopg returns tz-aware datetimes for ``timestamptz``; this makes a
+    misconfigured column (or a driver change) fail here rather than several
+    layers up, where the domain would reject it with less context.
+    """
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"expected a timezone-aware datetime, got {value!r}")
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# the aggregate
+# --------------------------------------------------------------------------- #
+def record_to_rows(
+    record: AssessmentRecord,
+) -> tuple[AssessmentRow, HumanDecisionRow | None]:
+    """Split an ``AssessmentRecord`` into its ``assessment`` (+ decision) rows."""
+    assessment = AssessmentRow(
+        assessment_id=record.assessment_id,
+        claim_id=record.claim_id,
+        verdict=record.verdict.value,
+        reasoning=record.reasoning,
+        recommended_action=record.recommended_action,
+        confidence=record.confidence,
+        context_sufficient=record.context_sufficient,
+        clarification_exhausted=record.clarification_exhausted,
+        missing_information=list(record.missing_information),
+        citations=[_citation_to_json(c) for c in record.citations],
+        consistency_flags=[_flag_to_json(f) for f in record.consistency_flags],
+        status=record.status.value,
+        created_at=record.created_at,
+    )
+    decision_row = (
+        _decision_to_row(record.decision) if record.decision is not None else None
+    )
+    return assessment, decision_row
+
+
+def rows_to_record(
+    assessment: AssessmentRow, decision: HumanDecisionRow | None
+) -> AssessmentRecord:
+    """Rebuild an ``AssessmentRecord`` from its rows (the aggregate re-validates)."""
+    return AssessmentRecord(
+        assessment_id=assessment.assessment_id,
+        claim_id=assessment.claim_id,
+        verdict=Verdict(assessment.verdict),
+        reasoning=assessment.reasoning,
+        recommended_action=assessment.recommended_action,
+        citations=tuple(_citation_from_json(item) for item in assessment.citations),
+        confidence=assessment.confidence,
+        consistency_flags=tuple(
+            _flag_from_json(item) for item in assessment.consistency_flags
+        ),
+        context_sufficient=assessment.context_sufficient,
+        clarification_exhausted=assessment.clarification_exhausted,
+        missing_information=tuple(assessment.missing_information),
+        status=AssessmentStatus(assessment.status),
+        created_at=_as_aware(assessment.created_at),
+        decision=_decision_from_row(decision) if decision is not None else None,
+    )

--- a/app/src/infrastructure/database/assessment_repository.py
+++ b/app/src/infrastructure/database/assessment_repository.py
@@ -1,0 +1,113 @@
+"""The SQLAlchemy ``AssessmentRepository`` -- [M5-03].
+
+Implements [application.ports.assessment_repository.AssessmentRepository] over
+the ``assessment`` / ``human_decision`` tables. Constructed with a ``Session``:
+
+* the write methods (``add`` / ``update``) are used through a
+  [infrastructure.database.unit_of_work.SqlAlchemyUnitOfWork], which owns the
+  transaction -- this class flushes, never commits;
+* the read methods (``get`` / ``list``) work on any ``Session``, so the [M5-04]
+  composition root can build a short-lived read instance on a fresh session
+  outside the unit of work ("two bindings", ``docs/ARCHITECTURE.md`` M5-02).
+
+The row <-> aggregate translation is entirely in
+[infrastructure.database.assessment_mapper].
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from infrastructure.database.assessment_mapper import record_to_rows, rows_to_record
+from infrastructure.database.models import AssessmentRow, HumanDecisionRow
+
+_DEFAULT_LIMIT = 50
+
+
+class SqlAlchemyAssessmentRepository:
+    """Persist and query ``AssessmentRecord`` aggregates in Postgres."""
+
+    def __init__(self, session: Session) -> None:
+        """Bind the repository to a session (the unit of work owns its lifecycle)."""
+        self._session = session
+
+    def add(self, record: AssessmentRecord) -> None:
+        """Persist a new record. A duplicate id raises ``IntegrityError`` on flush."""
+        assessment_row, decision_row = record_to_rows(record)
+        self._session.add(assessment_row)
+        if decision_row is not None:
+            self._session.add(decision_row)
+        self._session.flush()
+
+    def update(self, record: AssessmentRecord) -> None:
+        """Replace the stored record with the same ``assessment_id``.
+
+        Raises:
+            KeyError: no record exists for ``record.assessment_id`` -- matching
+                the in-memory fake's contract.
+        """
+        existing = self._session.get(AssessmentRow, record.assessment_id)
+        if existing is None:
+            raise KeyError(f"assessment {record.assessment_id!r} does not exist")
+
+        assessment_row, decision_row = record_to_rows(record)
+        self._session.merge(assessment_row)
+
+        stored_decision = self._session.get(HumanDecisionRow, record.assessment_id)
+        if decision_row is not None:
+            self._session.merge(decision_row)
+        elif stored_decision is not None:
+            self._session.delete(stored_decision)
+        self._session.flush()
+
+    def get(self, assessment_id: str) -> AssessmentRecord | None:
+        """Return the record for ``assessment_id``, or ``None`` if there is none."""
+        assessment_row = self._session.get(AssessmentRow, assessment_id)
+        if assessment_row is None:
+            return None
+        decision_row = self._session.get(HumanDecisionRow, assessment_id)
+        return rows_to_record(assessment_row, decision_row)
+
+    def list(
+        self,
+        *,
+        claim_id: str | None = None,
+        status: AssessmentStatus | None = None,
+        limit: int = _DEFAULT_LIMIT,
+        offset: int = 0,
+    ) -> tuple[AssessmentRecord, ...]:
+        """Return records newest first (``created_at`` desc, then ``assessment_id``)."""
+        statement = select(AssessmentRow)
+        if claim_id is not None:
+            statement = statement.where(AssessmentRow.claim_id == claim_id)
+        if status is not None:
+            statement = statement.where(AssessmentRow.status == status.value)
+        statement = (
+            statement.order_by(
+                AssessmentRow.created_at.desc(), AssessmentRow.assessment_id
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+
+        assessment_rows = list(self._session.execute(statement).scalars())
+        decisions = self._decisions_for([row.assessment_id for row in assessment_rows])
+        return tuple(
+            rows_to_record(row, decisions.get(row.assessment_id))
+            for row in assessment_rows
+        )
+
+    def _decisions_for(
+        self, assessment_ids: Sequence[str]
+    ) -> dict[str, HumanDecisionRow]:
+        """One query for every decision row in the current page."""
+        if not assessment_ids:
+            return {}
+        rows = self._session.execute(
+            select(HumanDecisionRow).where(
+                HumanDecisionRow.assessment_id.in_(assessment_ids)
+            )
+        ).scalars()
+        return {row.assessment_id: row for row in rows}

--- a/app/src/infrastructure/database/clause_repository.py
+++ b/app/src/infrastructure/database/clause_repository.py
@@ -1,0 +1,89 @@
+"""The SQLAlchemy ``ClauseRepository`` -- [M5-03].
+
+Implements [application.ports.clause_repository.ClauseRepository] over the
+existing ``chunk`` table -- there is no separate ``clause`` table, and the port
+docstring already commits to this backing. Read-only: the clause corpus is
+reference data built by the M1 pipeline, outside the assessment transaction.
+
+A ``chunk`` row records every clause-tree id folded into it in
+``source_clause_ids`` (the anchor plus any merged siblings), and a long clause
+splits across several rows. So a clause is reassembled by collecting every row
+whose ``source_clause_ids`` contains the wanted id, ordering by ``chunk_index``
+and joining ``display_text`` -- the same reconstruction
+[infrastructure.rag.graph_retrieval_adapter.build_clause_index] does for a
+retrieval hit, which is where a [domain.citation.Citation]'s ``clause_id`` comes
+from.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import any_, select
+from sqlalchemy.orm import Session
+
+from domain.clause_classification import ClauseType
+from domain.policy_clause import PolicyClause
+from domain.susep_process import SusepProcess
+from infrastructure.database.models import ChunkRow
+
+_TEXT_JOIN = "\n\n"
+
+
+class SqlAlchemyClauseRepository:
+    """Look up registered-product clauses, projected from the ``chunk`` table."""
+
+    def __init__(self, session: Session) -> None:
+        """Bind the repository to a session (reads only; no transaction needed)."""
+        self._session = session
+
+    def get(self, clause_id: str) -> PolicyClause | None:
+        """Return the clause with ``clause_id``, or ``None`` if the corpus has none."""
+        rows = list(
+            self._session.execute(
+                select(ChunkRow).where(any_(ChunkRow.source_clause_ids) == clause_id)
+            ).scalars()
+        )
+        return _assemble(clause_id, rows)
+
+    def get_many(self, clause_ids: Sequence[str]) -> tuple[PolicyClause, ...]:
+        """Return the clauses that exist, in the order their ids were given.
+
+        Its one caller (``SubmitHumanDecision`` validating an edit's citations)
+        passes a handful of ids, so a lookup per id is fine and keeps the query
+        simple.
+        """
+        found = (self.get(clause_id) for clause_id in clause_ids)
+        return tuple(clause for clause in found if clause is not None)
+
+    def list_for_policy(self, policy: SusepProcess) -> tuple[PolicyClause, ...]:
+        """Return every clause of the product identified by ``policy``."""
+        rows = list(
+            self._session.execute(
+                select(ChunkRow).where(ChunkRow.susep_process == policy.value)
+            ).scalars()
+        )
+
+        by_id: dict[str, list[ChunkRow]] = {}
+        for row in rows:
+            for source_id in row.source_clause_ids:
+                by_id.setdefault(source_id, []).append(row)
+
+        assembled = (
+            _assemble(clause_id, chunk_rows) for clause_id, chunk_rows in by_id.items()
+        )
+        return tuple(clause for clause in assembled if clause is not None)
+
+
+def _assemble(clause_id: str, rows: Sequence[ChunkRow]) -> PolicyClause | None:
+    """Build one ``PolicyClause`` from the chunk rows that carry ``clause_id``."""
+    if not rows:
+        return None
+    ordered = sorted(rows, key=lambda row: row.chunk_index)
+    anchor = ordered[0]
+    text = _TEXT_JOIN.join(row.display_text for row in ordered)
+    return PolicyClause(
+        clause_id=clause_id,
+        susep_process=SusepProcess(anchor.susep_process),
+        document_id=anchor.document_id,
+        clause_type=ClauseType(anchor.clause_type),
+        text=text,
+    )

--- a/app/src/infrastructure/database/models.py
+++ b/app/src/infrastructure/database/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy ORM models -- [M3-02], [M4-09].
+"""SQLAlchemy ORM models -- [M3-02], [M4-09], [M5-03].
 
 ``ChunkRow`` is the persistence representation of [domain.chunk.Chunk] /
 [infrastructure.rag.chunk_schema.ChunkRecord]: the chunk corpus indexed in
@@ -15,18 +15,39 @@ ANN-vs-exact measurement and the verdict are in docs/EMBEDDINGS.md.
 
 ``AuditEventRow`` ([M4-09]) is the same idea applied to the graph's audit trail:
 the persistence representation of [infrastructure.graph.state.AuditEvent].
+
+``AssessmentRow`` / ``HumanDecisionRow`` ([M5-03]) are the persistence
+representation of the servable aggregate
+[application.assessment_record.AssessmentRecord] and the analyst's
+[domain.human_decision.HumanDecision] recorded beside it. ``citations`` and
+``consistency_flags`` are ``JSONB`` rather than child tables: they are frozen
+value-object tuples read back whole with the record and never queried by field
+(the same call as ``AuditEventRow.payload``). The domain <-> row mapper lives in
+``infrastructure.database.assessment_mapper``.
 """
 
 from collections.abc import Iterable
 from datetime import datetime
 
 from pgvector.sqlalchemy import HALFVEC
-from sqlalchemy import CheckConstraint, DateTime, Float, Index, Integer, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
+from application.assessment_record import AssessmentStatus
 from domain.chunk import ChunkRule
 from domain.clause_classification import ClauseType, TypeSource
+from domain.human_decision import DecisionOutcome
+from domain.verdict import Verdict
 from infrastructure.database.base import Base
 from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS
 
@@ -193,3 +214,115 @@ class AuditEventRow(Base):
     payload: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
 
     __table_args__ = (Index("ix_audit_event_claim_id", "claim_id"),)
+
+
+class AssessmentRow(Base):
+    """One claim's assessment across its whole lifecycle -- [M5-03].
+
+    The persistence representation of
+    [application.assessment_record.AssessmentRecord] (the servable aggregate,
+    *not* the grounded [domain.assessment.Assessment] -- an abstain outcome has
+    no citations and still has to be stored and served). Column per field, so a
+    reader can query the trail in SQL; the domain <-> row mapper is in
+    [infrastructure.database.assessment_mapper].
+
+    ``citations`` and ``consistency_flags`` are ``JSONB`` arrays of objects, not
+    child tables: both are frozen value-object tuples with no identity of their
+    own, always loaded whole with the record and never filtered by field -- the
+    same reasoning as ``AuditEventRow.payload``. ``missing_information`` is a
+    plain ``TEXT[]`` (like ``ChunkRow.source_clause_ids``).
+
+    The enum-valued columns (``verdict``, ``status``) are ``TEXT`` + a named
+    ``CHECK``, matching ``ChunkRow``'s precedent -- no native PG enums in this
+    project. ``context_sufficient`` is genuinely tri-state
+    (``True``/``False``/``None`` -- retrieval succeeded / gated / never ran).
+    """
+
+    __tablename__ = "assessment"
+
+    assessment_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    claim_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    verdict: Mapped[str] = mapped_column(Text, nullable=False)
+    reasoning: Mapped[str] = mapped_column(Text, nullable=False)
+    recommended_action: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+
+    # Tri-state on purpose -- see the class docstring.
+    context_sufficient: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    clarification_exhausted: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    missing_information: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False)
+
+    citations: Mapped[list[dict[str, object]]] = mapped_column(JSONB, nullable=False)
+    consistency_flags: Mapped[list[dict[str, object]]] = mapped_column(
+        JSONB, nullable=False
+    )
+
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            _in_clause("verdict", (member.value for member in Verdict)),
+            name="verdict_valid",
+        ),
+        CheckConstraint(
+            _in_clause("status", (member.value for member in AssessmentStatus)),
+            name="status_valid",
+        ),
+        # `claim_id` -- every assessment of one claim ([List] filter, and what a
+        # human searches by). `status` -- the awaiting-review queue. `created_at`
+        # -- `AssessmentRepository.list` orders by it (newest first).
+        Index("ix_assessment_claim_id", "claim_id"),
+        Index("ix_assessment_status", "status"),
+        Index("ix_assessment_created_at", "created_at"),
+    )
+
+
+class HumanDecisionRow(Base):
+    """The analyst's decision on one assessment -- [M5-03].
+
+    The persistence representation of [domain.human_decision.HumanDecision]: one
+    row per *settled* assessment, recorded beside the system's opinion, never
+    over it. The primary key is also a foreign key to ``assessment`` -- a
+    decision "always references the assessment it acted on" is the M5-01
+    invariant, made structural here.
+
+    ``edited_assessment`` is the analyst's revised [domain.assessment.Assessment]
+    as ``JSONB``, present exactly when ``decision = 'edit'`` -- a ``CHECK``
+    enforces the biconditional, mirroring ``HumanDecision``'s own validator.
+    """
+
+    __tablename__ = "human_decision"
+
+    assessment_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("assessment.assessment_id"),
+        primary_key=True,
+    )
+    decision: Mapped[str] = mapped_column(Text, nullable=False)
+    decided_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    notes: Mapped[str] = mapped_column(Text, nullable=False)
+    # `none_as_null`: a Python `None` must become SQL NULL, not the JSON value
+    # `null` -- otherwise `edited_assessment IS NOT NULL` is true for a
+    # non-`edit` decision and the CHECK below fires.
+    edited_assessment: Mapped[dict[str, object] | None] = mapped_column(
+        JSONB(none_as_null=True), nullable=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            _in_clause("decision", (member.value for member in DecisionOutcome)),
+            name="decision_valid",
+        ),
+        # `edit` carries a revision; nothing else may -- the same rule
+        # `HumanDecision._check_edit_carries_a_revision` enforces in the domain.
+        CheckConstraint(
+            "(decision = 'edit') = (edited_assessment IS NOT NULL)",
+            name="edited_assessment_iff_edit",
+        ),
+    )

--- a/app/src/infrastructure/database/unit_of_work.py
+++ b/app/src/infrastructure/database/unit_of_work.py
@@ -1,0 +1,79 @@
+"""The SQLAlchemy unit of work -- [M5-03].
+
+Implements [application.ports.unit_of_work.UnitOfWork]: one database transaction,
+exposing the single repository the assessment use cases write through
+(``assessments``). The use cases take a ``UnitOfWorkFactory``
+(``Callable[[], UnitOfWork]``), so each invocation opens its own session and its
+own transaction -- the session-per-transaction shape the port docstring calls
+for.
+
+Contract (from the port): entering the context begins the unit; ``commit()``
+makes its writes durable; leaving without a ``commit()`` -- normally or by
+exception -- rolls everything back. An exception is never suppressed.
+"""
+
+from types import TracebackType
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.ports.assessment_repository import AssessmentRepository
+from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
+from infrastructure.database.assessment_repository import SqlAlchemyAssessmentRepository
+
+
+class SqlAlchemyUnitOfWork:
+    """One transaction over the assessment store, backed by a SQLAlchemy session."""
+
+    # Set on `__enter__`; typed as the port so the class structurally satisfies
+    # the `UnitOfWork` protocol (matching `tests/unit/application/fakes.py`).
+    assessments: AssessmentRepository
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        """Bind the unit to a session factory; the session opens on ``__enter__``."""
+        self._session_factory = session_factory
+        self._session: Session | None = None
+        self._committed = False
+
+    def __enter__(self) -> "UnitOfWork":
+        """Open the session and expose the assessment repository bound to it."""
+        self._session = self._session_factory()
+        self._committed = False
+        self.assessments = SqlAlchemyAssessmentRepository(self._session)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Roll back unless ``commit()`` was called, then close. Never suppress."""
+        try:
+            if not self._committed:
+                self.rollback()
+        finally:
+            assert self._session is not None
+            self._session.close()
+            self._session = None
+
+    def commit(self) -> None:
+        """Make every write in this unit durable."""
+        assert self._session is not None, "unit of work is not active"
+        self._session.commit()
+        self._committed = True
+
+    def rollback(self) -> None:
+        """Discard every write in this unit."""
+        assert self._session is not None, "unit of work is not active"
+        self._session.rollback()
+
+
+def sqlalchemy_unit_of_work_factory(
+    session_factory: sessionmaker[Session],
+) -> UnitOfWorkFactory:
+    """Build the ``UnitOfWorkFactory`` the use cases take -- one unit per call."""
+
+    def _open() -> UnitOfWork:
+        return SqlAlchemyUnitOfWork(session_factory)
+
+    return _open

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -719,12 +719,60 @@ LLM, no database, no graph; `test_assessment_record.py` on the projection and
 the status/decision pairing;
 `tests/architecture/test_layer_boundaries.py::test_application_imports_no_infrastructure_or_llm_sdk`.
 
-**Downstream.** [M5-03] implements the SQLAlchemy `AssessmentRepository` (two
-bindings — a read adapter on a fresh session, a write adapter bound to the
-`UnitOfWork` session), the `UnitOfWork`, the assessment/decision migrations, the
-append-only audit enforcement, and folds the record write into the audit-sink
-transaction (closing the narrow window where a persist failure after a
-successful resume diverges the record from the checkpoint). [M5-04] adds the
-FastAPI endpoints, the LangGraph orchestrator adapter, `SystemClock`, the
-`policy_ref` → retrieval-filter path, and the domain/application-error → HTTP
-status mapping.
+**Downstream.** [M5-03] implements the SQLAlchemy adapters behind these ports
+(see the next section). [M5-04] adds the FastAPI endpoints, the LangGraph
+orchestrator adapter, `SystemClock`, the `policy_ref` → retrieval-filter path,
+and the domain/application-error → HTTP status mapping.
+
+---
+
+## Persistence adapters mirror the ports; the audit trail is append-only in the database — [M5-03]
+
+**Decision.** `app/src/infrastructure/database/` gains the SQLAlchemy
+implementations of the [M5-02] ports: `SqlAlchemyAssessmentRepository`,
+`SqlAlchemyClauseRepository`, `SqlAlchemyUnitOfWork` (+
+`sqlalchemy_unit_of_work_factory`), the `assessment` / `human_decision` tables
+(`models.py`, migration `20260903_01`), and the row ↔ aggregate mapper
+(`assessment_mapper.py`). `audit_event` becomes append-only at the database via
+a `BEFORE UPDATE OR DELETE` trigger (migration `20260903_02`). Full column
+rationale: `docs/DATABASE.md`.
+
+**Why `citations` / `consistency_flags` are `JSONB`, not child tables.** They
+are frozen value-object tuples with no identity, read whole with the record and
+never queried by field — the same call as `audit_event.payload`. A normalised
+child table buys nothing here and costs a join, an ordering column and a mapper
+layer. `decisions` *is* its own table, as the DoD enumerates, because a decision
+has a lifecycle (it settles a specific assessment) and its own foreign key.
+
+**Why the `ClauseRepository` reads `chunk`.** There is no separate `clause`
+table and [M5-02]'s port docstring already commits to this. A `PolicyClause` is
+projected from the chunk rows whose `source_clause_ids` contains the wanted id —
+the same reconstruction `graph_retrieval_adapter.build_clause_index` does, and
+the id a `Citation` carries.
+
+**Why a trigger, not a rule, for append-only.** An `ON UPDATE … DO INSTEAD
+NOTHING` rule swallows the write silently; the trigger `RAISE`s, so a tamper
+attempt fails loudly and the DoD's "cannot be updated" test can assert it. The
+`INSERT … ON CONFLICT DO NOTHING` insert path never fires an `UPDATE`, so the
+checkpoint node's idempotent re-write is unaffected.
+
+**Two DoD items met differently, both recorded.** (a) "Alembic migrations: …
+checkpointer tables" — met by `make setup-checkpointer` ([M4-09]), not a
+migration duplicating `PostgresSaver.setup()`; the split is a settled decision
+(`alembic/env.py`'s `UNMANAGED_TABLES` filter, `docs/DATABASE.md`). (b) "folds
+the record write into the audit-sink transaction" — **deferred to [M5-04]**.
+The audit sink writes inside the `human_review` graph node; wrapping that write
+and the use case's record write in one transaction needs the orchestrator
+adapter and the composition root to coordinate, neither of which exists until
+[M5-04]. The `state.py` ↔ domain mapper (`docs/DOMAIN.md` "Deferred") is
+[M5-04]'s for the same reason — no [M5-03] consumer.
+
+**Enforcement.** `tests/unit/infrastructure/database/test_models.py` (the
+`CHECK` sets tie back to the domain enums; column/nullable/index/FK assertions);
+`tests/unit/infrastructure/database/test_assessment_mapper.py` (round-trip on
+grounded / abstain / every decision outcome, no DB);
+`tests/integration/test_assessment_repository.py`,
+`test_clause_repository.py`, `test_unit_of_work.py`,
+`test_audit_event_append_only.py` (real Postgres, one per repository plus the
+append-only guarantee). `make test-integration` and CI's `integration` job pick
+these up from the directory.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -9,8 +9,9 @@ domain tables to [M5-03].
 
 The audit table moved forward from [M5-03] deliberately: [M4-09]'s DoD requires
 the audit trail to be durable *and* separate from graph state, which is the
-table. [M5-03] keeps `Assessment` / `HumanDecision` and adds the database-level
-append-only enforcement.
+table. [M5-03] adds the `assessment` / `human_decision` tables, the repository
+and unit-of-work adapters behind the [M5-02] ports, and the database-level
+append-only enforcement on `audit_event` — see the [M5-03] sections below.
 
 The initial migration creates the `vector` extension and nothing else.
 
@@ -308,11 +309,75 @@ No CHECK constraints, unlike `chunk`: none of these columns is a closed enum —
 them would turn adding a node into a migration.
 
 The trail is append-only by construction — `infrastructure/database/audit_repository.py`
-offers an insert and nothing else — but not yet by the database. The rule or
-trigger rejecting `UPDATE`/`DELETE` is [M5-03]'s, along with its test.
+offers an insert and nothing else — and, since [M5-03], by the database too: see
+"Append-only enforcement" below.
 
 Rationale and the interrupt contract that produces these rows:
 `docs/HUMAN_CHECKPOINT.md`.
+
+## The assessment and human_decision tables ([M5-03])
+
+`AssessmentRow` / `HumanDecisionRow` (`app/src/infrastructure/database/models.py`)
+are the persistence representation of the servable aggregate
+`application.assessment_record.AssessmentRecord` and the analyst's
+`domain.human_decision.HumanDecision` recorded beside it — the same
+one-row-class-per-type pattern as `ChunkRow` and `AuditEventRow`. The
+row ↔ aggregate translation lives entirely in
+`infrastructure.database.assessment_mapper` (`docs/DOMAIN.md` names this mapper
+as [M5-03]'s deliverable). Migration `20260903_01`.
+
+- **`assessment`** — column per aggregate field. `verdict` and `status` are
+  `TEXT` + a named `CHECK` against the domain enum (like `chunk`'s enum columns;
+  `tests/unit/infrastructure/database/test_models.py` ties each `CHECK` set back
+  to the enum). `context_sufficient` is the one nullable column — it is
+  genuinely tri-state (`True` / `False` / `None`: retrieval succeeded / the
+  [M3-07] gate fired / retrieval never ran). Indexed on `claim_id` (a claim's
+  runs, and what a human searches by), `status` (the awaiting-review queue) and
+  `created_at` (`AssessmentRepository.list` orders newest-first).
+
+- **`citations` and `consistency_flags` are `JSONB`, not child tables.** Both
+  are frozen value-object tuples with no identity of their own, always loaded
+  whole with the record and never filtered or joined by field — the same call
+  as `audit_event.payload`. A `citation` child table would add a join, an
+  ordering column and a second mapper layer for no query it would ever serve.
+  `missing_information` is a plain `TEXT[]`, like `chunk.source_clause_ids`.
+
+- **`human_decision`** — one row per *settled* assessment. `assessment_id` is
+  both the primary key and a foreign key to `assessment`: "a decision always
+  references the assessment it acted on" (M5-01) made structural. The
+  `edited_assessment` JSONB holds the analyst's revised `Assessment` and is
+  present exactly when `decision = 'edit'` — a `CHECK`
+  (`(decision = 'edit') = (edited_assessment IS NOT NULL)`) enforces the
+  biconditional, mirroring `HumanDecision`'s own validator. The ORM column uses
+  `JSONB(none_as_null=True)` so a Python `None` becomes SQL `NULL` rather than
+  the JSON value `null`, which the `CHECK` would read as present.
+
+The clause corpus is **not** a new table — `SqlAlchemyClauseRepository`
+(`clause_repository.py`) projects `domain.policy_clause.PolicyClause` from the
+existing `chunk` table, reassembling a clause from every row whose
+`source_clause_ids` array contains its id (a split clause rejoins its
+`display_text` in `chunk_index` order). This is the same reconstruction
+`infrastructure.rag.graph_retrieval_adapter.build_clause_index` does, and the
+id it matches is the one a `Citation` carries.
+
+## Append-only enforcement ([M5-03])
+
+`audit_event` rejects `UPDATE` and `DELETE` at the database. Migration
+`20260903_02` installs a `plpgsql` function that `RAISE EXCEPTION`s and a
+`BEFORE UPDATE OR DELETE ON audit_event` trigger that calls it.
+
+A trigger, not an `ON UPDATE ... DO INSTEAD NOTHING` rule: a rule swallows the
+write silently, so a bug (or a compromised connection) trying to rewrite history
+would look like it succeeded. The trigger fails loudly — which is also what
+`tests/integration/test_audit_event_append_only.py` asserts. The insert path is
+untouched: `append_audit_events` uses `INSERT ... ON CONFLICT DO NOTHING`, which
+never fires an `UPDATE`, so the checkpoint node's idempotent re-write on resume
+still works.
+
+The checkpointer's own tables stay outside Alembic (see "The checkpointer owns
+its own schema" above); [M5-03]'s DoD line about migrating them is met by
+`make setup-checkpointer`, built in [M4-09], not a migration that would
+duplicate `PostgresSaver.setup()`.
 
 ## Integration tests
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -18,9 +18,11 @@ microseconds, with no graph, no database and no HTTP.
 Pydantic *twins* of several of these types (`Citation`, `CompatibilityAssessment`,
 `HumanDecision`, …) — it has to, because LangGraph needs Pydantic and Pydantic is
 forbidden in `domain/`. The graph keeps producing those inside a run; the domain
-dataclasses are the persisted, API-facing shape. The mappers between the two are
-[M5-03]'s deliverable. `domain.verdict.Verdict` is the one type already shared by
-both, unchanged since [M4-01].
+dataclasses are the persisted, API-facing shape. The aggregate ↔ ORM-row mapper
+is [M5-03]'s (`infrastructure/database/assessment_mapper.py`); the graph-state ↔
+domain mapper is [M5-04]'s, with the orchestrator adapter that needs it (see
+"Deferred"). `domain.verdict.Verdict` is the one type already shared by both,
+unchanged since [M4-01].
 
 ---
 
@@ -98,8 +100,11 @@ One clause of a registered product, as the service layer sees it: a stable id,
 its business type, its text. **Distinct from `domain.clause_tree.Clause`** — that
 is an 18-field parse-tree node (parent/child pointers, page spans, per-line page
 attribution), a build-time artifact cached to Parquet and never persisted.
-[M5-02]'s `ClauseRepository` returns `PolicyClause`; [M5-03]'s mapper builds one
-from a `clause_tree.Clause` + its `TypedClause` classification + `ClauseProvenance`.
+[M5-02]'s `ClauseRepository` returns `PolicyClause`; [M5-03]'s
+`SqlAlchemyClauseRepository` projects one from the `chunk` table (grouping the
+rows whose `source_clause_ids` carries the wanted id), not from the clause tree —
+the corpus is already indexed there and that is the granularity a `Citation`
+refers to.
 
 The DoD names this entity `Clause`; it is `PolicyClause` to avoid shadowing the
 existing name (`docs/ARCHITECTURE.md` records the deviation).
@@ -212,6 +217,11 @@ the rest of `domain/`.
   unchanged.
 - **`ExtractedEntities`** — stays graph working state in `infrastructure/graph/
   state.py`; not a DoD entity.
-- **Mappers** — domain ↔ ORM row, and domain ↔ `state.py` Pydantic — are [M5-03].
+- **Mappers** — domain/aggregate ↔ ORM row landed in [M5-03]
+  (`app/src/infrastructure/database/assessment_mapper.py`). The domain ↔
+  `state.py` Pydantic mapper is deferred to [M5-04]: its only consumer is the
+  LangGraph orchestrator adapter, and `AssessmentRecord.from_orchestrator_result`
+  already bridges the graph-free DTO — this codebase does not land a mapper
+  ahead of its caller (the same call that dropped `RetrievalService` in [M5-02]).
 - **`Claim.policy_ref` as a required field** — [M5-04], when the submission API
   takes it explicitly.

--- a/tests/integration/test_assessment_repository.py
+++ b/tests/integration/test_assessment_repository.py
@@ -1,0 +1,203 @@
+"""The SQLAlchemy ``AssessmentRepository`` against a real Postgres -- [M5-03].
+
+Covers what only the database proves: the aggregate round-trips through the
+``assessment`` / ``human_decision`` tables (grounded, abstain, and each decision
+outcome), ``list`` orders and filters in SQL, timestamps come back tz-aware, and
+a duplicate ``add`` is rejected by the primary key.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from application.assessment_record import AssessmentStatus
+from domain.assessment import Assessment
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.verdict import Verdict
+from infrastructure.database.assessment_repository import SqlAlchemyAssessmentRepository
+from tests.unit.application.fakes import (
+    make_citation,
+    make_consistency_flag,
+    make_record,
+)
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+
+
+def _repo(session: Session) -> SqlAlchemyAssessmentRepository:
+    return SqlAlchemyAssessmentRepository(session)
+
+
+def _decision(
+    assessment_id: str,
+    outcome: DecisionOutcome = DecisionOutcome.APPROVE,
+    *,
+    edited: Assessment | None = None,
+) -> HumanDecision:
+    return HumanDecision(
+        assessment_id=assessment_id,
+        decision=outcome,
+        decided_at=_NOW + timedelta(hours=1),
+        notes="conferido",
+        edited_assessment=edited,
+    )
+
+
+def test_grounded_record_round_trips(db_session: Session) -> None:
+    repo = _repo(db_session)
+    record = make_record(
+        assessment_id="a-grounded",
+        citations=(make_citation(), make_citation(clause_id="doc:3.2")),
+        consistency_flags=(make_consistency_flag(),),
+        missing_information=("vehicle_info",),
+        context_sufficient=True,
+    )
+
+    repo.add(record)
+    db_session.commit()
+
+    assert repo.get("a-grounded") == record
+
+
+def test_abstain_record_round_trips(db_session: Session) -> None:
+    repo = _repo(db_session)
+    record = make_record(
+        assessment_id="a-abstain",
+        verdict=Verdict.INSUFFICIENT_INFORMATION,
+        citations=(),
+        consistency_flags=(),
+        confidence=0.2,
+        context_sufficient=False,
+        missing_information=(),
+    )
+
+    repo.add(record)
+    db_session.commit()
+
+    fetched = repo.get("a-abstain")
+    assert fetched == record
+    assert fetched is not None and fetched.citations == ()
+
+
+def test_get_unknown_id_returns_none(db_session: Session) -> None:
+    assert _repo(db_session).get("nope") is None
+
+
+def test_duplicate_add_is_rejected(db_session: Session) -> None:
+    repo = _repo(db_session)
+    repo.add(make_record(assessment_id="a-dup"))
+    db_session.commit()
+
+    with pytest.raises(IntegrityError):
+        repo.add(make_record(assessment_id="a-dup"))
+        db_session.flush()
+
+
+@pytest.mark.parametrize("outcome", [DecisionOutcome.APPROVE, DecisionOutcome.REJECT])
+def test_update_to_decided_without_an_edit(
+    db_session: Session, outcome: DecisionOutcome
+) -> None:
+    repo = _repo(db_session)
+    repo.add(make_record(assessment_id="a-decide"))
+    db_session.commit()
+
+    decided = make_record(
+        assessment_id="a-decide",
+        status=AssessmentStatus.DECIDED,
+        decision=_decision("a-decide", outcome),
+    )
+    repo.update(decided)
+    db_session.commit()
+
+    fetched = repo.get("a-decide")
+    assert fetched == decided
+    assert fetched is not None and fetched.decision is not None
+    assert fetched.decision.decision is outcome
+    assert fetched.decision.decided_at.tzinfo is not None
+
+
+def test_update_to_decided_with_a_nested_edited_assessment(
+    db_session: Session,
+) -> None:
+    repo = _repo(db_session)
+    repo.add(make_record(assessment_id="a-edit"))
+    db_session.commit()
+
+    edited = Assessment(
+        assessment_id="a-edit",
+        claim_id="claim-1",
+        verdict=Verdict.INCOMPATIBLE,
+        reasoning="Reclassificado como enchente, excluida.",
+        citations=(make_citation(clause_id="doc:5.1"),),
+        confidence=0.6,
+        recommended_action="Negar.",
+    )
+    decided = make_record(
+        assessment_id="a-edit",
+        status=AssessmentStatus.DECIDED,
+        decision=_decision("a-edit", DecisionOutcome.EDIT, edited=edited),
+    )
+    repo.update(decided)
+    db_session.commit()
+
+    fetched = repo.get("a-edit")
+    assert fetched == decided
+    assert fetched is not None and fetched.decision is not None
+    assert fetched.decision.edited_assessment == edited
+
+
+def test_update_missing_record_raises(db_session: Session) -> None:
+    with pytest.raises(KeyError):
+        _repo(db_session).update(make_record(assessment_id="a-ghost"))
+
+
+def test_list_orders_newest_first_and_filters(db_session: Session) -> None:
+    repo = _repo(db_session)
+    repo.add(make_record(assessment_id="a-old", claim_id="c-1", created_at=_NOW))
+    repo.add(
+        make_record(
+            assessment_id="a-mid",
+            claim_id="c-2",
+            created_at=_NOW + timedelta(hours=1),
+        )
+    )
+    newest = make_record(
+        assessment_id="a-new",
+        claim_id="c-1",
+        created_at=_NOW + timedelta(hours=2),
+    )
+    repo.add(newest)
+    db_session.commit()
+
+    assert [r.assessment_id for r in repo.list()] == ["a-new", "a-mid", "a-old"]
+    assert [r.assessment_id for r in repo.list(claim_id="c-1")] == [
+        "a-new",
+        "a-old",
+    ]
+    assert [
+        r.assessment_id for r in repo.list(status=AssessmentStatus.AWAITING_REVIEW)
+    ] == ["a-new", "a-mid", "a-old"]
+    assert [r.assessment_id for r in repo.list(limit=1, offset=1)] == ["a-mid"]
+
+
+def test_list_hydrates_the_decision_for_a_settled_row(db_session: Session) -> None:
+    repo = _repo(db_session)
+    repo.add(make_record(assessment_id="a-1", claim_id="c", created_at=_NOW))
+    settled = make_record(
+        assessment_id="a-2",
+        claim_id="c",
+        created_at=_NOW + timedelta(hours=1),
+        status=AssessmentStatus.DECIDED,
+        decision=_decision("a-2", DecisionOutcome.REJECT),
+    )
+    repo.add(settled)
+    db_session.commit()
+
+    listed = {r.assessment_id: r for r in repo.list(claim_id="c")}
+    assert listed["a-1"].decision is None
+    assert listed["a-2"].decision is not None
+    assert listed["a-2"].decision.decision is DecisionOutcome.REJECT

--- a/tests/integration/test_audit_event_append_only.py
+++ b/tests/integration/test_audit_event_append_only.py
@@ -1,0 +1,97 @@
+"""``audit_event`` is append-only at the database -- [M5-03].
+
+The DoD: "the audit trail is append-only; add a test asserting it cannot be
+updated." Migration ``20260903_02`` installs a ``BEFORE UPDATE OR DELETE``
+trigger that raises; this proves both halves fail loudly and that the insert
+path (``append_audit_events``, ``INSERT ... ON CONFLICT DO NOTHING``) is
+untouched.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
+
+from infrastructure.database.audit_repository import append_audit_events
+from infrastructure.graph.state import AuditEvent, AuditRecord
+
+pytestmark = pytest.mark.integration
+
+_THREAD = "thread-append-only"
+_CLAIM = "claim-append-only"
+
+
+def _seed(session: Session) -> None:
+    append_audit_events(
+        session,
+        claim_id=_CLAIM,
+        thread_id=_THREAD,
+        records=[
+            AuditRecord(AuditEvent(node="intake", action="extract_entities")),
+            AuditRecord(
+                AuditEvent(node="human_review", action="human_decision:approve"),
+                {"decision": "approve"},
+            ),
+        ],
+    )
+    session.commit()
+
+
+def test_update_is_rejected(db_session: Session) -> None:
+    _seed(db_session)
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        db_session.execute(
+            text("UPDATE audit_event SET action = 'tampered' WHERE thread_id = :t"),
+            {"t": _THREAD},
+        )
+    db_session.rollback()
+
+    still = (
+        db_session.execute(
+            text(
+                "SELECT action FROM audit_event WHERE thread_id = :t ORDER BY sequence"
+            ),
+            {"t": _THREAD},
+        )
+        .scalars()
+        .all()
+    )
+    assert still == ["extract_entities", "human_decision:approve"]
+
+
+def test_delete_is_rejected(db_session: Session) -> None:
+    _seed(db_session)
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        db_session.execute(
+            text("DELETE FROM audit_event WHERE thread_id = :t"), {"t": _THREAD}
+        )
+    db_session.rollback()
+
+    count = db_session.execute(
+        text("SELECT count(*) FROM audit_event WHERE thread_id = :t"), {"t": _THREAD}
+    ).scalar_one()
+    assert count == 2
+
+
+def test_the_idempotent_insert_path_still_works(db_session: Session) -> None:
+    _seed(db_session)
+
+    # The same trail again: `ON CONFLICT DO NOTHING` is an INSERT, so the trigger
+    # never fires -- the checkpoint node's re-write on resume is unaffected.
+    written = append_audit_events(
+        db_session,
+        claim_id=_CLAIM,
+        thread_id=_THREAD,
+        records=[
+            AuditRecord(AuditEvent(node="intake", action="extract_entities")),
+            AuditRecord(
+                AuditEvent(node="human_review", action="human_decision:approve"),
+                {"decision": "approve"},
+            ),
+        ],
+    )
+    db_session.commit()
+
+    assert written == 0

--- a/tests/integration/test_clause_repository.py
+++ b/tests/integration/test_clause_repository.py
@@ -1,0 +1,159 @@
+"""The SQLAlchemy ``ClauseRepository`` against a real Postgres -- [M5-03].
+
+The port reads the existing ``chunk`` table. What only SQL proves: a clause is
+reassembled from every chunk whose ``source_clause_ids`` array contains its id
+(the ``= ANY`` match), a split clause rejoins its ``display_text`` in
+``chunk_index`` order, a merged sibling id resolves to the same clause,
+``get_many`` preserves request order and omits gaps, and ``list_for_policy``
+filters by SUSEP process.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from domain.clause_classification import ClauseType
+from domain.susep_process import SusepProcess
+from infrastructure.database.chunk_repository import upsert_chunks
+from infrastructure.database.clause_repository import SqlAlchemyClauseRepository
+from infrastructure.rag.chunk_schema import SCHEMA_VERSION, ChunkRecord
+
+pytestmark = pytest.mark.integration
+
+_SUSEP_A = "15414.900666/2014-89"
+_SUSEP_B = "15414.610650/2024-59"
+
+
+def _chunk(**overrides: object) -> ChunkRecord:
+    base: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "chunk_id": "docA:2.1",
+        "document_id": "docA",
+        "clause_id": "docA:2.1",
+        "source_clause_ids": ["docA:2.1"],
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "parent_path": "2. COBERTURAS",
+        "text": "2. COBERTURAS\n\nTexto.",
+        "display_text": "2.1 Colisao\n\nTexto da cobertura.",
+        "char_count": 21,
+        "rule": "single",
+        "clause_type": "coverage",
+        "type_source": "rule",
+        "confidence": None,
+        "bundle_section": None,
+        "source": "text",
+        "susep_process": _SUSEP_A,
+        "insurer": "Bradesco Seguros",
+        "cnpj": "12345678000199",
+        "product_line": "CASCO",
+        "indemnity_regime": "VD",
+        "filing_year": "2019",
+    }
+    base.update(overrides)
+    return ChunkRecord.model_validate(base)
+
+
+def _solo(clause_id: str, **overrides: object) -> ChunkRecord:
+    """A one-chunk clause whose id is its own anchor and only source id."""
+    return _chunk(
+        chunk_id=clause_id,
+        clause_id=clause_id,
+        source_clause_ids=[clause_id],
+        **overrides,
+    )
+
+
+def _load(session: Session, *records: ChunkRecord) -> None:
+    upsert_chunks(session, list(records))
+    session.commit()
+
+
+def test_get_returns_a_single_chunk_clause(db_session: Session) -> None:
+    _load(db_session, _chunk())
+
+    clause = SqlAlchemyClauseRepository(db_session).get("docA:2.1")
+
+    assert clause is not None
+    assert clause.clause_id == "docA:2.1"
+    assert clause.document_id == "docA"
+    assert clause.susep_process == SusepProcess(_SUSEP_A)
+    assert clause.clause_type is ClauseType.COVERAGE
+    assert clause.text == "2.1 Colisao\n\nTexto da cobertura."
+
+
+def test_get_rejoins_a_split_clause_in_chunk_order(db_session: Session) -> None:
+    _load(
+        db_session,
+        _chunk(
+            chunk_id="docA:3#1",
+            clause_id="docA:3",
+            source_clause_ids=["docA:3"],
+            chunk_index=1,
+            chunk_count=2,
+            display_text="segunda parte",
+        ),
+        _chunk(
+            chunk_id="docA:3#0",
+            clause_id="docA:3",
+            source_clause_ids=["docA:3"],
+            chunk_index=0,
+            chunk_count=2,
+            display_text="primeira parte",
+        ),
+    )
+
+    clause = SqlAlchemyClauseRepository(db_session).get("docA:3")
+
+    assert clause is not None
+    assert clause.text == "primeira parte\n\nsegunda parte"
+
+
+def test_get_resolves_a_merged_sibling_id(db_session: Session) -> None:
+    _load(
+        db_session,
+        _chunk(
+            chunk_id="docA:4",
+            clause_id="docA:4",
+            source_clause_ids=["docA:4", "docA:4.1"],
+            display_text="clausula 4 com o item 4.1 dobrado",
+        ),
+    )
+
+    repo = SqlAlchemyClauseRepository(db_session)
+    anchor = repo.get("docA:4")
+    sibling = repo.get("docA:4.1")
+    assert anchor is not None and sibling is not None
+    # Same underlying clause -- only the id the caller asked by differs.
+    assert anchor.clause_id == "docA:4"
+    assert sibling.clause_id == "docA:4.1"
+    assert (anchor.text, anchor.document_id) == (sibling.text, sibling.document_id)
+
+
+def test_get_unknown_clause_returns_none(db_session: Session) -> None:
+    _load(db_session, _chunk())
+    assert SqlAlchemyClauseRepository(db_session).get("docA:9.9") is None
+
+
+def test_get_many_preserves_order_and_omits_gaps(db_session: Session) -> None:
+    _load(db_session, _solo("docA:2.1"), _solo("docA:2.2"))
+
+    clauses = SqlAlchemyClauseRepository(db_session).get_many(
+        ["docA:2.2", "docA:missing", "docA:2.1"]
+    )
+
+    assert [c.clause_id for c in clauses] == ["docA:2.2", "docA:2.1"]
+
+
+def test_list_for_policy_filters_by_susep_process(db_session: Session) -> None:
+    _load(
+        db_session,
+        _solo("docA:2.1"),
+        _solo("docA:2.2"),
+        _solo("docB:1", document_id="docB", susep_process=_SUSEP_B),
+    )
+
+    clauses = SqlAlchemyClauseRepository(db_session).list_for_policy(
+        SusepProcess(_SUSEP_A)
+    )
+
+    assert {c.clause_id for c in clauses} == {"docA:2.1", "docA:2.2"}

--- a/tests/integration/test_pgvector_extension.py
+++ b/tests/integration/test_pgvector_extension.py
@@ -32,7 +32,11 @@ def test_vector_column_round_trips_and_orders_by_distance(
                 "CREATE TEMPORARY TABLE pgvector_probe ("
                 "  id integer PRIMARY KEY,"
                 "  embedding vector(3)"
-                ")"
+                # `ON COMMIT DROP`: `postgres_engine` is a pooled, session-scoped
+                # fixture, so a plain temp table would outlive this transaction
+                # on the pooled connection and block a later test's
+                # `DROP EXTENSION vector` in the `migrated_database` teardown.
+                ") ON COMMIT DROP"
             )
         )
         connection.execute(

--- a/tests/integration/test_unit_of_work.py
+++ b/tests/integration/test_unit_of_work.py
@@ -1,0 +1,69 @@
+"""The SQLAlchemy unit of work against a real Postgres -- [M5-03].
+
+The port's contract, proven transactionally: ``commit()`` makes writes durable;
+leaving the block without one -- normally or by exception -- rolls everything
+back; each factory call is its own transaction.
+"""
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from infrastructure.database.assessment_repository import SqlAlchemyAssessmentRepository
+from infrastructure.database.unit_of_work import (
+    SqlAlchemyUnitOfWork,
+    sqlalchemy_unit_of_work_factory,
+)
+from tests.unit.application.fakes import make_record
+
+pytestmark = pytest.mark.integration
+
+
+def test_commit_makes_the_write_durable(
+    session_factory: sessionmaker[Session],
+) -> None:
+    factory = sqlalchemy_unit_of_work_factory(session_factory)
+
+    with factory() as uow:
+        uow.assessments.add(make_record(assessment_id="a-commit"))
+        uow.commit()
+
+    with factory() as uow:
+        assert uow.assessments.get("a-commit") is not None
+
+
+def test_leaving_without_commit_rolls_back(
+    session_factory: sessionmaker[Session],
+) -> None:
+    factory = sqlalchemy_unit_of_work_factory(session_factory)
+
+    with factory() as uow:
+        uow.assessments.add(make_record(assessment_id="a-norollback"))
+        # no commit
+
+    with factory() as uow:
+        assert uow.assessments.get("a-norollback") is None
+
+
+def test_an_exception_rolls_back_and_propagates(
+    session_factory: sessionmaker[Session],
+) -> None:
+    factory = sqlalchemy_unit_of_work_factory(session_factory)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with factory() as uow:
+            uow.assessments.add(make_record(assessment_id="a-boom"))
+            raise RuntimeError("boom")
+
+    with factory() as uow:
+        assert uow.assessments.get("a-boom") is None
+
+
+def test_the_repository_is_bound_to_the_units_session(
+    session_factory: sessionmaker[Session],
+) -> None:
+    with SqlAlchemyUnitOfWork(session_factory) as uow:
+        assert isinstance(uow.assessments, SqlAlchemyAssessmentRepository)
+        # A write is visible to a read on the same unit before commit...
+        uow.assessments.add(make_record(assessment_id="a-samesession"))
+        assert uow.assessments.get("a-samesession") is not None
+        uow.commit()

--- a/tests/unit/infrastructure/database/test_assessment_mapper.py
+++ b/tests/unit/infrastructure/database/test_assessment_mapper.py
@@ -1,0 +1,110 @@
+"""The assessment aggregate <-> ORM-row mapper -- [M5-03].
+
+Pure round-trip checks, no database: ``rows_to_record(record_to_rows(x)) == x``
+across the shapes that matter -- a grounded record, a 0-citation abstain, and a
+settled record for each decision outcome (an ``edit`` carries a nested
+``Assessment``).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from domain.assessment import Assessment
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.verdict import Verdict
+from infrastructure.database.assessment_mapper import record_to_rows, rows_to_record
+from tests.unit.application.fakes import (
+    make_citation,
+    make_consistency_flag,
+    make_record,
+)
+
+_DECIDED_AT = datetime(2026, 9, 3, 15, 30, tzinfo=UTC)
+
+
+def _round_trip(record: AssessmentRecord) -> AssessmentRecord:
+    assessment_row, decision_row = record_to_rows(record)
+    return rows_to_record(assessment_row, decision_row)
+
+
+@pytest.mark.unit
+def test_grounded_record_round_trips() -> None:
+    record = make_record(
+        citations=(make_citation(), make_citation(clause_id="doc:3.2")),
+        consistency_flags=(make_consistency_flag(),),
+        missing_information=("vehicle_info",),
+        context_sufficient=True,
+    )
+
+    assert _round_trip(record) == record
+
+
+@pytest.mark.unit
+def test_abstain_record_round_trips_with_empty_json_arrays() -> None:
+    record = make_record(
+        verdict=Verdict.INSUFFICIENT_INFORMATION,
+        citations=(),
+        consistency_flags=(),
+        confidence=0.2,
+        context_sufficient=False,
+        missing_information=(),
+    )
+
+    assessment_row, decision_row = record_to_rows(record)
+
+    assert decision_row is None
+    assert assessment_row.citations == []
+    assert assessment_row.consistency_flags == []
+    assert rows_to_record(assessment_row, decision_row) == record
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("outcome", [DecisionOutcome.APPROVE, DecisionOutcome.REJECT])
+def test_settled_record_round_trips_without_an_edit(
+    outcome: DecisionOutcome,
+) -> None:
+    decision = HumanDecision(
+        assessment_id="assessment-1",
+        decision=outcome,
+        decided_at=_DECIDED_AT,
+        notes="conferido",
+    )
+    record = make_record(status=AssessmentStatus.DECIDED, decision=decision)
+
+    assessment_row, decision_row = record_to_rows(record)
+
+    assert decision_row is not None
+    assert decision_row.edited_assessment is None
+    assert _round_trip(record) == record
+
+
+@pytest.mark.unit
+def test_settled_record_round_trips_with_a_nested_edited_assessment() -> None:
+    edited = Assessment(
+        assessment_id="assessment-1",
+        claim_id="claim-1",
+        verdict=Verdict.INCOMPATIBLE,
+        reasoning="O evento e uma enchente, excluida pela clausula 5.1.",
+        citations=(make_citation(clause_id="doc:5.1"),),
+        confidence=0.55,
+        recommended_action="Negar a cobertura.",
+    )
+    decision = HumanDecision(
+        assessment_id="assessment-1",
+        decision=DecisionOutcome.EDIT,
+        decided_at=_DECIDED_AT,
+        notes="reclassificado",
+        edited_assessment=edited,
+    )
+    record = make_record(status=AssessmentStatus.DECIDED, decision=decision)
+
+    _, decision_row = record_to_rows(record)
+    assert decision_row is not None
+    assert decision_row.edited_assessment is not None
+
+    restored = _round_trip(record)
+    assert restored == record
+    assert restored.decision is not None
+    assert restored.decision.edited_assessment == edited

--- a/tests/unit/infrastructure/database/test_models.py
+++ b/tests/unit/infrastructure/database/test_models.py
@@ -1,17 +1,26 @@
 """Schema-level guarantees for the ORM models.
 
-``chunk`` -- [M3-02]; ``audit_event`` -- [M4-09].
+``chunk`` -- [M3-02]; ``audit_event`` -- [M4-09]; ``assessment`` /
+``human_decision`` -- [M5-03].
 """
 
 import re
 
 import pytest
 from pgvector.sqlalchemy import HALFVEC
-from sqlalchemy import CheckConstraint, DateTime
+from sqlalchemy import CheckConstraint, DateTime, Table
 
+from application.assessment_record import AssessmentStatus
 from domain.chunk import ChunkRule
 from domain.clause_classification import ClauseType, TypeSource
-from infrastructure.database.models import AuditEventRow, ChunkRow
+from domain.human_decision import DecisionOutcome
+from domain.verdict import Verdict
+from infrastructure.database.models import (
+    AssessmentRow,
+    AuditEventRow,
+    ChunkRow,
+    HumanDecisionRow,
+)
 from infrastructure.graph.state import AuditEvent
 from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS
 
@@ -19,6 +28,8 @@ from infrastructure.rag.embedding_config import EMBEDDING_DIMENSIONS
 # FromClause).
 _CHUNK_TABLE = ChunkRow.metadata.tables["chunk"]
 _AUDIT_TABLE = AuditEventRow.metadata.tables["audit_event"]
+_ASSESSMENT_TABLE = AssessmentRow.metadata.tables["assessment"]
+_DECISION_TABLE = HumanDecisionRow.metadata.tables["human_decision"]
 
 _EXPECTED_INDEXES = {
     "ix_chunk_clause_type",
@@ -30,8 +41,8 @@ _EXPECTED_INDEXES = {
 }
 
 
-def _check_constraint_values(name: str) -> set[str]:
-    for constraint in _CHUNK_TABLE.constraints:
+def _check_constraint_values(name: str, table: Table = _CHUNK_TABLE) -> set[str]:
+    for constraint in table.constraints:
         if isinstance(constraint, CheckConstraint) and str(constraint.name) == name:
             return set(re.findall(r"'([^']*)'", str(constraint.sqltext)))
     raise AssertionError(f"no CHECK constraint named {name}")
@@ -189,5 +200,104 @@ def test_audit_event_timestamp_is_timezone_aware() -> None:
     # `AuditEvent.timestamp` defaults to `datetime.now(UTC)`; a naive column
     # would silently drop the offset.
     column_type = _AUDIT_TABLE.c.timestamp.type
+    assert isinstance(column_type, DateTime)
+    assert column_type.timezone is True
+
+
+# --- assessment / human_decision -- [M5-03] --------------------------------
+
+
+@pytest.mark.unit
+def test_assessment_table_name_and_primary_key() -> None:
+    assert AssessmentRow.__tablename__ == "assessment"
+    assert [c.name for c in _ASSESSMENT_TABLE.primary_key.columns] == ["assessment_id"]
+
+
+@pytest.mark.unit
+def test_assessment_mirrors_every_record_field() -> None:
+    # The aggregate's fields, minus the nested `decision` (its own table) and
+    # the identity that is the PK, must each have a column.
+    expected = {
+        "assessment_id",
+        "claim_id",
+        "verdict",
+        "reasoning",
+        "recommended_action",
+        "confidence",
+        "context_sufficient",
+        "clarification_exhausted",
+        "missing_information",
+        "citations",
+        "consistency_flags",
+        "status",
+        "created_at",
+    }
+    assert expected == set(_ASSESSMENT_TABLE.c.keys())
+
+
+@pytest.mark.unit
+def test_assessment_context_sufficient_is_the_only_nullable_column() -> None:
+    # `context_sufficient` is genuinely tri-state; everything else is required.
+    nullable = {c.name for c in _ASSESSMENT_TABLE.c if c.nullable}
+    assert nullable == {"context_sufficient"}
+
+
+@pytest.mark.unit
+def test_assessment_check_constraints_match_the_domain_enums() -> None:
+    assert _check_constraint_values(
+        "ck_assessment_verdict_valid", _ASSESSMENT_TABLE
+    ) == {member.value for member in Verdict}
+    assert _check_constraint_values(
+        "ck_assessment_status_valid", _ASSESSMENT_TABLE
+    ) == {member.value for member in AssessmentStatus}
+
+
+@pytest.mark.unit
+def test_assessment_indexes_the_columns_list_queries_by() -> None:
+    assert {str(index.name) for index in _ASSESSMENT_TABLE.indexes} == {
+        "ix_assessment_claim_id",
+        "ix_assessment_status",
+        "ix_assessment_created_at",
+    }
+
+
+@pytest.mark.unit
+def test_assessment_created_at_is_timezone_aware() -> None:
+    column_type = _ASSESSMENT_TABLE.c.created_at.type
+    assert isinstance(column_type, DateTime)
+    assert column_type.timezone is True
+
+
+@pytest.mark.unit
+def test_human_decision_is_keyed_and_foreign_keyed_to_its_assessment() -> None:
+    assert HumanDecisionRow.__tablename__ == "human_decision"
+    assert [c.name for c in _DECISION_TABLE.primary_key.columns] == ["assessment_id"]
+    foreign_keys = list(_DECISION_TABLE.c.assessment_id.foreign_keys)
+    assert len(foreign_keys) == 1
+    assert foreign_keys[0].column.table.name == "assessment"
+
+
+@pytest.mark.unit
+def test_human_decision_check_constraint_matches_the_decision_enum() -> None:
+    assert _check_constraint_values(
+        "ck_human_decision_decision_valid", _DECISION_TABLE
+    ) == {member.value for member in DecisionOutcome}
+
+
+@pytest.mark.unit
+def test_human_decision_pairs_edited_assessment_with_the_edit_outcome() -> None:
+    # Mirrors `HumanDecision._check_edit_carries_a_revision`.
+    names = {
+        str(c.name)
+        for c in _DECISION_TABLE.constraints
+        if isinstance(c, CheckConstraint)
+    }
+    assert "ck_human_decision_edited_assessment_iff_edit" in names
+    assert _DECISION_TABLE.c.edited_assessment.nullable is True
+
+
+@pytest.mark.unit
+def test_human_decision_decided_at_is_timezone_aware() -> None:
+    column_type = _DECISION_TABLE.c.decided_at.type
     assert isinstance(column_type, DateTime)
     assert column_type.timezone is True


### PR DESCRIPTION
## Summary

Puts a real Postgres database behind the [M5-02] application ports.

New in `app/src/infrastructure/database/`:

- **`AssessmentRow` / `HumanDecisionRow`** (`models.py`) — the persistence twins
  of `AssessmentRecord` and the `HumanDecision` recorded beside it. Column per
  field; `verdict` / `status` / `decision` are `TEXT` + a named `CHECK` against
  the domain enum (chunk-table precedent). `citations` and `consistency_flags`
  are `JSONB`, not child tables: frozen value-object tuples with no identity,
  read whole with the record and never queried by field — the same call as
  `audit_event.payload`. `human_decision.assessment_id` is both the primary key
  and a foreign key to `assessment`; `edited_assessment` is present exactly when
  `decision = 'edit'`, enforced by a `CHECK` that mirrors `HumanDecision`'s own
  validator.
- **`assessment_mapper.py`** — pure aggregate ↔ row translation (the domain ↔
  ORM-row mapper `docs/DOMAIN.md` names as this issue's deliverable).
- **`SqlAlchemyAssessmentRepository`** — `add` / `update` / `get` / `list`
  behind the port; flushes, never commits (the unit of work owns the
  transaction). Reads work on any session, so M5-04 can bind a read instance
  outside the unit of work.
- **`SqlAlchemyClauseRepository`** — projects `PolicyClause` from the existing
  `chunk` table (there is no separate `clause` table; the M5-02 port docstring
  already commits to this), reassembling a clause from every row whose
  `source_clause_ids` array holds its id — the same reconstruction
  `graph_retrieval_adapter.build_clause_index` does.
- **`SqlAlchemyUnitOfWork`** + `sqlalchemy_unit_of_work_factory` —
  session-per-transaction, matching the in-memory fake's contract.

Migrations:

- `20260903_01` — the `assessment` and `human_decision` tables, indexes,
  `CHECK`s and the FK.
- `20260903_02` — `a

Also fixes a latent test-isolation bug surfaced by the new files' sort order:
`test_pgvector_extension.py`'s probe table now uses `ON COMMIT DROP`, so it no
longer outlives its transaction on the pooled engine connection and block a
later test's `DROP EXTENSION vector`.

**Three DoD items handled differently, all recorded in `docs/ARCHITECTURE.md`:**

- *"Alembic migrations: … checkpointer tables"* — met by `make setup-checkpointer`
  ([M4-09]), not a migration duplicating `PostgresSaver.setup()`. Keeping the
  checkpointer schema outside Alembic is a settled decision
  (`alembic/env.py`'s `UNMANAGED_TABLES` filter).
- *"folds the record write into the audit-sink transaction"* — deferred to
  [M5-04]. The audit sink writes inside the `human_review` graph node; wrapping
  that write and the use case's record write in one transaction needs the
  orchestrator adapter and composition root, which arrive in [M5-04].
- The `state.py` ↔ domain mapper (`docs/DOMAIN.md` "Deferred") is [M5-04]'s for
  the same reason — no consumer here, and `AssessmentRecord.from_orchestrator_result`
  already bridges the graph-free DTO.

## Related issue

[M5-03]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
  — unit: `test_models.py` (CHECK↔enum, columns, FK), `test_assessment_mapper.py`
  (round-trip on grounded / abstain / every decision outcome); integration:
  `test_assessment_repository.py`, `test_clause_repository.py`,
  `test_unit_of_work.py`, `test_audit_event_append_only.py` — one per repository
  plus the append-only guarantee. 53 integration + 1232 unit pass.
- [x] Docs updated — `docs/DATABASE.md` (the new tables, the JSONB rationale, the
  append-only trigger), `docs/ARCHITECTURE.md` (a new [M5-03] section), `docs/DOMAIN.md`
  (the mapper deferred items).
- [x] Evaluation impact considered — none. This is infrastructure behind the
  ports; no parsing, retrieval or evaluation path changes. No dependency,
  Makefile, CI or compose changes.
- [x] `make check` passes locally (`ruff`, `ruff format --check`, `mypy --strict`,
  `pytest -m unit`); `make test-integration` passes against a real Postgres.