### PR TITLE
feat(presentation): expose the assessment graph over an async-shaped …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,10 @@ repos:
       - id: mypy
         args: ["--config-file=pyproject.toml"]
         additional_dependencies:
-          # - fastapi>=0.128.0
+          # [M5-04]: presentation/ imports fastapi; tests/ import
+          # starlette.testclient (httpx).
+          - fastapi>=0.128.0
+          - httpx>=0.28.0
           - pydantic>=2.12.5
           - pydantic-settings>=2.12.0
           - pytest>=9.1.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check serve migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -13,6 +13,7 @@ help:
 	@echo "  test-integration  - Apply migrations, then run the database-backed tests in tests/integration (needs TEST_DATABASE_URL)"
 	@echo "  test-eval         - Run the eval-marked pytest suite (requires build/parsed_clauses.jsonl; run fetch-corpus-artifacts or parse first)"
 	@echo "  check             - Run all checks (lint, format-check, typecheck, test)"
+	@echo "  serve             - M5-04: run the assessment API locally (uvicorn presentation.app:app on :8000; needs make migrate + setup-checkpointer + build-index and LLM_* in .env)"
 	@echo "  migrate           - Apply Alembic migrations to the configured database"
 	@echo "  migrate-down      - Roll back the latest Alembic migration"
 	@echo "  setup-checkpointer - M4-09: run the LangGraph Postgres checkpointer's own migrations (its tables live outside Alembic); idempotent, acts on the same DATABASE_URL as make migrate"
@@ -94,6 +95,9 @@ test-eval:
 	PYTHONPATH=app/src uv run pytest -m eval
 
 check: lint format-check typecheck test
+
+serve:
+	PYTHONPATH=app/src uv run --group embed uvicorn presentation.app:app --reload --port 8000
 
 migrate:
 	PYTHONPATH=app/src uv run alembic upgrade head

--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ Score every retrieval configuration on the golden set with
 `make eval-retrieval-matrix` — the committed comparison table and verdict are in
 [`docs/RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md).
 
+### Run the assessment API
+
+Once the schema, the checkpointer and the index are in place:
+
+```bash
+make serve           # uvicorn presentation.app:app on :8000
+```
+
+`POST /v1/assessments` submits a claim, `GET /v1/assessments/{id}` reads its
+state and recommendation, `POST /v1/assessments/{id}/decision` submits the human
+decision and resumes the run, `GET /v1/assessments/{id}/audit` returns the audit
+trail. Endpoint shapes, the error codes and the design notes are in
+[`docs/API.md`](docs/API.md). The Docker Compose stack is [M5-09].
+
 ### Pre-commit hooks
 
 1. Install the dev dependency (skip if already in the lockfile — run `uv sync` instead):

--- a/app/src/application/audit_trail_entry.py
+++ b/app/src/application/audit_trail_entry.py
@@ -1,0 +1,52 @@
+"""The audit-trail entry DTO the application layer speaks in [M5-04].
+
+The graph-free projection of one ``infrastructure.graph.state.AuditEvent`` row
+of a run's durable trail. It exists for two callers:
+
+- ``GetAuditTrail`` / ``AuditTrailReader`` -- the read model behind
+  ``GET /v1/assessments/{id}/audit``;
+- ``OrchestratorResult.audit_records`` -- the trail the resume path captures so
+  the use case can persist it in the *same* transaction as the settled record
+  (``docs/ARCHITECTURE.md``, the [M5-04] transactional fold), instead of the
+  graph node committing it on its own.
+
+``TokenUsage`` is flattened into the three integer fields, matching
+``AuditEventRow``; ``payload`` is the optional JSON detail the human-review
+event carries (the analyst's whole decision).
+
+Standard library and typing only -- the application layer never imports
+Pydantic or ``infrastructure`` (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class AuditTrailEntry:
+    """One entry of a graph run's durable audit trail, framework-free."""
+
+    sequence: int
+    timestamp: datetime
+    node: str
+    action: str
+    model: str | None = None
+    model_version: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    confidence: float | None = None
+    node_input: str | None = None
+    payload: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a negative sequence or empty node/action."""
+        if self.sequence < 0:
+            raise ValueError(
+                f"AuditTrailEntry.sequence must not be negative, got {self.sequence}"
+            )
+        for name in ("node", "action"):
+            if not getattr(self, name):
+                raise ValueError(f"AuditTrailEntry.{name} must not be empty")

--- a/app/src/application/orchestrator_result.py
+++ b/app/src/application/orchestrator_result.py
@@ -18,12 +18,20 @@ paths produce a recommendation with no clauses. That is a valid
 ``OrchestratorResult`` and a valid ``AssessmentRecord``; it is only not a
 persistable domain ``Assessment``.
 
-Standard library and domain types only (enforced by
+``audit_records`` is the trail the run produced past the human checkpoint,
+captured by the [M5-04] adapter on the ``resume`` path so ``SubmitHumanDecision``
+can persist it in the same transaction as the settled record. Empty on the
+``start`` path (the run pauses before the audit write) and whenever the adapter
+lets the graph commit its own trail. ``AssessmentRecord.from_orchestrator_result``
+ignores it -- it is not part of the servable aggregate.
+
+Standard library and domain/application DTO types only (enforced by
 tests/architecture/test_layer_boundaries.py).
 """
 
 from dataclasses import dataclass
 
+from application.audit_trail_entry import AuditTrailEntry
 from application.consistency_flag import ConsistencyFlag
 from domain.citation import Citation
 from domain.verdict import Verdict
@@ -43,6 +51,7 @@ class OrchestratorResult:
     clarification_exhausted: bool
     missing_information: tuple[str, ...]
     awaiting_review: bool
+    audit_records: tuple[AuditTrailEntry, ...] = ()
 
     def __post_init__(self) -> None:
         """Reject empty prose, a non-``Verdict`` verdict or a bad confidence."""

--- a/app/src/application/ports/audit_trail_reader.py
+++ b/app/src/application/ports/audit_trail_reader.py
@@ -1,0 +1,32 @@
+"""Port for reading a run's durable audit trail [M5-04].
+
+The read behind ``GET /v1/assessments/{id}/audit``. Read-only reference over
+the append-only ``audit_event`` table, standalone like ``ClauseRepository`` --
+not part of the ``UnitOfWork`` (its one writer is the resume path, through
+``UnitOfWork.audit``).
+
+The trail is keyed by the graph ``thread_id``, which is the ``assessment_id``
+(``ClaimAssessmentOrchestrator`` uses one as the other). It is written once, in
+the ``human_review`` node, *after* the human decision -- so an assessment still
+``AWAITING_REVIEW`` has an empty trail, and that is a valid answer, not an
+error.
+
+Standard library and application DTO types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from typing import Protocol
+
+from application.audit_trail_entry import AuditTrailEntry
+
+
+class AuditTrailReader(Protocol):
+    """Read the durable audit trail for one assessment run."""
+
+    def get_trail(self, assessment_id: str) -> tuple[AuditTrailEntry, ...]:
+        """Return the trail for ``assessment_id`` in ``sequence`` order.
+
+        Empty when the run has not been decided yet (the trail is persisted at
+        the human checkpoint, not before).
+        """
+        ...

--- a/app/src/application/ports/audit_trail_writer.py
+++ b/app/src/application/ports/audit_trail_writer.py
@@ -1,0 +1,37 @@
+"""Port for persisting a run's audit trail inside a unit of work [M5-04].
+
+Exposed as ``UnitOfWork.audit``. Its one caller is ``SubmitHumanDecision``:
+the resume path captures the trail the ``human_review`` node produced (rather
+than letting that node commit it on its own) and writes it here, in the same
+transaction as the settled ``AssessmentRecord`` -- so a crash between the two
+can no longer leave the trail durable while the record still reads
+``AWAITING_REVIEW`` (``docs/ARCHITECTURE.md``, the [M5-04] transactional fold).
+
+Insert-only and idempotent on ``(thread_id, sequence)``: the same trail
+re-submitted (the self-healing decision retry) rewrites the same rows harmlessly.
+
+Standard library and application DTO types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from application.audit_trail_entry import AuditTrailEntry
+
+
+class AuditTrailWriter(Protocol):
+    """Append audit-trail entries within the current transaction."""
+
+    def append(
+        self,
+        *,
+        claim_id: str,
+        thread_id: str,
+        entries: Sequence[AuditTrailEntry],
+    ) -> None:
+        """Persist ``entries`` for one run, skipping any already written.
+
+        The caller owns the transaction: this flushes but never commits.
+        """
+        ...

--- a/app/src/application/ports/unit_of_work.py
+++ b/app/src/application/ports/unit_of_work.py
@@ -1,9 +1,10 @@
 """Port for the transactional boundary around assessment writes [M5-02].
 
-A ``UnitOfWork`` is one transaction. It exposes the single repository the use
-cases write through -- ``assessments`` -- and nothing else: the clause corpus is
-read-only reference data with its own lifecycle, so ``ClauseRepository`` is not
-part of it.
+A ``UnitOfWork`` is one transaction. It exposes the two writers the use cases
+need in one atomic step -- ``assessments`` (the record) and ``audit`` (the trail
+the resume path captured, [M5-04]'s transactional fold) -- and nothing else: the
+clause corpus is read-only reference data with its own lifecycle, so
+``ClauseRepository`` is not part of it.
 
 The use cases take a ``UnitOfWorkFactory`` (``Callable[[], UnitOfWork]``), not a
 ``UnitOfWork``, so each call opens its own transaction -- which is what
@@ -20,12 +21,14 @@ from types import TracebackType
 from typing import Protocol
 
 from application.ports.assessment_repository import AssessmentRepository
+from application.ports.audit_trail_writer import AuditTrailWriter
 
 
 class UnitOfWork(Protocol):
-    """One transaction over the assessment store."""
+    """One transaction over the assessment store and the audit trail."""
 
     assessments: AssessmentRepository
+    audit: AuditTrailWriter
 
     def __enter__(self) -> "UnitOfWork":
         """Begin the unit and return it."""

--- a/app/src/application/use_cases/get_audit_trail.py
+++ b/app/src/application/use_cases/get_audit_trail.py
@@ -1,0 +1,35 @@
+"""Use case: fetch one assessment run's durable audit trail [M5-04].
+
+The read behind ``GET /v1/assessments/{id}/audit``. It resolves the id against
+``AssessmentRepository`` first -- an unknown id is a 404, not an empty trail --
+then returns the entries the ``AuditTrailReader`` holds for it.
+
+An assessment still ``AWAITING_REVIEW`` has an empty trail: the durable trail is
+written once, in the ``human_review`` node, after the analyst decides. That is a
+valid answer (an empty list), not an error.
+"""
+
+from dataclasses import dataclass
+
+from application.audit_trail_entry import AuditTrailEntry
+from application.errors import AssessmentNotFoundError
+from application.ports.assessment_repository import AssessmentRepository
+from application.ports.audit_trail_reader import AuditTrailReader
+
+
+@dataclass(frozen=True)
+class GetAuditTrail:
+    """Return the audit trail for an assessment id, or raise if the id is unknown."""
+
+    assessments: AssessmentRepository
+    audit: AuditTrailReader
+
+    def __call__(self, assessment_id: str) -> tuple[AuditTrailEntry, ...]:
+        """Fetch the trail for ``assessment_id``.
+
+        Raises:
+            AssessmentNotFoundError: no assessment exists for the id.
+        """
+        if self.assessments.get(assessment_id) is None:
+            raise AssessmentNotFoundError(assessment_id)
+        return self.audit.get_trail(assessment_id)

--- a/app/src/application/use_cases/submit_claim.py
+++ b/app/src/application/use_cases/submit_claim.py
@@ -13,8 +13,11 @@ The orchestrator runs *before* the transaction opens: the graph is a long call
 and must not hold a database transaction open, and it must pause at the
 checkpoint before there is anything worth persisting. A failure to persist after
 the graph has paused leaves the run recoverable from its checkpoint but without
-a record -- a narrow window [M5-03] closes by writing the record in the same
-transaction as the audit trail.
+a record. Nothing folds that window shut on the ``start`` path -- the graph
+pauses before it writes any audit trail, so there is no second write to share a
+transaction with, and the checkpoint itself is a separate connection. [M5-05]'s
+run-status tracking closes it; the [M5-04] fold is on the ``resume`` path, in
+``SubmitHumanDecision``.
 """
 
 from collections.abc import Callable

--- a/app/src/application/use_cases/submit_human_decision.py
+++ b/app/src/application/use_cases/submit_human_decision.py
@@ -14,9 +14,19 @@ becomes a domain ``Assessment`` and therefore always cites at least one clause
 -- and every cited clause is checked against ``ClauseRepository`` before the
 graph is resumed.
 
-Ordering mirrors ``SubmitClaim``: the read and the validation happen first, the
-orchestrator resume (a long call) runs outside any transaction, and only the
-record update is transactional.
+Ordering mirrors ``SubmitClaim``: the read and the validation happen first, then
+the orchestrator resumes the paused run. The resume does no model calls -- it
+re-runs only the ``human_review`` node -- so, unlike ``start``, it is not a long
+call held outside a transaction for its own sake.
+
+The [M5-04] transactional fold: the adapter captures the audit trail the resumed
+run produced (``result.audit_records``) instead of letting the graph node commit
+it, and this use case writes it through ``uow.audit`` in the *same* transaction
+as the settled record. One ``commit()`` persists both, or neither -- closing the
+window where a crash left the trail durable while the record still read
+``AWAITING_REVIEW``. The append is idempotent, so the self-healing retry (a
+second decision on a record still ``AWAITING_REVIEW``, whose thread the first
+attempt already finished) rewrites the same rows harmlessly.
 """
 
 from collections.abc import Sequence
@@ -109,6 +119,11 @@ class SubmitHumanDecision:
 
         with self.uow_factory() as uow:
             uow.assessments.update(updated)
+            uow.audit.append(
+                claim_id=record.claim_id,
+                thread_id=assessment_id,
+                entries=result.audit_records,
+            )
             uow.commit()
 
         return updated

--- a/app/src/infrastructure/clock.py
+++ b/app/src/infrastructure/clock.py
@@ -1,0 +1,18 @@
+"""The real ``Clock`` -- [M5-04].
+
+``application.ports.clock.Clock`` asks for one method: the current instant as a
+timezone-aware UTC ``datetime``. The port docstring assigns the concrete
+implementation to the composition root; this is it, a one-line
+``datetime.now(UTC)`` wrapper. Kept as a class so it satisfies the ``Clock``
+protocol structurally and a test can still swap in a ``FixedClock``.
+"""
+
+from datetime import UTC, datetime
+
+
+class SystemClock:
+    """A ``Clock`` backed by the wall clock."""
+
+    def now(self) -> datetime:
+        """Return the current instant as a timezone-aware UTC ``datetime``."""
+        return datetime.now(UTC)

--- a/app/src/infrastructure/database/__init__.py
+++ b/app/src/infrastructure/database/__init__.py
@@ -11,7 +11,12 @@ from infrastructure.database.assessment_mapper import (
 from infrastructure.database.assessment_repository import (
     SqlAlchemyAssessmentRepository,
 )
-from infrastructure.database.audit_repository import append_audit_events
+from infrastructure.database.audit_repository import (
+    append_audit_entries,
+    append_audit_events,
+)
+from infrastructure.database.audit_trail_reader import SqlAlchemyAuditTrailReader
+from infrastructure.database.audit_trail_writer import SqlAlchemyAuditTrailWriter
 from infrastructure.database.base import Base
 from infrastructure.database.chunk_repository import (
     assert_chunk_table_ready,
@@ -45,9 +50,12 @@ __all__ = [
     "ChunkRow",
     "HumanDecisionRow",
     "SqlAlchemyAssessmentRepository",
+    "SqlAlchemyAuditTrailReader",
     "SqlAlchemyAuditTrailSink",
+    "SqlAlchemyAuditTrailWriter",
     "SqlAlchemyClauseRepository",
     "SqlAlchemyUnitOfWork",
+    "append_audit_entries",
     "append_audit_events",
     "assert_chunk_table_ready",
     "create_engine_from_database_url",

--- a/app/src/infrastructure/database/audit_repository.py
+++ b/app/src/infrastructure/database/audit_repository.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
+from application.audit_trail_entry import AuditTrailEntry
 from infrastructure.database.models import AuditEventRow
 from infrastructure.graph.state import AuditRecord
 
@@ -50,6 +51,53 @@ def _row_values(
     }
 
 
+def _entry_values(
+    entry: AuditTrailEntry, *, claim_id: str, thread_id: str
+) -> dict[str, object]:
+    """Map one ``AuditTrailEntry`` DTO to an ``audit_event`` row.
+
+    The [M5-04] resume path captures the graph's trail as ``AuditTrailEntry``
+    DTOs (``sequence`` already assigned) so the use case can persist it in its
+    own transaction; this is the same row shape ``_row_values`` produces.
+    """
+    return {
+        "thread_id": thread_id,
+        "sequence": entry.sequence,
+        "claim_id": claim_id,
+        "timestamp": entry.timestamp,
+        "node": entry.node,
+        "action": entry.action,
+        "model": entry.model,
+        "model_version": entry.model_version,
+        "input_tokens": entry.input_tokens,
+        "output_tokens": entry.output_tokens,
+        "total_tokens": entry.total_tokens,
+        "confidence": entry.confidence,
+        "node_input": entry.node_input,
+        "payload": dict(entry.payload) if entry.payload is not None else None,
+    }
+
+
+def _insert_rows(session: Session, rows: list[dict[str, object]]) -> int:
+    """Insert ``rows`` into ``audit_event``, skipping any already written.
+
+    RETURNING, not ``rowcount``: a multi-row insert goes through SQLAlchemy's
+    executemany path, where the driver may report ``rowcount`` as -1. The rows
+    that come back are exactly the ones the conflict clause did *not* skip. The
+    caller owns the transaction -- this flushes but never commits.
+    """
+    if not rows:
+        return 0
+    statement = (
+        pg_insert(AuditEventRow)
+        .on_conflict_do_nothing(index_elements=["thread_id", "sequence"])
+        .returning(AuditEventRow.sequence)
+    )
+    written = session.execute(statement, rows).all()
+    session.flush()
+    return len(written)
+
+
 def append_audit_events(
     session: Session,
     *,
@@ -63,23 +111,32 @@ def append_audit_events(
     its ``sequence``. The caller owns the transaction -- this flushes but never
     commits.
     """
-    if not records:
-        return 0
-
-    # RETURNING, not `rowcount`: a multi-row insert goes through SQLAlchemy's
-    # executemany path, where the driver may report `rowcount` as -1. The rows
-    # that come back are exactly the ones the conflict clause did *not* skip.
-    statement = (
-        pg_insert(AuditEventRow)
-        .on_conflict_do_nothing(index_elements=["thread_id", "sequence"])
-        .returning(AuditEventRow.sequence)
-    )
-    written = session.execute(
-        statement,
+    return _insert_rows(
+        session,
         [
             _row_values(record, claim_id=claim_id, thread_id=thread_id, sequence=index)
             for index, record in enumerate(records)
         ],
-    ).all()
-    session.flush()
-    return len(written)
+    )
+
+
+def append_audit_entries(
+    session: Session,
+    *,
+    claim_id: str,
+    thread_id: str,
+    entries: Sequence[AuditTrailEntry],
+) -> int:
+    """Insert one row per entry, skipping any already written. Return the count.
+
+    The [M5-04] counterpart of ``append_audit_events``: the entries already carry
+    their ``sequence`` (assigned when the resume path captured the trail), and
+    the idempotent ``ON CONFLICT`` keeps a decision retry a no-op.
+    """
+    return _insert_rows(
+        session,
+        [
+            _entry_values(entry, claim_id=claim_id, thread_id=thread_id)
+            for entry in entries
+        ],
+    )

--- a/app/src/infrastructure/database/audit_trail_reader.py
+++ b/app/src/infrastructure/database/audit_trail_reader.py
@@ -1,0 +1,54 @@
+"""The durable audit-trail read model -- [M5-04].
+
+``SqlAlchemyAuditTrailReader`` satisfies
+``application.ports.audit_trail_reader.AuditTrailReader``, the read behind
+``GET /v1/assessments/{id}/audit``. Read-only over the append-only ``audit_event``
+table, keyed by ``thread_id`` -- which is the ``assessment_id``.
+
+The trail is written once, in the ``human_review`` node, after the analyst
+decides; an assessment still ``AWAITING_REVIEW`` returns an empty tuple.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from application.audit_trail_entry import AuditTrailEntry
+from infrastructure.database.models import AuditEventRow
+
+
+def _row_to_entry(row: AuditEventRow) -> AuditTrailEntry:
+    return AuditTrailEntry(
+        sequence=row.sequence,
+        timestamp=row.timestamp,
+        node=row.node,
+        action=row.action,
+        model=row.model,
+        model_version=row.model_version,
+        input_tokens=row.input_tokens,
+        output_tokens=row.output_tokens,
+        total_tokens=row.total_tokens,
+        confidence=row.confidence,
+        node_input=row.node_input,
+        payload=row.payload,
+    )
+
+
+class SqlAlchemyAuditTrailReader:
+    """Read one assessment run's durable audit trail from ``audit_event``."""
+
+    def __init__(self, session: Session) -> None:
+        """Bind the reader to a session (any session -- it never writes)."""
+        self._session = session
+
+    def get_trail(self, assessment_id: str) -> tuple[AuditTrailEntry, ...]:
+        """Return the trail for ``assessment_id`` in ``sequence`` order."""
+        rows = (
+            self._session.execute(
+                select(AuditEventRow)
+                .where(AuditEventRow.thread_id == assessment_id)
+                .order_by(AuditEventRow.sequence)
+            )
+            .scalars()
+            .all()
+        )
+        return tuple(_row_to_entry(row) for row in rows)

--- a/app/src/infrastructure/database/audit_trail_writer.py
+++ b/app/src/infrastructure/database/audit_trail_writer.py
@@ -1,0 +1,36 @@
+"""The transactional audit-trail writer -- [M5-04].
+
+``SqlAlchemyAuditTrailWriter`` satisfies
+``application.ports.audit_trail_writer.AuditTrailWriter``. Unlike
+``SqlAlchemyAuditTrailSink`` (the graph-facing adapter, which owns its own
+session and commits), this one is bound to the ``SqlAlchemyUnitOfWork``'s
+session and only flushes -- so the trail the resume path captured lands in the
+same transaction as the settled ``AssessmentRecord``.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from application.audit_trail_entry import AuditTrailEntry
+from infrastructure.database.audit_repository import append_audit_entries
+
+
+class SqlAlchemyAuditTrailWriter:
+    """Append captured audit-trail entries within the current unit of work."""
+
+    def __init__(self, session: Session) -> None:
+        """Bind the writer to the unit of work's session."""
+        self._session = session
+
+    def append(
+        self,
+        *,
+        claim_id: str,
+        thread_id: str,
+        entries: Sequence[AuditTrailEntry],
+    ) -> None:
+        """Persist ``entries``, skipping any already written. Flushes, never commits."""
+        append_audit_entries(
+            self._session, claim_id=claim_id, thread_id=thread_id, entries=entries
+        )

--- a/app/src/infrastructure/database/unit_of_work.py
+++ b/app/src/infrastructure/database/unit_of_work.py
@@ -17,16 +17,19 @@ from types import TracebackType
 from sqlalchemy.orm import Session, sessionmaker
 
 from application.ports.assessment_repository import AssessmentRepository
+from application.ports.audit_trail_writer import AuditTrailWriter
 from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
 from infrastructure.database.assessment_repository import SqlAlchemyAssessmentRepository
+from infrastructure.database.audit_trail_writer import SqlAlchemyAuditTrailWriter
 
 
 class SqlAlchemyUnitOfWork:
     """One transaction over the assessment store, backed by a SQLAlchemy session."""
 
-    # Set on `__enter__`; typed as the port so the class structurally satisfies
+    # Set on `__enter__`; typed as the ports so the class structurally satisfies
     # the `UnitOfWork` protocol (matching `tests/unit/application/fakes.py`).
     assessments: AssessmentRepository
+    audit: AuditTrailWriter
 
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         """Bind the unit to a session factory; the session opens on ``__enter__``."""
@@ -35,10 +38,11 @@ class SqlAlchemyUnitOfWork:
         self._committed = False
 
     def __enter__(self) -> "UnitOfWork":
-        """Open the session and expose the assessment repository bound to it."""
+        """Open the session and expose the writers bound to it."""
         self._session = self._session_factory()
         self._committed = False
         self.assessments = SqlAlchemyAssessmentRepository(self._session)
+        self.audit = SqlAlchemyAuditTrailWriter(self._session)
         return self
 
     def __exit__(

--- a/app/src/infrastructure/graph/orchestrator.py
+++ b/app/src/infrastructure/graph/orchestrator.py
@@ -1,0 +1,164 @@
+"""The concrete ``ClaimAssessmentOrchestrator`` -- LangGraph behind the port [M5-04].
+
+``application.ports.claim_assessment_orchestrator.ClaimAssessmentOrchestrator``
+promises the application layer an assessment without a graph in sight. This is
+the adapter that keeps that promise: it compiles ``build_claim_graph()`` against
+the Postgres checkpointer, runs a claim to the human checkpoint (``start``) or
+resumes a paused run to completion (``resume``), and hands back a graph-free
+``OrchestratorResult`` via ``infrastructure.graph.state_mapper``.
+
+Design notes:
+
+- **``assessment_id`` is the graph ``thread_id``** -- the port's sole run key, so
+  ``resume`` needs nothing more to find the paused run.
+- **A checkpointer connection per call.** ``open_claim_checkpointer`` opens its
+  own autocommit psycopg connection; a fresh SQLAlchemy session per run feeds the
+  retriever. Concurrent requests never share either. A pooled connection is
+  "the M5 shape" (``docs/DATABASE.md``); [M5-05]'s worker model revisits it.
+- **The audit trail is captured, not committed here.** The composition root
+  builds the per-run ``GraphContext`` without a sink; this adapter swaps in a
+  ``_CapturingAuditSink`` so the ``human_review`` node's trail comes back in the
+  ``OrchestratorResult`` and ``SubmitHumanDecision`` writes it in the same
+  transaction as the settled record (``docs/ARCHITECTURE.md``, the [M5-04] fold).
+- **The contract checks belong to the use case.** ``start`` not pausing / ``resume``
+  not finishing is surfaced by the use case as ``OrchestratorContractError``
+  (per the port docstring); this adapter just reports ``awaiting_review`` as it
+  found it and still returns a well-formed result either way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from typing import Any, cast
+
+from langgraph.graph import StateGraph
+from langgraph.types import Command
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.orchestrator_result import OrchestratorResult
+from domain.claim import Claim
+from domain.human_decision import HumanDecision
+from infrastructure.graph import state_mapper
+from infrastructure.graph.build import build_claim_graph
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.context import GraphContext
+from infrastructure.graph.state import AuditRecord, ClaimState
+
+_GraphFactory = Callable[
+    [], StateGraph[ClaimState, GraphContext, ClaimState, ClaimState]
+]
+_ContextFactory = Callable[[Session], GraphContext]
+
+
+class _CapturingAuditSink:
+    """An ``AuditTrailSink`` that keeps the run's trail in memory for the adapter.
+
+    ``human_review`` calls ``record`` once, after the pause, with the run's whole
+    trail. The adapter reads it back and returns it as
+    ``OrchestratorResult.audit_records`` for the use case to persist
+    transactionally -- so nothing is committed from inside the graph node.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[AuditRecord] = []
+        self.calls: list[tuple[str, str]] = []
+
+    def record(
+        self,
+        *,
+        claim_id: str,
+        thread_id: str,
+        records: Sequence[AuditRecord],
+    ) -> int:
+        """Capture ``records`` (the whole trail) and report how many there are."""
+        self.records = list(records)
+        self.calls.append((claim_id, thread_id))
+        return len(self.records)
+
+
+class LangGraphClaimAssessmentOrchestrator:
+    """Run and resume claim assessments on the compiled LangGraph graph."""
+
+    def __init__(
+        self,
+        *,
+        context_factory: _ContextFactory,
+        session_factory: sessionmaker[Session],
+        database_url: str | None = None,
+        graph_builder: _GraphFactory = build_claim_graph,
+    ) -> None:
+        """Wire the adapter to its per-run dependencies.
+
+        ``context_factory`` builds a ``GraphContext`` on a fresh session (models
+        and retriever components are singletons the composition root closes over);
+        ``database_url`` is passed to ``open_claim_checkpointer`` -- ``None`` uses
+        the service database the rest of the app reads.
+        """
+        self._context_factory = context_factory
+        self._session_factory = session_factory
+        self._database_url = database_url
+        self._graph_builder = graph_builder
+
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        """Assess ``claim`` from scratch, up to the human checkpoint."""
+        final_state, sink = self._invoke(
+            assessment_id,
+            {
+                "claim_id": claim.claim_id,
+                "raw_claim_text": self._claim_text(claim),
+            },
+        )
+        return state_mapper.result_from_final_state(
+            final_state,
+            awaiting_review="__interrupt__" in final_state,
+            audit_records=state_mapper.audit_entries_from_records(sink.records),
+        )
+
+    def resume(
+        self, *, assessment_id: str, decision: HumanDecision
+    ) -> OrchestratorResult:
+        """Resume the paused run ``assessment_id`` with the analyst's decision."""
+        final_state, sink = self._invoke(
+            assessment_id,
+            Command(resume=state_mapper.resume_payload(decision)),
+        )
+        return state_mapper.result_from_final_state(
+            final_state,
+            awaiting_review="__interrupt__" in final_state,
+            audit_records=state_mapper.audit_entries_from_records(sink.records),
+        )
+
+    def _invoke(
+        self,
+        assessment_id: str,
+        graph_input: ClaimState | Command[Any],
+    ) -> tuple[dict[str, Any], _CapturingAuditSink]:
+        """Compile the graph, invoke it once for this run, return its final state."""
+        config: Any = {"configurable": {"thread_id": assessment_id}}
+        sink = _CapturingAuditSink()
+        with (
+            self._session_factory() as session,
+            open_claim_checkpointer(self._database_url) as checkpointer,
+        ):
+            compiled = self._graph_builder().compile(checkpointer=checkpointer)
+            context = replace(self._context_factory(session), audit_sink=sink)
+            final_state = compiled.invoke(graph_input, config=config, context=context)
+        return cast("dict[str, Any]", final_state), sink
+
+    @staticmethod
+    def _claim_text(claim: Claim) -> str:
+        """The graph's ``raw_claim_text``: the narrative, with its policy if known.
+
+        A one-line SUSEP-process header the way a claim filed against a known
+        policy would carry it -- byte-identical to
+        ``scripts/eval_end_to_end.py::build_claim_text``'s measured headline arm,
+        so intake extracts the process and ``nodes/retrieval._build_filter``
+        pre-filters on it with no graph change and no eval regression.
+        """
+        if claim.policy_ref is None:
+            return claim.raw_text
+        return (
+            f"[Apólice registrada: processo SUSEP {claim.policy_ref.value}]\n"
+            f"{claim.raw_text}"
+        )

--- a/app/src/infrastructure/graph/state_mapper.py
+++ b/app/src/infrastructure/graph/state_mapper.py
@@ -1,0 +1,179 @@
+"""The graph ``state.py`` <-> application boundary -- [M5-04].
+
+The one place a LangGraph ``ClaimState`` becomes an
+``application.orchestrator_result.OrchestratorResult`` and a domain
+``HumanDecision`` becomes the resume payload the ``human_review`` node validates.
+Its only consumer is ``LangGraphClaimAssessmentOrchestrator`` -- which is why
+this mapper is [M5-04]'s and not [M5-03]'s (``docs/DOMAIN.md`` "Deferred").
+
+Three things it reconciles between the two representations:
+
+- ``state.Recommendation`` has no ``verdict`` -- it is read from the
+  recommendation node's audit event via
+  ``infrastructure.graph.verdict_readout``;
+- ``state.Citation.susep_process`` is a bare string, ``domain.citation.Citation``
+  wants a ``SusepProcess`` value object;
+- the graph twin ``state.HumanDecision`` (``decision`` a ``Literal``,
+  ``edited_recommendation``) and the domain ``HumanDecision`` (``DecisionOutcome``,
+  ``assessment_id``, ``edited_assessment``) differ in shape -- ``resume_payload``
+  converts the domain one *to* the plain mapping the node's
+  ``HumanDecision.model_validate`` accepts.
+
+A reviewer ``edit`` drops the recommendation's consistency flags: an
+``EditedAssessmentInput`` -> domain ``Assessment`` carries none, and flags are
+attention points kept beside the verdict, not part of the decision
+(``docs/ARCHITECTURE.md``, [M4-08]).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from application.audit_trail_entry import AuditTrailEntry
+from application.consistency_flag import ConsistencyFlag
+from application.orchestrator_result import OrchestratorResult
+from domain.citation import Citation
+from domain.human_decision import HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+from infrastructure.graph import state, verdict_readout
+
+# Fallbacks for the two non-empty prose fields ``OrchestratorResult`` requires.
+# The recommendation node always writes both (LLM or its deterministic template),
+# so these guard an impossible-in-practice empty rather than a real path.
+_MISSING_JUSTIFICATION = "(sem justificativa registrada)"
+_MISSING_ACTION = "(nenhuma ação recomendada registrada)"
+_MISSING_EXCERPT = "—"
+
+
+def result_from_final_state(
+    final_state: Mapping[str, object],
+    *,
+    awaiting_review: bool,
+    audit_records: tuple[AuditTrailEntry, ...] = (),
+) -> OrchestratorResult:
+    """Project a compiled graph's final/paused state onto an ``OrchestratorResult``."""
+    recommendation = final_state.get("recommendation")
+    if not isinstance(recommendation, state.Recommendation):
+        raise RuntimeError(
+            "graph run produced no recommendation -- the recommendation node must "
+            "run before the result is read (got "
+            f"{type(recommendation).__name__})"
+        )
+
+    audit_trail = cast(
+        "Sequence[state.AuditEvent]", final_state.get("audit_trail") or ()
+    )
+    verdict = verdict_readout.effective_verdict(audit_trail) or (
+        Verdict.INSUFFICIENT_INFORMATION
+    )
+
+    missing_information = tuple(
+        cast("Sequence[str]", final_state.get("missing_information") or ())
+    )
+
+    return OrchestratorResult(
+        verdict=verdict,
+        reasoning=recommendation.justification.strip() or _MISSING_JUSTIFICATION,
+        recommended_action=(
+            recommendation.recommended_action.strip() or _MISSING_ACTION
+        ),
+        citations=tuple(_domain_citation(c) for c in recommendation.citations),
+        confidence=recommendation.confidence,
+        consistency_flags=tuple(
+            _consistency_flag(signal) for signal in recommendation.consistency_flags
+        ),
+        context_sufficient=cast("bool | None", final_state.get("context_sufficient")),
+        clarification_exhausted=bool(final_state.get("clarification_exhausted")),
+        missing_information=missing_information,
+        awaiting_review=awaiting_review,
+        audit_records=audit_records,
+    )
+
+
+def audit_entries_from_records(
+    records: Sequence[state.AuditRecord],
+) -> tuple[AuditTrailEntry, ...]:
+    """Flatten the trail the ``human_review`` node built into application DTOs.
+
+    ``sequence`` is the record's position in the run's whole trail -- the same
+    numbering ``infrastructure.database.audit_repository.append_audit_events``
+    uses, so a reader sees exactly what the graph's own sink would have written.
+    """
+    entries: list[AuditTrailEntry] = []
+    for index, record in enumerate(records):
+        event = record.event
+        usage = event.token_usage
+        entries.append(
+            AuditTrailEntry(
+                sequence=index,
+                timestamp=event.timestamp,
+                node=event.node,
+                action=event.action,
+                model=event.model,
+                model_version=event.model_version,
+                input_tokens=usage.input_tokens if usage is not None else None,
+                output_tokens=usage.output_tokens if usage is not None else None,
+                total_tokens=usage.total_tokens if usage is not None else None,
+                confidence=event.confidence,
+                node_input=event.node_input,
+                payload=record.payload,
+            )
+        )
+    return tuple(entries)
+
+
+def resume_payload(decision: HumanDecision) -> dict[str, object]:
+    """The plain mapping ``human_review._await_decision`` validates as a decision.
+
+    ``state.HumanDecision.model_validate`` accepts a mapping (the HTTP-boundary
+    case its docstring anticipates) and enforces the same "``edit`` carries a
+    revision" rule the domain ``HumanDecision`` already guaranteed.
+    """
+    payload: dict[str, object] = {
+        "decision": decision.decision.value,
+        "notes": decision.notes,
+        "decided_at": decision.decided_at.isoformat(),
+    }
+    edited = decision.edited_assessment
+    if edited is not None:
+        payload["edited_recommendation"] = {
+            "recommended_action": edited.recommended_action,
+            "justification": edited.reasoning,
+            "citations": [_state_citation_dict(c) for c in edited.citations],
+            "consistency_flags": [],
+            "confidence": edited.confidence,
+        }
+    return payload
+
+
+def _domain_citation(citation: state.Citation) -> Citation:
+    return Citation(
+        clause_id=citation.clause_id,
+        document_id=citation.document_id,
+        susep_process=SusepProcess.parse(citation.susep_process),
+        clause_type=citation.clause_type,
+        excerpt=citation.excerpt or _MISSING_EXCERPT,
+        relevance_score=max(citation.relevance_score, 0.0),
+    )
+
+
+def _consistency_flag(signal: state.ConsistencySignal) -> ConsistencyFlag:
+    return ConsistencyFlag(
+        check=signal.check,
+        severity=signal.severity,
+        detail=signal.detail,
+        source=signal.source,
+    )
+
+
+def _state_citation_dict(citation: Citation) -> dict[str, object]:
+    return {
+        "clause_id": citation.clause_id,
+        "document_id": citation.document_id,
+        "susep_process": citation.susep_process.value,
+        "clause_type": citation.clause_type.value,
+        "relevance_score": citation.relevance_score,
+        "excerpt": citation.excerpt,
+    }

--- a/app/src/infrastructure/graph/verdict_readout.py
+++ b/app/src/infrastructure/graph/verdict_readout.py
@@ -1,0 +1,77 @@
+"""Read the effective verdict from the recommendation node's audit event -- [M4-08].
+
+``state.Recommendation`` has no ``verdict`` field by [M4-08]'s design: everything
+load-bearing is derived, and the derivation the recommendation node settled on is
+recorded in its own ``AuditEvent`` as ``posture=<p> verdict=<v> ...``. Anything
+that needs the end-to-end verdict -- ``scripts/eval_end_to_end.py``, and the
+[M5-04] orchestrator adapter building an ``OrchestratorResult`` -- reads it from
+there rather than re-deriving it, so both see exactly what the graph decided.
+
+``verdict=`` is authoritative; ``posture=`` is the fallback, and also says *why*
+an abstention happened, not only that it did.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+from domain.verdict import Verdict
+from infrastructure.graph.state import AuditEvent
+
+_RECOMMENDATION_NODE = "recommendation"
+
+_POSTURE_RE = re.compile(r"posture=(\S+)")
+_VERDICT_RE = re.compile(r"verdict=(\S+)")
+
+# Maps the recommendation node's posture onto the M0-06 verdict vocabulary. The
+# posture carries more than the verdict (it distinguishes claimant gaps from a
+# retrieval miss from an inconclusive assessment) -- all three collapse to
+# insufficient_information here.
+_POSTURE_VERDICT: dict[str, Verdict] = {
+    "compatible": Verdict.COMPATIBLE,
+    "incompatible": Verdict.INCOMPATIBLE,
+    "inconclusive": Verdict.INSUFFICIENT_INFORMATION,
+    "claimant_gaps": Verdict.INSUFFICIENT_INFORMATION,
+    "retrieval_miss": Verdict.INSUFFICIENT_INFORMATION,
+    "no_assessment": Verdict.INSUFFICIENT_INFORMATION,
+}
+
+_VERDICT_VALUES = {member.value for member in Verdict}
+
+
+def _last_recommendation_input(audit_trail: Sequence[AuditEvent]) -> str | None:
+    """The ``node_input`` of the last recommendation-node event, if any."""
+    for event in reversed(list(audit_trail)):
+        if event.node == _RECOMMENDATION_NODE and event.node_input:
+            return event.node_input
+    return None
+
+
+def posture_of(audit_trail: Sequence[AuditEvent]) -> str | None:
+    """The posture string the recommendation node recorded, or ``None``."""
+    node_input = _last_recommendation_input(audit_trail)
+    if node_input is None:
+        return None
+    match = _POSTURE_RE.search(node_input)
+    return match.group(1) if match else None
+
+
+def effective_verdict(audit_trail: Sequence[AuditEvent]) -> Verdict | None:
+    """The verdict the recommendation node settled on, or ``None`` if unreadable.
+
+    ``verdict=`` in the node's audit input wins; failing that, ``posture=``
+    mapped through :data:`_POSTURE_VERDICT`.
+    """
+    node_input = _last_recommendation_input(audit_trail)
+    if node_input is None:
+        return None
+
+    verdict_match = _VERDICT_RE.search(node_input)
+    if verdict_match and verdict_match.group(1) in _VERDICT_VALUES:
+        return Verdict(verdict_match.group(1))
+
+    posture_match = _POSTURE_RE.search(node_input)
+    if posture_match:
+        return _POSTURE_VERDICT.get(posture_match.group(1))
+    return None

--- a/app/src/infrastructure/rag/retriever_factory.py
+++ b/app/src/infrastructure/rag/retriever_factory.py
@@ -1,0 +1,128 @@
+"""Build the production retrieval stack behind the graph's ``RetrievalPort`` -- [M5-04].
+
+Until [M5-04] this pipeline -- hybrid RRF (BM25 + dense) + cross-encoder rerank +
+[M3-06] exclusion co-retrieval, the [M3-08] best config -- was assembled ad hoc
+in every eval script (``scripts/eval_retrieval_node.py::_build_adapter`` and
+friends). The API composition root needs the same thing, so it lives here once.
+
+Two-phase, because the pieces have very different lifecycles:
+
+- ``load_retriever_components()`` loads the heavy, process-wide parts -- the
+  sentence-transformers query embedder and the cross-encoder reranker (the
+  optional ``embed`` uv group; torch), the BM25 index over the chunk corpus, the
+  clause index and the exclusion clause graph. Call it once, at startup.
+- ``build_graph_retriever(session, components)`` is cheap and per-run: it binds
+  the dense leg to a live Postgres session and composes the adapter.
+
+``load_retriever_components`` raises a ``RuntimeError`` naming the fix
+(``uv sync --group embed`` / ``make build-index``) when the group or the embedded
+chunk corpus is missing, so a misconfigured deployment fails at boot with an
+actionable message rather than on the first request.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from infrastructure.parsing.clause_schema import ParsedClauseRecord
+from infrastructure.parsing.corpus_artifact import (
+    JSONL_PATH,
+    read_parsed_clauses_jsonl,
+)
+from infrastructure.rag.chunk_artifact import CHUNKS_JSONL_PATH, read_chunks_jsonl
+from infrastructure.rag.chunk_schema import ChunkRecord
+from infrastructure.rag.dense_retriever import DenseRetriever
+from infrastructure.rag.embedder import Embedder
+from infrastructure.rag.embedding_cache import CachingEmbedder
+from infrastructure.rag.exclusion_co_retrieval import ClauseGraph
+from infrastructure.rag.graph_retrieval_adapter import (
+    GraphRetrievalAdapter,
+    IndexedClause,
+    build_clause_index,
+)
+from infrastructure.rag.hybrid_retriever import HybridRetriever
+from infrastructure.rag.lexical_analyzer import build_analyzer
+from infrastructure.rag.lexical_retriever import LexicalRetriever
+from infrastructure.rag.reranker import Reranker
+from infrastructure.rag.reranker_cache import CachingReranker
+
+
+@dataclass(frozen=True)
+class RetrieverComponents:
+    """The load-once parts of the retrieval stack -- everything but the DB session."""
+
+    embedder: CachingEmbedder
+    reranker: CachingReranker
+    lexical: LexicalRetriever
+    clause_index: dict[str, IndexedClause]
+    clause_graph: ClauseGraph
+
+
+def load_retriever_components() -> RetrieverComponents:
+    """Load the heavy, process-wide retrieval components (needs the ``embed`` group)."""
+    if not CHUNKS_JSONL_PATH.exists():
+        raise RuntimeError(
+            f"{CHUNKS_JSONL_PATH} not found -- the API needs the built chunk "
+            "corpus. Run `make build-index` (raw PDFs -> Postgres + embeddings)."
+        )
+    if not JSONL_PATH.exists():
+        raise RuntimeError(
+            f"{JSONL_PATH} not found -- run `make fetch-corpus-artifacts` or "
+            "`make parse` first."
+        )
+
+    return retriever_components_from_corpora(
+        read_chunks_jsonl(CHUNKS_JSONL_PATH),
+        read_parsed_clauses_jsonl(JSONL_PATH),
+    )
+
+
+def retriever_components_from_corpora(
+    chunks: Sequence[ChunkRecord],
+    corpus: Sequence[ParsedClauseRecord],
+) -> RetrieverComponents:
+    """Build the load-once components from already-read corpora (for eval scripts)."""
+    return RetrieverComponents(
+        embedder=CachingEmbedder(_load_query_embedder()),
+        reranker=CachingReranker(_load_reranker()),
+        lexical=LexicalRetriever.from_chunks(list(chunks), build_analyzer()),
+        clause_index=build_clause_index(chunks),
+        clause_graph=ClauseGraph(corpus),
+    )
+
+
+def build_graph_retriever(
+    session: Session, components: RetrieverComponents
+) -> GraphRetrievalAdapter:
+    """Compose the per-run retrieval adapter over a live Postgres session."""
+    dense = DenseRetriever(session, components.embedder)
+    hybrid = HybridRetriever(components.lexical, dense)
+    return GraphRetrievalAdapter(
+        hybrid,
+        components.reranker,
+        components.clause_index,
+        co_retrieval=components.clause_graph,
+    )
+
+
+def _load_query_embedder() -> Embedder:
+    """The real sentence-transformers query embedder ([M3-02]).
+
+    Deferred import so the heavy ``embed`` group is only required where the real
+    retrieval stack is built (mirrors ``scripts/eval_retrieval._load_query_embedder``).
+    """
+    from infrastructure.rag.sentence_transformer_embedder import (
+        SentenceTransformerEmbedder,
+    )
+
+    return SentenceTransformerEmbedder()
+
+
+def _load_reranker() -> Reranker:
+    """The real local cross-encoder reranker ([M3-05]); deferred import as above."""
+    from infrastructure.rag.cross_encoder_reranker import CrossEncoderReranker
+
+    return CrossEncoderReranker()

--- a/app/src/presentation/app.py
+++ b/app/src/presentation/app.py
@@ -1,0 +1,128 @@
+"""The FastAPI app and its composition root -- [M5-04].
+
+``create_app()`` mounts the routers and the error edge. ``_default_lifespan``
+is the composition root: it builds the process-wide singletons (the DB engine
+and session factory, the two chat models, the retrieval components, the
+LangGraph orchestrator, the clock, the id minter), stashes them on
+``app.state.components`` for the dependency layer, and disposes the engine on
+shutdown. A checkpointer probe at startup turns a missing checkpointer schema
+into an actionable "run ``make setup-checkpointer``" message before the first
+request rather than after it.
+
+``lifespan`` is injectable so a test can supply its own composition (real
+Postgres, a fake-context orchestrator) without the heavy model / retriever load
+-- see ``tests/integration/test_assessment_api.py``. Unit tests skip the
+lifespan entirely and override the use-case providers
+(``tests/unit/presentation/conftest.py``).
+
+Run locally with ``make serve`` (``uvicorn presentation.app:app``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from uuid import uuid4
+
+from fastapi import FastAPI
+from sqlalchemy.orm import Session
+
+from infrastructure.clock import SystemClock
+from infrastructure.config.llm_client_factory import build_chat_model
+from infrastructure.config.settings import (
+    get_database_settings,
+    get_llm_settings,
+    get_observability_settings,
+)
+from infrastructure.database import (
+    create_engine_from_settings,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.context import GraphContext
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.rag.retriever_factory import (
+    build_graph_retriever,
+    load_retriever_components,
+)
+from presentation.dependencies import AppComponents
+from presentation.errors import register_exception_handlers
+from presentation.routes import assessments, health
+
+logger = logging.getLogger(__name__)
+
+_LifespanFactory = Callable[[FastAPI], AbstractAsyncContextManager[None]]
+
+
+@asynccontextmanager
+async def _default_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Build the production composition root and tear it down on shutdown."""
+    obs = get_observability_settings()
+    logging.basicConfig(level=obs.log_level)
+
+    db = get_database_settings()
+    engine = create_engine_from_settings(db)
+    session_factory = create_session_factory(engine=engine)
+
+    # Fail fast with the actionable message if the checkpointer schema is absent.
+    with open_claim_checkpointer(db.sqlalchemy_database_url):
+        pass
+
+    llm = get_llm_settings()
+    fast_model = build_chat_model(
+        llm,
+        llm.llm_model_fast,
+        provider_order=llm.llm_fast_provider_order,
+        allow_fallbacks=llm.llm_fast_allow_fallbacks,
+    )
+    reasoning_model = build_chat_model(
+        llm,
+        llm.llm_model_reasoning,
+        provider_order=llm.llm_reasoning_provider_order,
+        allow_fallbacks=llm.llm_reasoning_allow_fallbacks,
+    )
+    retriever_components = load_retriever_components()
+
+    def context_factory(session: Session) -> GraphContext:
+        return GraphContext(
+            fast_model=fast_model,
+            reasoning_model=reasoning_model,
+            retriever=build_graph_retriever(session, retriever_components),
+            llm_settings=llm,
+            audit_sink=None,
+        )
+
+    app.state.components = AppComponents(
+        clock=SystemClock(),
+        orchestrator=LangGraphClaimAssessmentOrchestrator(
+            context_factory=context_factory,
+            session_factory=session_factory,
+            database_url=db.sqlalchemy_database_url,
+        ),
+        uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+        session_factory=session_factory,
+        new_id=lambda: str(uuid4()),
+    )
+    logger.info("assessment API composition root ready")
+    try:
+        yield
+    finally:
+        engine.dispose()
+
+
+def create_app(*, lifespan: _LifespanFactory | None = None) -> FastAPI:
+    """Build the FastAPI app; ``lifespan`` overrides the production composition."""
+    app = FastAPI(
+        title="Insurance claim assessment API",
+        version="1",
+        lifespan=lifespan or _default_lifespan,
+    )
+    app.include_router(health.router)
+    app.include_router(assessments.router)
+    register_exception_handlers(app)
+    return app
+
+
+app = create_app()

--- a/app/src/presentation/dependencies.py
+++ b/app/src/presentation/dependencies.py
@@ -1,0 +1,134 @@
+"""FastAPI dependency wiring for the assessment use cases -- [M5-04].
+
+The composition root (``presentation.app.lifespan``) builds the process-wide
+singletons -- the clock, the LangGraph orchestrator, the unit-of-work factory,
+the session factory, the id minter -- and stashes them in an ``AppComponents``
+on ``app.state``. Everything here reads that and assembles a use case *per
+request*: a fresh read session for the ``GET`` / list paths, the uow factory for
+the writes.
+
+Every provider is a plain function so a test can replace any one of them through
+``app.dependency_overrides`` -- overriding ``get_orchestrator`` alone is enough
+to run the whole API against ``tests/unit/application/fakes.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Annotated, cast
+
+from fastapi import Depends, Request
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.ports.clock import Clock
+from application.ports.unit_of_work import UnitOfWorkFactory
+from application.use_cases.get_assessment import GetAssessment
+from application.use_cases.get_audit_trail import GetAuditTrail
+from application.use_cases.list_assessments import ListAssessments
+from application.use_cases.submit_claim import SubmitClaim
+from application.use_cases.submit_human_decision import SubmitHumanDecision
+from infrastructure.database import (
+    SqlAlchemyAssessmentRepository,
+    SqlAlchemyAuditTrailReader,
+    SqlAlchemyClauseRepository,
+)
+
+
+@dataclass
+class AppComponents:
+    """The process-wide singletons the composition root builds once."""
+
+    clock: Clock
+    orchestrator: ClaimAssessmentOrchestrator
+    uow_factory: UnitOfWorkFactory
+    session_factory: sessionmaker[Session]
+    new_id: Callable[[], str]
+
+
+def _components(request: Request) -> AppComponents:
+    return cast(AppComponents, request.app.state.components)
+
+
+def get_read_session(request: Request) -> Iterator[Session]:
+    """A per-request read session -- never committed, rolled back on the way out."""
+    with _components(request).session_factory() as session:
+        yield session
+        session.rollback()
+
+
+def get_clock(request: Request) -> Clock:
+    """The wall clock the use cases stamp timestamps from."""
+    return _components(request).clock
+
+
+def get_orchestrator(request: Request) -> ClaimAssessmentOrchestrator:
+    """The LangGraph-backed assessment orchestrator."""
+    return _components(request).orchestrator
+
+
+def get_uow_factory(request: Request) -> UnitOfWorkFactory:
+    """Opens one write transaction per use-case invocation."""
+    return _components(request).uow_factory
+
+
+def get_new_id(request: Request) -> Callable[[], str]:
+    """Mints the claim / assessment identifiers."""
+    return _components(request).new_id
+
+
+_Session = Annotated[Session, Depends(get_read_session)]
+_Clock = Annotated[Clock, Depends(get_clock)]
+_Orchestrator = Annotated[ClaimAssessmentOrchestrator, Depends(get_orchestrator)]
+_UowFactory = Annotated[UnitOfWorkFactory, Depends(get_uow_factory)]
+_NewId = Annotated[Callable[[], str], Depends(get_new_id)]
+
+
+def get_submit_claim(
+    clock: _Clock,
+    orchestrator: _Orchestrator,
+    uow_factory: _UowFactory,
+    new_id: _NewId,
+) -> SubmitClaim:
+    """Wire ``SubmitClaim`` for one request."""
+    return SubmitClaim(
+        clock=clock,
+        orchestrator=orchestrator,
+        uow_factory=uow_factory,
+        new_id=new_id,
+    )
+
+
+def get_get_assessment(session: _Session) -> GetAssessment:
+    """Wire ``GetAssessment`` for one request."""
+    return GetAssessment(assessments=SqlAlchemyAssessmentRepository(session))
+
+
+def get_list_assessments(session: _Session) -> ListAssessments:
+    """Wire ``ListAssessments`` for one request."""
+    return ListAssessments(assessments=SqlAlchemyAssessmentRepository(session))
+
+
+def get_submit_human_decision(
+    clock: _Clock,
+    orchestrator: _Orchestrator,
+    uow_factory: _UowFactory,
+    session: _Session,
+) -> SubmitHumanDecision:
+    """Wire ``SubmitHumanDecision`` for one request."""
+    return SubmitHumanDecision(
+        clock=clock,
+        orchestrator=orchestrator,
+        assessments=SqlAlchemyAssessmentRepository(session),
+        clauses=SqlAlchemyClauseRepository(session),
+        uow_factory=uow_factory,
+    )
+
+
+def get_get_audit_trail(session: _Session) -> GetAuditTrail:
+    """Wire ``GetAuditTrail`` for one request."""
+    return GetAuditTrail(
+        assessments=SqlAlchemyAssessmentRepository(session),
+        audit=SqlAlchemyAuditTrailReader(session),
+    )

--- a/app/src/presentation/errors.py
+++ b/app/src/presentation/errors.py
@@ -1,0 +1,120 @@
+"""The one edge where domain/application errors become HTTP responses -- [M5-04].
+
+Every failure a use case raises is caught here and rendered as the uniform
+envelope ``{"error": {"code", "message", "details"}}`` with a stable string
+code, so a client can branch on ``code`` and never on a status alone or a
+message string. The ``application.errors`` / ``domain.errors`` hierarchies were
+built as a single cluster for exactly this (``application/errors.py`` docstring).
+
+Registration is by exception type; Starlette resolves a raised exception to the
+most-derived registered handler via its MRO, so the order of the table does not
+matter. ``RequestValidationError`` (FastAPI's own body-validation failure) is
+normalised into the same envelope; a genuinely unexpected exception becomes a
+logged 500 with no traceback in the body.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from application.errors import (
+    ApplicationError,
+    AssessmentAlreadyDecidedError,
+    AssessmentNotFoundError,
+    OrchestratorContractError,
+    UnknownClauseError,
+)
+from domain.errors import (
+    CitationRequiredError,
+    DecisionMustReferenceAssessmentError,
+    DomainError,
+    InvalidCnpjError,
+    InvalidSusepProcessError,
+    InvalidValueObjectError,
+    InvariantViolationError,
+    PolicyYearMismatchError,
+    VerdictNotPermittedError,
+)
+from presentation.schemas import ErrorBody, ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+_Handler = Callable[[Request, Exception], Awaitable[JSONResponse]]
+
+# (exception type, HTTP status, stable error code). Leaf types plus the three
+# bases plus `ValueError` -- Starlette picks the most-derived match.
+_MAPPING: tuple[tuple[type[Exception], int, str], ...] = (
+    (AssessmentNotFoundError, 404, "assessment_not_found"),
+    (AssessmentAlreadyDecidedError, 409, "assessment_already_decided"),
+    (UnknownClauseError, 422, "unknown_clause"),
+    (OrchestratorContractError, 502, "orchestrator_contract_error"),
+    (ApplicationError, 500, "application_error"),
+    (CitationRequiredError, 422, "citation_required"),
+    (VerdictNotPermittedError, 422, "verdict_not_permitted"),
+    (DecisionMustReferenceAssessmentError, 422, "decision_must_reference_assessment"),
+    (PolicyYearMismatchError, 422, "policy_year_mismatch"),
+    (InvalidSusepProcessError, 422, "invalid_susep_process"),
+    (InvalidCnpjError, 422, "invalid_cnpj"),
+    (InvalidValueObjectError, 422, "invalid_value_object"),
+    (InvariantViolationError, 422, "invariant_violation"),
+    (DomainError, 422, "domain_error"),
+    (ValueError, 422, "invalid_request"),
+)
+
+
+def _envelope(
+    status_code: int,
+    code: str,
+    message: str,
+    details: dict[str, object] | None = None,
+) -> JSONResponse:
+    body = ErrorResponse(error=ErrorBody(code=code, message=message, details=details))
+    return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"))
+
+
+def _details_for(exc: Exception) -> dict[str, object] | None:
+    if isinstance(
+        exc,
+        AssessmentNotFoundError | AssessmentAlreadyDecidedError | CitationRequiredError,
+    ):
+        return {"assessment_id": exc.assessment_id}
+    if isinstance(exc, UnknownClauseError):
+        return {"clause_ids": list(exc.clause_ids)}
+    return None
+
+
+def _make_handler(status_code: int, code: str) -> _Handler:
+    async def handler(_request: Request, exc: Exception) -> JSONResponse:
+        return _envelope(status_code, code, str(exc), _details_for(exc))
+
+    return handler
+
+
+async def _validation_handler(_request: Request, exc: Exception) -> JSONResponse:
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else []
+    return _envelope(
+        422,
+        "request_validation_error",
+        "request body failed validation",
+        {"errors": list(errors)},
+    )
+
+
+async def _unexpected_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception(
+        "unhandled error on %s %s", request.method, request.url.path, exc_info=exc
+    )
+    return _envelope(500, "internal_error", "an unexpected error occurred")
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Wire every domain/application error to its HTTP status and stable code."""
+    for exc_type, status_code, code in _MAPPING:
+        app.add_exception_handler(exc_type, _make_handler(status_code, code))
+    app.add_exception_handler(RequestValidationError, _validation_handler)
+    app.add_exception_handler(Exception, _unexpected_handler)

--- a/app/src/presentation/mappers.py
+++ b/app/src/presentation/mappers.py
@@ -1,0 +1,188 @@
+"""Pure conversions between the API schemas and the application/domain types -- [M5-04].
+
+One direction builds a response model from an ``AssessmentRecord`` /
+``AuditTrailEntry`` (enum values rendered as strings, value objects as their
+canonical form). The other turns a request body into the domain inputs the use
+cases take -- and a malformed value object (a bad SUSEP process, an unknown
+clause type, a non-permitted verdict) raises the domain ``ValueError`` /
+``InvalidValueObjectError`` here, which the error edge maps to 422.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from application.assessment_record import AssessmentRecord
+from application.audit_trail_entry import AuditTrailEntry
+from application.consistency_flag import ConsistencyFlag
+from application.edited_assessment_input import EditedAssessmentInput
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+from presentation.schemas import (
+    AssessmentResponse,
+    AuditEntrySchema,
+    AuditTrailResponse,
+    CitationInput,
+    CitationSchema,
+    ConsistencyFlagSchema,
+    DecisionRequest,
+    EditedAssessmentPayload,
+    EditedAssessmentView,
+    HumanDecisionSchema,
+)
+
+# --------------------------------------------------------------------------- #
+# domain/application -> response
+# --------------------------------------------------------------------------- #
+
+
+def _citation_schema(citation: Citation) -> CitationSchema:
+    return CitationSchema(
+        clause_id=citation.clause_id,
+        document_id=citation.document_id,
+        susep_process=citation.susep_process.value,
+        clause_type=citation.clause_type.value,
+        excerpt=citation.excerpt,
+        relevance_score=citation.relevance_score,
+    )
+
+
+def _consistency_flag_schema(flag: ConsistencyFlag) -> ConsistencyFlagSchema:
+    return ConsistencyFlagSchema(
+        check=flag.check,
+        severity=flag.severity,
+        detail=flag.detail,
+        source=flag.source,
+    )
+
+
+def _decision_schema(decision: HumanDecision) -> HumanDecisionSchema:
+    edited = decision.edited_assessment
+    return HumanDecisionSchema(
+        assessment_id=decision.assessment_id,
+        decision=decision.decision.value,
+        decided_at=decision.decided_at,
+        notes=decision.notes,
+        edited_assessment=(
+            EditedAssessmentView(
+                verdict=edited.verdict.value,
+                reasoning=edited.reasoning,
+                recommended_action=edited.recommended_action,
+                citations=[_citation_schema(c) for c in edited.citations],
+                confidence=edited.confidence,
+            )
+            if edited is not None
+            else None
+        ),
+    )
+
+
+def assessment_response(record: AssessmentRecord) -> AssessmentResponse:
+    """Render an ``AssessmentRecord`` as the API response model."""
+    return AssessmentResponse(
+        assessment_id=record.assessment_id,
+        claim_id=record.claim_id,
+        status=record.status.value,
+        verdict=record.verdict.value,
+        reasoning=record.reasoning,
+        recommended_action=record.recommended_action,
+        confidence=record.confidence,
+        citations=[_citation_schema(c) for c in record.citations],
+        consistency_flags=[
+            _consistency_flag_schema(f) for f in record.consistency_flags
+        ],
+        context_sufficient=record.context_sufficient,
+        clarification_exhausted=record.clarification_exhausted,
+        missing_information=list(record.missing_information),
+        is_grounded=record.is_grounded,
+        created_at=record.created_at,
+        decision=(
+            _decision_schema(record.decision) if record.decision is not None else None
+        ),
+    )
+
+
+def _audit_entry_schema(entry: AuditTrailEntry) -> AuditEntrySchema:
+    return AuditEntrySchema(
+        sequence=entry.sequence,
+        timestamp=entry.timestamp,
+        node=entry.node,
+        action=entry.action,
+        model=entry.model,
+        model_version=entry.model_version,
+        input_tokens=entry.input_tokens,
+        output_tokens=entry.output_tokens,
+        total_tokens=entry.total_tokens,
+        confidence=entry.confidence,
+        node_input=entry.node_input,
+        payload=dict(entry.payload) if entry.payload is not None else None,
+    )
+
+
+def audit_trail_response(
+    assessment_id: str, entries: Sequence[AuditTrailEntry]
+) -> AuditTrailResponse:
+    """Render a run's audit trail as the API response model."""
+    return AuditTrailResponse(
+        assessment_id=assessment_id,
+        entries=[_audit_entry_schema(entry) for entry in entries],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# request -> domain/application
+# --------------------------------------------------------------------------- #
+
+
+def to_policy_ref(raw: str | None) -> SusepProcess | None:
+    """Parse the optional ``policy_ref`` string into a ``SusepProcess``.
+
+    Raises ``domain.errors.InvalidSusepProcessError`` (a ``ValueError``) on a
+    malformed value -- mapped to 422 at the error edge.
+    """
+    if raw is None or not raw.strip():
+        return None
+    return SusepProcess.parse(raw)
+
+
+def to_decision_outcome(value: str) -> DecisionOutcome:
+    """Map the request's decision literal onto the domain enum."""
+    return DecisionOutcome(value)
+
+
+def _citation_from_input(payload: CitationInput) -> Citation:
+    return Citation(
+        clause_id=payload.clause_id,
+        document_id=payload.document_id,
+        susep_process=SusepProcess.parse(payload.susep_process),
+        clause_type=ClauseType(payload.clause_type),
+        excerpt=payload.excerpt,
+        relevance_score=payload.relevance_score,
+    )
+
+
+def to_edited_assessment_input(
+    payload: EditedAssessmentPayload,
+) -> EditedAssessmentInput:
+    """Build the ``EditedAssessmentInput`` the use case validates and grounds.
+
+    Raises ``domain.errors.InvalidValueObjectError`` / ``ValueError`` on a
+    malformed verdict, clause type or SUSEP process -- 422 at the edge.
+    """
+    return EditedAssessmentInput(
+        verdict=Verdict(payload.verdict),
+        reasoning=payload.reasoning,
+        recommended_action=payload.recommended_action,
+        citations=tuple(_citation_from_input(c) for c in payload.citations),
+        confidence=payload.confidence,
+    )
+
+
+def edited_from_request(request: DecisionRequest) -> EditedAssessmentInput | None:
+    """The ``EditedAssessmentInput`` for the request, or ``None`` when not editing."""
+    if request.edited is None:
+        return None
+    return to_edited_assessment_input(request.edited)

--- a/app/src/presentation/routes/__init__.py
+++ b/app/src/presentation/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP routers for the assessment API -- [M5-04]."""

--- a/app/src/presentation/routes/assessments.py
+++ b/app/src/presentation/routes/assessments.py
@@ -1,0 +1,135 @@
+"""The assessment endpoints -- [M5-04].
+
+Five routes over the four use cases:
+
+- ``POST /v1/assessments`` -> ``SubmitClaim``. Returns **202** with the id in the
+  body and in ``Location``. The graph runs synchronously in the handler for now
+  (minutes, LLM calls); [M5-05]'s queue makes it truly non-blocking and adds
+  ``PENDING/RUNNING/FAILED`` run states.
+- ``GET /v1/assessments`` -> ``ListAssessments`` (newest first).
+- ``GET /v1/assessments/{id}`` -> ``GetAssessment`` (state, recommendation,
+  structured citations).
+- ``POST /v1/assessments/{id}/decision`` -> ``SubmitHumanDecision``. Resumes the
+  paused run and returns the settled record (200 -- the resume completes).
+- ``GET /v1/assessments/{id}/audit`` -> ``GetAuditTrail``. Empty until a decision
+  is submitted (the durable trail is written at the human checkpoint).
+
+Every domain/application error raised below is turned into the uniform envelope
+by ``presentation.errors``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query, Response
+
+from application.assessment_record import AssessmentStatus
+from application.use_cases.get_assessment import GetAssessment
+from application.use_cases.get_audit_trail import GetAuditTrail
+from application.use_cases.list_assessments import ListAssessments
+from application.use_cases.submit_claim import SubmitClaim
+from application.use_cases.submit_human_decision import SubmitHumanDecision
+from presentation.dependencies import (
+    get_get_assessment,
+    get_get_audit_trail,
+    get_list_assessments,
+    get_submit_claim,
+    get_submit_human_decision,
+)
+from presentation.mappers import (
+    assessment_response,
+    audit_trail_response,
+    edited_from_request,
+    to_decision_outcome,
+    to_policy_ref,
+)
+from presentation.schemas import (
+    AssessmentResponse,
+    AuditTrailResponse,
+    DecisionRequest,
+    SubmitClaimRequest,
+    SubmitClaimResponse,
+)
+
+router = APIRouter(prefix="/v1/assessments", tags=["assessments"])
+
+_StatusFilter = Literal["awaiting_review", "decided"]
+
+_SubmitClaim = Annotated[SubmitClaim, Depends(get_submit_claim)]
+_ListAssessments = Annotated[ListAssessments, Depends(get_list_assessments)]
+_GetAssessment = Annotated[GetAssessment, Depends(get_get_assessment)]
+_SubmitHumanDecision = Annotated[
+    SubmitHumanDecision, Depends(get_submit_human_decision)
+]
+_GetAuditTrail = Annotated[GetAuditTrail, Depends(get_get_audit_trail)]
+
+
+@router.post("", status_code=202, response_model=SubmitClaimResponse)
+def submit_claim(
+    body: SubmitClaimRequest,
+    response: Response,
+    use_case: _SubmitClaim,
+) -> SubmitClaimResponse:
+    """Accept a claim, run it to the human checkpoint, return 202 + the id."""
+    record = use_case(
+        raw_text=body.raw_text,
+        policy_ref=to_policy_ref(body.policy_ref),
+        claim_id=body.claim_id,
+    )
+    response.headers["Location"] = f"/v1/assessments/{record.assessment_id}"
+    return SubmitClaimResponse(
+        assessment_id=record.assessment_id, status=record.status.value
+    )
+
+
+@router.get("", response_model=list[AssessmentResponse])
+def list_assessments(
+    use_case: _ListAssessments,
+    claim_id: Annotated[str | None, Query()] = None,
+    status: Annotated[_StatusFilter | None, Query()] = None,
+    limit: Annotated[int, Query(gt=0)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> list[AssessmentResponse]:
+    """List assessment records, newest first, optionally filtered."""
+    records = use_case(
+        claim_id=claim_id,
+        status=AssessmentStatus(status) if status is not None else None,
+        limit=limit,
+        offset=offset,
+    )
+    return [assessment_response(record) for record in records]
+
+
+@router.get("/{assessment_id}", response_model=AssessmentResponse)
+def get_assessment(
+    assessment_id: str,
+    use_case: _GetAssessment,
+) -> AssessmentResponse:
+    """Return one assessment's state, recommendation and citations."""
+    return assessment_response(use_case(assessment_id))
+
+
+@router.post("/{assessment_id}/decision", response_model=AssessmentResponse)
+def submit_decision(
+    assessment_id: str,
+    body: DecisionRequest,
+    use_case: _SubmitHumanDecision,
+) -> AssessmentResponse:
+    """Submit the analyst's decision and resume the paused run to completion."""
+    record = use_case(
+        assessment_id=assessment_id,
+        decision=to_decision_outcome(body.decision),
+        notes=body.notes,
+        edited=edited_from_request(body),
+    )
+    return assessment_response(record)
+
+
+@router.get("/{assessment_id}/audit", response_model=AuditTrailResponse)
+def get_audit_trail(
+    assessment_id: str,
+    use_case: _GetAuditTrail,
+) -> AuditTrailResponse:
+    """Return the durable audit trail for one assessment run."""
+    return audit_trail_response(assessment_id, use_case(assessment_id))

--- a/app/src/presentation/routes/health.py
+++ b/app/src/presentation/routes/health.py
@@ -1,0 +1,16 @@
+"""Liveness endpoint -- [M5-04].
+
+``GET /health`` returns 200 without touching any dependency, so a load balancer
+can tell the process is up. Readiness (``/ready`` with per-check detail on
+Postgres / Redis / the vector index) is [M5-06]'s.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    """Report that the process is alive."""
+    return {"status": "ok"}

--- a/app/src/presentation/schemas.py
+++ b/app/src/presentation/schemas.py
@@ -1,0 +1,178 @@
+"""Request and response models for the assessment API -- [M5-04].
+
+Pydantic v2 models: the presentation layer is the one place in this codebase
+that speaks JSON, so it is the one place Pydantic is allowed (``domain`` and
+``application`` stay stdlib-only, enforced by
+``tests/architecture/test_layer_boundaries.py``).
+
+Citations are structured objects here, never prose (a DoD item): ``clause_id``,
+``document_id``, ``susep_process``, ``clause_type``, ``excerpt``,
+``relevance_score``. Enums are rendered as their string values.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# --------------------------------------------------------------------------- #
+# shared value shapes
+# --------------------------------------------------------------------------- #
+
+_VERDICTS = Literal["compatible", "incompatible", "insufficient_information"]
+_DECISIONS = Literal["approve", "edit", "reject"]
+
+
+class CitationSchema(BaseModel):
+    """One clause an assessment's reasoning is grounded in -- a structured object."""
+
+    clause_id: str
+    document_id: str
+    susep_process: str
+    clause_type: str
+    excerpt: str
+    relevance_score: float
+
+
+class ConsistencyFlagSchema(BaseModel):
+    """One attention point raised while assessing -- kept beside the verdict."""
+
+    check: str
+    severity: Literal["info", "attention"]
+    detail: str
+    source: Literal["deterministic", "llm"]
+
+
+class EditedAssessmentView(BaseModel):
+    """The analyst's revised assessment, as recorded on an ``edit`` decision."""
+
+    verdict: _VERDICTS
+    reasoning: str
+    recommended_action: str
+    citations: list[CitationSchema]
+    confidence: float
+
+
+class HumanDecisionSchema(BaseModel):
+    """The analyst's decision, recorded beside the system's opinion, never over it."""
+
+    assessment_id: str
+    decision: _DECISIONS
+    decided_at: datetime
+    notes: str
+    edited_assessment: EditedAssessmentView | None = None
+
+
+class AssessmentResponse(BaseModel):
+    """One claim's assessment across its whole lifecycle -- the servable aggregate."""
+
+    assessment_id: str
+    claim_id: str
+    status: Literal["awaiting_review", "decided"]
+    verdict: _VERDICTS
+    reasoning: str
+    recommended_action: str
+    confidence: float
+    citations: list[CitationSchema]
+    consistency_flags: list[ConsistencyFlagSchema]
+    context_sufficient: bool | None
+    clarification_exhausted: bool
+    missing_information: list[str]
+    is_grounded: bool
+    created_at: datetime
+    decision: HumanDecisionSchema | None = None
+
+
+class AuditEntrySchema(BaseModel):
+    """One entry of a run's durable audit trail."""
+
+    sequence: int
+    timestamp: datetime
+    node: str
+    action: str
+    model: str | None = None
+    model_version: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    confidence: float | None = None
+    node_input: str | None = None
+    payload: dict[str, object] | None = None
+
+
+class AuditTrailResponse(BaseModel):
+    """The audit trail for one assessment run, in ``sequence`` order."""
+
+    assessment_id: str
+    entries: list[AuditEntrySchema]
+
+
+# --------------------------------------------------------------------------- #
+# requests
+# --------------------------------------------------------------------------- #
+
+
+class SubmitClaimRequest(BaseModel):
+    """The body of ``POST /v1/assessments``."""
+
+    raw_text: str = Field(min_length=1)
+    policy_ref: str | None = Field(
+        default=None,
+        description=(
+            "The registered product the claim is filed against -- a SUSEP "
+            "process number (canonical NNNNN.NNNNNN/NNNN-NN or 17 bare digits)."
+        ),
+    )
+    claim_id: str | None = None
+
+
+class SubmitClaimResponse(BaseModel):
+    """The 202 body of ``POST /v1/assessments``; the id also rides in ``Location``."""
+
+    assessment_id: str
+    status: Literal["awaiting_review", "decided"]
+
+
+class CitationInput(BaseModel):
+    """One clause the analyst grounds an edited assessment in."""
+
+    clause_id: str
+    document_id: str
+    susep_process: str
+    clause_type: str
+    excerpt: str
+    relevance_score: float = 0.0
+
+
+class EditedAssessmentPayload(BaseModel):
+    """The analyst's replacement assessment on an ``edit`` decision."""
+
+    verdict: _VERDICTS
+    reasoning: str
+    recommended_action: str
+    citations: list[CitationInput]
+    confidence: float
+
+
+class DecisionRequest(BaseModel):
+    """The body of ``POST /v1/assessments/{id}/decision``."""
+
+    decision: _DECISIONS
+    notes: str = ""
+    edited: EditedAssessmentPayload | None = None
+
+
+class ErrorBody(BaseModel):
+    """The inner object of every error response."""
+
+    code: str
+    message: str
+    details: dict[str, object] | None = None
+
+
+class ErrorResponse(BaseModel):
+    """The uniform error envelope: ``{"error": {"code", "message", "details"}}``."""
+
+    error: ErrorBody

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,192 @@
+# The assessment API — [M5-04]
+
+The HTTP surface over the [M5-02] use cases. Five endpoints, one uniform error
+envelope, citations as structured objects. The graph stays entirely behind
+`ClaimAssessmentOrchestrator` — no route, schema or mapper imports LangGraph.
+
+```
+POST   /v1/assessments                     submit a claim            -> 202 + id
+GET    /v1/assessments                      list, newest first       -> 200
+GET    /v1/assessments/{id}                 state + recommendation   -> 200
+POST   /v1/assessments/{id}/decision        approve / edit / reject  -> 200
+GET    /v1/assessments/{id}/audit           durable audit trail      -> 200
+GET    /health                              liveness                 -> 200
+```
+
+Code:
+
+- `app/src/presentation/app.py` — `create_app()` and the `lifespan` composition
+  root (engine, session factory, the two chat models, the retrieval components,
+  the LangGraph orchestrator, `SystemClock`, the id minter).
+- `app/src/presentation/dependencies.py` — `Depends` providers; one use case per
+  request, a fresh read session for the `GET` paths.
+- `app/src/presentation/{schemas,mappers}.py` — Pydantic models, pure
+  dataclass↔schema conversions.
+- `app/src/presentation/errors.py` — the single error→HTTP edge.
+- `app/src/presentation/routes/{assessments,health}.py` — the routers.
+- `app/src/infrastructure/graph/orchestrator.py` — `LangGraphClaimAssessmentOrchestrator`
+  and its `_CapturingAuditSink`.
+- `app/src/infrastructure/graph/state_mapper.py` — the `state.py` ↔ domain mapper.
+- `app/src/infrastructure/graph/verdict_readout.py` — the verdict read (shared
+  with `scripts/eval_end_to_end.py`).
+- `app/src/infrastructure/clock.py` — `SystemClock`.
+- `app/src/infrastructure/rag/retriever_factory.py` — the shared retrieval-stack
+  builder.
+- `app/src/infrastructure/database/audit_trail_{reader,writer}.py` — the audit
+  read model and the transactional writer.
+
+## Bring-up
+
+```bash
+cp .env.example .env          # fill LLM_PROVIDER / LLM_API_KEY / DATABASE_URL
+make migrate                  # assessment / decision / audit_event tables
+make setup-checkpointer       # the LangGraph checkpointer's own tables
+make build-index              # raw PDFs -> parsed -> chunks -> Postgres -> embeddings
+make serve                    # uvicorn presentation.app:app --reload --port 8000
+```
+
+`make serve` runs under the `embed` uv group — the retriever loads the local
+sentence-transformers embedder and cross-encoder reranker once at startup and
+fails fast with an actionable message if the group or the embedded chunk corpus
+is missing. The checkpointer schema is probed at startup too.
+
+## The endpoints
+
+### `POST /v1/assessments`
+
+```json
+{ "raw_text": "Bati o carro na traseira de outro veículo...",
+  "policy_ref": "15414.610650/2024-59",   // optional; SUSEP process, canonical or 17 digits
+  "claim_id": "optional-external-id" }
+```
+
+`202 Accepted`, `Location: /v1/assessments/<id>`, body `{"assessment_id": "<id>",
+"status": "awaiting_review"}`. The graph runs synchronously to the human
+checkpoint before the response returns (see *Findings*). `policy_ref` is
+prepended to the narrative as `[Apólice registrada: processo SUSEP …]` so intake
+extracts it and retrieval pre-filters on it.
+
+### `GET /v1/assessments/{id}` and `GET /v1/assessments`
+
+The full servable aggregate:
+
+```json
+{ "assessment_id": "...", "claim_id": "...", "status": "awaiting_review",
+  "verdict": "compatible", "reasoning": "...", "recommended_action": "...",
+  "confidence": 0.72, "is_grounded": true,
+  "citations": [ { "clause_id": "...", "document_id": "...",
+                   "susep_process": "15414.610650/2024-59",
+                   "clause_type": "coverage", "excerpt": "...",
+                   "relevance_score": 0.83 } ],
+  "consistency_flags": [ { "check": "...", "severity": "attention",
+                           "detail": "...", "source": "deterministic" } ],
+  "context_sufficient": true, "clarification_exhausted": false,
+  "missing_information": [], "created_at": "2026-09-03T12:00:00Z",
+  "decision": null }
+```
+
+The collection endpoint takes `claim_id`, `status`, `limit` (>0, default 50) and
+`offset` (>=0), newest first.
+
+### `POST /v1/assessments/{id}/decision`
+
+```json
+{ "decision": "approve" | "edit" | "reject",
+  "notes": "conferido",
+  "edited": {                         // required iff decision == "edit"
+    "verdict": "incompatible", "reasoning": "...", "recommended_action": "...",
+    "confidence": 0.6,
+    "citations": [ { "clause_id": "...", "document_id": "...",
+                     "susep_process": "...", "clause_type": "exclusion",
+                     "excerpt": "..." } ] } }
+```
+
+`200 OK` with the settled aggregate. The system's verdict/prose/citations are
+**unchanged** — an `edit` lives entirely in `decision.edited_assessment`. Every
+cited clause on an `edit` is validated against the corpus before the graph is
+resumed.
+
+### `GET /v1/assessments/{id}/audit`
+
+```json
+{ "assessment_id": "...",
+  "entries": [ { "sequence": 0, "timestamp": "...", "node": "retrieval",
+                 "action": "retrieve_clauses", "model": null, "confidence": null,
+                 "node_input": "...", "payload": null },
+               ... ,
+               { "sequence": 6, "node": "human_review",
+                 "action": "human_decision:approve",
+                 "payload": { "decision": "approve", "notes": "conferido", ... } } ] }
+```
+
+Empty (`"entries": []`) until a decision is submitted — the durable trail is
+written once, at the human checkpoint.
+
+## Errors
+
+Uniform envelope; `code` is stable, branch on it:
+
+```json
+{ "error": { "code": "assessment_not_found", "message": "...",
+             "details": { "assessment_id": "..." } } }
+```
+
+| code | HTTP | when |
+| --- | --- | --- |
+| `assessment_not_found` | 404 | `GET` / decision / audit on an unknown id |
+| `assessment_already_decided` | 409 | a decision on a settled assessment |
+| `unknown_clause` | 422 | an `edit` cites a clause absent from the corpus (`details.clause_ids`) |
+| `citation_required` | 422 | an `edit` cites nothing |
+| `invalid_susep_process` / `invalid_value_object` / `verdict_not_permitted` | 422 | a malformed `policy_ref` or `edited` payload |
+| `invalid_request` | 422 | an `edit` without a payload, a non-`edit` carrying one, bad paging |
+| `request_validation_error` | 422 | the body failed schema validation (`details.errors`) |
+| `orchestrator_contract_error` | 502 | `start` did not pause / `resume` did not finish |
+| `internal_error` | 500 | anything unexpected — logged, no traceback in the body |
+
+## Results
+
+`tests/integration/test_assessment_api.py` runs the whole flow against real
+Postgres (the assessment/decision/audit tables and the LangGraph checkpointer)
+with a canned-output model and a one-clause stub retriever: `POST` → 202 + id →
+`GET` shows `awaiting_review` + a `compatible` recommendation + a structured
+citation → `GET …/audit` is empty → `POST …/decision {approve}` → 200 `decided`
+→ `GET` shows the system verdict unchanged beside the decision → `GET …/audit`
+shows the trail ending in `human_review` / `human_decision:approve` with the
+decision in `payload`. A second decision returns 409. The `reject` and `edit`
+paths, the unknown-clause 422, the unknown-id 404, and the transactional fold
+(a `SELECT count(*) FROM audit_event` proving the trail committed with the
+`DECIDED` record) are covered too.
+
+## Findings
+
+1. **`POST` is synchronous behind its 202.** The handler blocks for the whole
+   graph run (minutes, many LLM calls). This is the interim: [M5-05] owns the
+   Redis queue and the `PENDING/RUNNING/FAILED` run states that make it truly
+   non-blocking. The 202 + `Location` contract does not change.
+2. **The audit trail is empty before a decision.** By [M4-09] design the durable
+   trail is written once, in `human_review`, after the analyst decides. `GET
+   …/audit` on an `AWAITING_REVIEW` assessment is `200 {"entries": []}`, not a
+   404.
+3. **`policy_ref` is a text header, not a graph change.** It is byte-identical to
+   the measured headline arm of `scripts/eval_end_to_end.py` — no new code path,
+   no eval re-run.
+4. **The transactional fold uses a capturing sink.** On `resume` the graph's
+   trail is captured in `OrchestratorResult.audit_records` and written by the
+   use case in the same transaction as the settled record, through
+   `UnitOfWork.audit`. One `commit()`, both or neither. The append is idempotent,
+   so a decision retry after a mid-write crash is a no-op.
+5. **An `edit` drops consistency flags.** `EditedAssessmentInput` → domain
+   `Assessment` carries none. Flags are attention points kept beside the verdict,
+   not part of the decision.
+
+## What this leaves for later
+
+- **[M5-05]** — Redis-backed queue, bounded concurrency, retry/back-off,
+  dead-letter, and the `PENDING/RUNNING/FAILED` run states behind a non-blocking
+  202.
+- **[M5-06]** — `GET /ready` with per-check detail, JSON logs to stdout, and
+  correlation-id propagation from the request into every node and LLM call.
+- **[M5-09]** — the Compose `api` service, the Dockerfile, the CI image build,
+  and the proxy-header / trusted-host middleware from `ObservabilitySettings`.
+- A pooled checkpointer connection (`docs/DATABASE.md` "the M5 shape") — the
+  adapter opens one per `start` / `resume` today.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -776,3 +776,90 @@ grounded / abstain / every decision outcome, no DB);
 `test_audit_event_append_only.py` (real Postgres, one per repository plus the
 append-only guarantee). `make test-integration` and CI's `integration` job pick
 these up from the directory.
+
+---
+
+## The HTTP surface: FastAPI over the use cases, errors mapped at one edge — [M5-04]
+
+**Decision.** `app/src/presentation/` gains the FastAPI app: `app.py`
+(`create_app()` + the `lifespan` composition root), `dependencies.py`
+(`Depends` providers building a use case per request off `app.state.components`),
+`schemas.py` / `mappers.py` (Pydantic request/response models, pure
+dataclass↔schema conversions), `errors.py` (the single error→HTTP edge), and
+`routes/` (`assessments.py` — the five endpoints — and `health.py`). Three
+infrastructure pieces the application layer was designed around land with it:
+`infrastructure/graph/orchestrator.py`
+(`LangGraphClaimAssessmentOrchestrator`, the concrete
+`ClaimAssessmentOrchestrator` wrapping `build_claim_graph`),
+`infrastructure/graph/state_mapper.py` (the `state.py` ↔ domain mapper — its
+only consumer, so it is [M5-04]'s per `docs/DOMAIN.md`), and
+`infrastructure/clock.py` (`SystemClock`). `infrastructure/graph/verdict_readout.py`
+extracts the "read the verdict from the recommendation node's audit event"
+logic that `scripts/eval_end_to_end.py` had inline; `infrastructure/rag/retriever_factory.py`
+consolidates the ad-hoc retrieval-stack assembly the eval scripts each carried.
+The new audit read model is a port (`AuditTrailReader`), a use case
+(`GetAuditTrail`) and an adapter (`SqlAlchemyAuditTrailReader`), landing with its
+first caller like every other port.
+
+**Why.** (a) `POST /v1/assessments` returns **202** but runs the graph
+synchronously in the handler for now — the real Redis queue and the
+`PENDING/RUNNING/FAILED` run states are [M5-05]'s, which owns the queue; the id
+in the 202 body and `Location` always resolves on `GET`. (b) `policy_ref` reaches
+retrieval as a **text header** the adapter prepends to the narrative
+(`[Apólice registrada: processo SUSEP …]`), byte-identical to the measured
+headline arm of `scripts/eval_end_to_end.py::build_claim_text` — intake extracts
+the process, `nodes/retrieval._build_filter` pre-filters on it, no graph change
+and no eval re-run. (c) The orchestrator opens `open_claim_checkpointer` and a
+fresh session **per call**; a pooled connection is "the M5 shape"
+(`docs/DATABASE.md`), deferred to [M5-05]'s worker model. (d) The
+`start`-must-pause / `resume`-must-finish contract stays the **use case's** to
+enforce (per the port docstring) — the adapter reports `awaiting_review` as it
+found it. (e) Errors map at one Starlette exception-handler layer: each
+`application.errors` / `domain.errors` type → an HTTP status + a stable string
+`code`, in the envelope `{"error": {"code", "message", "details"}}`; a client
+branches on `code`, never on a status or a message.
+
+**The transactional fold (the [M5-03]-deferred DoD item).** On the `resume` path
+the composition root gives the graph a `_CapturingAuditSink` instead of the
+committing `SqlAlchemyAuditTrailSink`: the `human_review` node's trail comes back
+in `OrchestratorResult.audit_records`, and `SubmitHumanDecision` writes it
+through the new `UnitOfWork.audit` writer in the **same transaction** as the
+settled record — one `commit()`, both or neither. `resume` does no model calls
+(it re-runs only `human_review`), so nothing long-running is pulled into the
+transaction. The append is idempotent on `(thread_id, sequence)`, so the
+self-healing retry (a second decision on a record still `AWAITING_REVIEW` whose
+thread the first attempt finished) rewrites the same rows harmlessly. `start`
+has no fold — the run pauses before it writes any trail; that window is
+inherent (the checkpoint is a separate psycopg connection) and [M5-05]'s
+run-status closes it.
+
+**Deviation on record.** (a) `POST` blocks behind its 202 (above). (b)
+`GET /v1/assessments/{id}/audit` returns `200 {"entries": []}` for an
+`AWAITING_REVIEW` assessment — the durable trail is written once, in
+`human_review`, after the decision, a deliberate [M4-09] design. (c) An analyst
+`edit` drops the recommendation's consistency flags: an `EditedAssessmentInput` →
+domain `Assessment` carries none, and flags are attention points kept beside the
+verdict, not part of the decision ([M4-08]). (d) The `presentation/` layer is
+not scanned by `test_layer_boundaries.py`; the `langgraph` import stays in
+`infrastructure/`, and `domain` + `application` stay free of FastAPI/SQLAlchemy/
+LangGraph as the M5 exit criteria require.
+
+**Enforcement.** `tests/unit/presentation/**` (every endpoint's happy path and
+every error→status mapping, driven through `tests/unit/application/fakes.py` via
+`app.dependency_overrides` — no Postgres, graph or LLM);
+`tests/unit/infrastructure/graph/test_{state_mapper,verdict_readout,orchestrator}.py`;
+`tests/unit/infrastructure/test_clock.py`;
+`tests/unit/application/test_get_audit_trail.py`;
+`tests/unit/application/use_cases/test_submit_human_decision.py` (the fold — the
+record and the trail roll back together). `tests/integration/test_assessment_api.py`
+runs the whole flow against real Postgres (assessment/decision/audit tables + the
+LangGraph checkpointer) with a fake model and stub retriever: submit → 202 → read
+→ submit a decision → observe the resumed run and its durable trail.
+`make test-integration` and CI's `integration` job pick it up; CI's `quality` job
+runs the presentation unit tests.
+
+**Downstream.** [M5-05] replaces the synchronous 202 with a Redis queue and adds
+run-status states. [M5-06] adds `/ready`, JSON logging and correlation-id
+propagation. [M5-09] adds the Compose `api` service, the Dockerfile and the CI
+image build, and wires the proxy-header / trusted-host middleware from
+`ObservabilitySettings`.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -286,7 +286,19 @@ One consequence for tests: `tests/integration/conftest.py` drops **every**
 reflected table between tests, checkpoint tables included, and the Alembic replay
 does not bring them back. A checkpointer test creates them itself — which is also
 how `tests/integration/test_human_checkpoint.py` proves `setup()` builds the
-schema from nothing.
+schema from nothing (and `tests/integration/test_assessment_api.py` does the same
+before building the API).
+
+**[M5-04]: one checkpointer connection per orchestrator call.**
+`LangGraphClaimAssessmentOrchestrator.start` / `.resume` each open
+`open_claim_checkpointer` (its own autocommit psycopg connection) and a fresh
+SQLAlchemy session for the run, then close both. Concurrent API requests never
+share either. A pooled connection (`ConnectionPool`) is still the M5 shape; the
+[M5-05] worker model revisits it. On `resume`, the `human_review` node's audit
+write no longer commits on its own — the orchestrator captures the trail and
+`SubmitHumanDecision` writes it through `UnitOfWork.audit`
+(`append_audit_entries`, same `ON CONFLICT DO NOTHING` insert path) in the same
+transaction as the settled `assessment` row.
 
 ## The audit_event table ([M4-09])
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -219,9 +219,10 @@ the rest of `domain/`.
   state.py`; not a DoD entity.
 - **Mappers** — domain/aggregate ↔ ORM row landed in [M5-03]
   (`app/src/infrastructure/database/assessment_mapper.py`). The domain ↔
-  `state.py` Pydantic mapper is deferred to [M5-04]: its only consumer is the
-  LangGraph orchestrator adapter, and `AssessmentRecord.from_orchestrator_result`
-  already bridges the graph-free DTO — this codebase does not land a mapper
-  ahead of its caller (the same call that dropped `RetrievalService` in [M5-02]).
-- **`Claim.policy_ref` as a required field** — [M5-04], when the submission API
-  takes it explicitly.
+  `state.py` Pydantic mapper landed in [M5-04]
+  (`app/src/infrastructure/graph/state_mapper.py`), with its only consumer, the
+  `LangGraphClaimAssessmentOrchestrator` adapter.
+- **`Claim.policy_ref` as a required field** — still `SusepProcess | None`.
+  [M5-04]'s `POST /v1/assessments` takes it explicitly and the orchestrator
+  prepends it to the narrative as a policy header, but a claim submitted without
+  one is still valid (intake extracts it from the text when present).

--- a/docs/HUMAN_CHECKPOINT.md
+++ b/docs/HUMAN_CHECKPOINT.md
@@ -267,9 +267,14 @@ Integration (`make test-integration`, real Postgres):
   The fields the interrupt payload above exposes (`recommendation`,
   `context_sufficient`, `clarification_exhausted`, `missing_information`) are
   all on that record.
-- **[M5-04]** builds the concrete LangGraph-backed orchestrator adapter and the
-  HTTP endpoints on top: `POST .../decision` maps a 422 to a payload the domain
-  rejects, and resumes the run through the port.
+- **[M5-04]** built the concrete LangGraph-backed orchestrator adapter
+  (`infrastructure/graph/orchestrator.py`) and the HTTP endpoints on top:
+  `POST .../decision` maps a payload the domain rejects to a 422 and resumes the
+  run through the port. On the resume path the adapter swaps a
+  `_CapturingAuditSink` in for `SqlAlchemyAuditTrailSink`, so `human_review`'s
+  trail rides back in `OrchestratorResult.audit_records` and
+  `SubmitHumanDecision` commits it in the same transaction as the settled record
+  (`docs/API.md`, `docs/ARCHITECTURE.md` [M5-04]).
 - **[M5-03]** takes the connection story further. `open_claim_checkpointer` opens
   a single connection, which is right for a script or a test and not for a
   service handling concurrent requests; a `ConnectionPool` is the M5 shape. It

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
     "tokenizers>=0.20",
     "pgvector>=0.5.0",
     "snowballstemmer>=2.2",
+    # [M5-04] the HTTP surface. uvicorn's `standard` extra pulls the production
+    # server bits (uvloop, httptools, websockets, watchfiles for `--reload`).
+    "fastapi>=0.128.0",
+    "uvicorn[standard]>=0.34.0",
 ]
 
 [dependency-groups]
@@ -37,6 +41,8 @@ dev = [
     "pre-commit>=4.6.1",
     "pytest>=9.1.1",
     "ruff>=0.16.0",
+    # [M5-04] starlette.testclient (FastAPI's TestClient) needs httpx.
+    "httpx>=0.28.0",
 ]
 
 # Real local embedder (`make embed-chunks`) and cross-encoder reranker

--- a/scripts/eval_end_to_end.py
+++ b/scripts/eval_end_to_end.py
@@ -85,20 +85,18 @@ from infrastructure.evaluation.verdict_metrics import (
     per_class_table_lines,
     verdict_metrics,
 )
+from infrastructure.graph import verdict_readout
 from infrastructure.graph.build import build_claim_graph
 from infrastructure.graph.checkpointer import build_checkpoint_serializer
 from infrastructure.graph.context import GraphContext
 from infrastructure.graph.reasoning_format import parse_reasoning
 from infrastructure.graph.state import AuditEvent, Citation, Recommendation
-from infrastructure.parsing.corpus_artifact import JSONL_PATH
-from scripts.eval_consistency import load_claims
-from scripts.eval_retrieval import (
-    MANIFEST_PATH,
-    load_chunk_corpus,
-    load_corpus,
-    load_document_metadata,
+from infrastructure.rag.retriever_factory import (
+    build_graph_retriever,
+    load_retriever_components,
 )
-from scripts.eval_retrieval_node import _build_adapter
+from scripts.eval_consistency import load_claims
+from scripts.eval_retrieval import MANIFEST_PATH, load_document_metadata
 
 SCHEMA_VERSION = "v1"
 OUTPUT_DIR = Path("eval/runs")
@@ -117,11 +115,10 @@ _RESUME_DECISION: dict[str, Any] = {
 
 # `Recommendation` carries no verdict field by [M4-08]'s design -- everything
 # load-bearing is derived, and the derivation is recorded in the node's audit
-# event as `posture=... verdict=...`. The effective verdict is read from there
-# directly; the posture map below is the fallback, and says why an abstention
-# happened as well as that it did.
-_POSTURE_RE = re.compile(r"posture=(\S+)")
-_VERDICT_RE = re.compile(r"verdict=(\S+)")
+# event as `posture=... verdict=...`. The read is shared with the [M5-04]
+# orchestrator adapter (`infrastructure.graph.verdict_readout`); the posture map
+# below is this script's fallback, and says why an abstention happened as well
+# as that it did.
 _POSTURE_VERDICT: dict[str, str] = {
     "compatible": "compatible",
     "incompatible": "incompatible",
@@ -307,12 +304,7 @@ def build_claim_text(
 
 
 def _posture_of(audit_trail: Sequence[AuditEvent]) -> str | None:
-    for event in reversed(list(audit_trail)):
-        if event.node == "recommendation" and event.node_input:
-            match = _POSTURE_RE.search(event.node_input)
-            if match:
-                return match.group(1)
-    return None
+    return verdict_readout.posture_of(audit_trail)
 
 
 def _effective_verdict(
@@ -320,15 +312,15 @@ def _effective_verdict(
 ) -> str | None:
     """The end-to-end verdict the recommendation node settled on.
 
-    Read from the node's own audit record rather than re-derived here, so the
-    published accuracy scores what the graph decided and not this script's
-    reading of it. Falls back to the posture map only if the record is missing.
+    Read from the node's own audit record rather than re-derived here (shared
+    with the [M5-04] orchestrator adapter in
+    ``infrastructure.graph.verdict_readout``), so the published accuracy scores
+    what the graph decided and not this script's reading of it. ``posture`` is
+    kept for the fallback map below.
     """
-    for event in reversed(list(audit_trail)):
-        if event.node == "recommendation" and event.node_input:
-            match = _VERDICT_RE.search(event.node_input)
-            if match and match.group(1) in _POSTURE_VERDICT.values():
-                return match.group(1)
+    verdict = verdict_readout.effective_verdict(audit_trail)
+    if verdict is not None:
+        return verdict.value
     return _POSTURE_VERDICT.get(posture or "")
 
 
@@ -563,8 +555,7 @@ def run_end_to_end_eval(
     if limit is not None:
         Random(_SHUFFLE_SEED).shuffle(claims)
         claims = claims[:limit]
-    chunks = load_chunk_corpus()
-    corpus = load_corpus(JSONL_PATH)
+    retriever_components = load_retriever_components()
 
     engine = create_engine_from_settings()
     session = create_session_factory(engine=engine)()
@@ -574,7 +565,7 @@ def run_end_to_end_eval(
     excerpts: dict[str, dict[str, str]] = {}
     try:
         assert_chunk_table_ready(session)
-        adapter = _build_adapter(session, chunks, corpus)
+        adapter = build_graph_retriever(session, retriever_components)
         context = GraphContext(
             fast_model=fast_model,
             reasoning_model=reasoning_model,

--- a/scripts/eval_retrieval_node.py
+++ b/scripts/eval_retrieval_node.py
@@ -58,21 +58,14 @@ from infrastructure.graph.context import GraphContext
 from infrastructure.graph.nodes.retrieval import RETRIEVAL_K, retrieval
 from infrastructure.graph.state import Citation, ClaimState, ExtractedEntities
 from infrastructure.parsing.corpus_artifact import JSONL_PATH
-from infrastructure.rag.dense_retriever import DenseRetriever
-from infrastructure.rag.embedding_cache import CachingEmbedder
-from infrastructure.rag.exclusion_co_retrieval import ClauseGraph
-from infrastructure.rag.graph_retrieval_adapter import (
-    GraphRetrievalAdapter,
-    build_clause_index,
+from infrastructure.rag.graph_retrieval_adapter import GraphRetrievalAdapter
+from infrastructure.rag.retriever_factory import (
+    build_graph_retriever,
+    retriever_components_from_corpora,
 )
-from infrastructure.rag.hybrid_retriever import HybridRetriever
-from infrastructure.rag.reranker_cache import CachingReranker
 from scripts.eval_retrieval import (
     GOLDEN_SET_DIR,
     MANIFEST_PATH,
-    _load_query_embedder,
-    _load_reranker,
-    build_lexical_retriever,
     load_chunk_corpus,
     load_corpus,
     load_document_metadata,
@@ -187,15 +180,13 @@ def _stub_llm_settings() -> LlmSettings:
 def _build_adapter(
     session: Any, chunks: Sequence[Any], corpus: Sequence[Any]
 ) -> GraphRetrievalAdapter:
-    embedder = CachingEmbedder(_load_query_embedder())
-    dense = DenseRetriever(session, embedder)
-    hybrid = HybridRetriever(build_lexical_retriever(chunks), dense)
-    reranker = CachingReranker(_load_reranker())
-    return GraphRetrievalAdapter(
-        hybrid,
-        reranker,
-        build_clause_index(chunks),
-        co_retrieval=ClauseGraph(corpus),
+    """Compose the [M3-08] retrieval stack (shared with the [M5-04] API root).
+
+    A thin wrapper over ``infrastructure.rag.retriever_factory`` kept because
+    ``eval_compatibility`` / ``eval_recommendation`` import it by this name.
+    """
+    return build_graph_retriever(
+        session, retriever_components_from_corpora(chunks, corpus)
     )
 
 

--- a/tests/integration/test_assessment_api.py
+++ b/tests/integration/test_assessment_api.py
@@ -1,0 +1,271 @@
+"""The assessment API over the full stack -- [M5-04].
+
+Real Postgres (the assessment / decision / audit tables and the LangGraph
+Postgres checkpointer), the real use cases, the real orchestrator adapter and
+its capturing sink -- only the LLM and the retriever are faked
+(``tests/integration/_checkpoint_fakes.build_fake_context``: a canned-output
+model and a one-clause stub retriever). Proves the DoD end to end: submit ->
+202 + id, read state/recommendation/citations, submit a decision and observe the
+resumed run, read the audit trail.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.orm import Session, sessionmaker
+
+from infrastructure.clock import SystemClock
+from infrastructure.database import (
+    create_engine_from_database_url,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.database.chunk_repository import upsert_chunks
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.rag.chunk_schema import SCHEMA_VERSION, ChunkRecord
+from presentation.app import create_app
+from presentation.dependencies import AppComponents
+from tests.integration._checkpoint_fakes import CLAUSE_ID, build_fake_context
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_stub_clause(session: Session) -> None:
+    """Persist a chunk for the stub retriever's clause so an ``edit`` can cite it."""
+    document_id, _, _ = CLAUSE_ID.partition(":")
+    upsert_chunks(
+        session,
+        [
+            ChunkRecord(
+                schema_version=SCHEMA_VERSION,
+                chunk_id=CLAUSE_ID,
+                document_id=document_id,
+                clause_id=CLAUSE_ID,
+                source_clause_ids=[CLAUSE_ID],
+                chunk_index=0,
+                chunk_count=1,
+                parent_path="1. COBERTURAS",
+                text="1.1 A seguradora cobre colisao.",
+                display_text="1.1 A seguradora cobre colisao.",
+                char_count=31,
+                rule="single",
+                clause_type="coverage",
+                type_source="rule",
+                confidence=None,
+                bundle_section=None,
+                source="text",
+                susep_process="15414.900000/2013-00",
+                insurer="Seguradora Teste",
+                cnpj="00.000.000/0001-00",
+                product_line="CASCO",
+                indemnity_regime="valor_de_mercado",
+                filing_year="2013",
+            )
+        ],
+    )
+    session.commit()
+
+
+def _test_lifespan(database_url: str, session_factory: sessionmaker[Session]) -> object:
+    ids = (f"it-{n}" for n in itertools.count(1))
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.components = AppComponents(
+            clock=SystemClock(),
+            orchestrator=LangGraphClaimAssessmentOrchestrator(
+                context_factory=lambda _session: build_fake_context(),
+                session_factory=session_factory,
+                database_url=database_url,
+            ),
+            uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+            session_factory=session_factory,
+            new_id=lambda: next(ids),
+        )
+        yield
+
+    return lifespan
+
+
+@dataclass
+class Api:
+    """The test client plus the session factory the app runs on."""
+
+    client: TestClient
+    session_factory: sessionmaker[Session]
+
+
+@pytest.fixture
+def api(
+    postgres_database_url: str,
+    migrated_database: None,
+) -> Iterator[Api]:
+    with open_claim_checkpointer(postgres_database_url, setup=True):
+        pass
+    engine = create_engine_from_database_url(postgres_database_url)
+    session_factory = create_session_factory(engine=engine)
+    app = create_app(
+        lifespan=_test_lifespan(postgres_database_url, session_factory)  # type: ignore[arg-type]
+    )
+    with TestClient(app) as test_client:
+        yield Api(client=test_client, session_factory=session_factory)
+    engine.dispose()
+
+
+def _submit(client: TestClient, **body: object) -> str:
+    response = client.post(
+        "/v1/assessments", json={"raw_text": "Bati o carro.", **body}
+    )
+    assert response.status_code == 202, response.text
+    assessment_id = str(response.json()["assessment_id"])
+    assert response.headers["location"] == f"/v1/assessments/{assessment_id}"
+    return assessment_id
+
+
+def test_full_flow_approve(api: Api) -> None:
+    client = api.client
+    assessment_id = _submit(client)
+
+    awaiting = client.get(f"/v1/assessments/{assessment_id}").json()
+    assert awaiting["status"] == "awaiting_review"
+    assert awaiting["verdict"] == "compatible"
+    assert awaiting["citations"], "the recommendation should carry a clause"
+    assert awaiting["reasoning"] and awaiting["recommended_action"]
+
+    assert client.get(f"/v1/assessments/{assessment_id}/audit").json()["entries"] == []
+
+    decided = client.post(
+        f"/v1/assessments/{assessment_id}/decision",
+        json={"decision": "approve", "notes": "conferido"},
+    )
+    assert decided.status_code == 200, decided.text
+    body = decided.json()
+    assert body["status"] == "decided"
+    assert body["decision"]["decision"] == "approve"
+    assert body["decision"]["notes"] == "conferido"
+
+    reread = client.get(f"/v1/assessments/{assessment_id}").json()
+    assert reread["status"] == "decided"
+    assert reread["verdict"] == awaiting["verdict"]
+    assert reread["citations"] == awaiting["citations"]
+    assert reread["reasoning"] == awaiting["reasoning"]
+
+    trail = client.get(f"/v1/assessments/{assessment_id}/audit").json()["entries"]
+    assert trail, "the resumed run wrote its durable trail"
+    assert [e["sequence"] for e in trail] == list(range(len(trail)))
+    last = trail[-1]
+    assert last["node"] == "human_review"
+    assert last["action"] == "human_decision:approve"
+    assert last["payload"]["decision"] == "approve"
+
+    # a second decision on a settled assessment is a conflict
+    again = client.post(
+        f"/v1/assessments/{assessment_id}/decision", json={"decision": "approve"}
+    )
+    assert again.status_code == 409
+    assert again.json()["error"]["code"] == "assessment_already_decided"
+
+
+def test_full_flow_reject(api: Api) -> None:
+    client = api.client
+    assessment_id = _submit(client)
+
+    body = client.post(
+        f"/v1/assessments/{assessment_id}/decision", json={"decision": "reject"}
+    ).json()
+
+    assert body["status"] == "decided"
+    trail = client.get(f"/v1/assessments/{assessment_id}/audit").json()["entries"]
+    assert trail[-1]["action"] == "human_decision:reject"
+
+
+def test_decision_edit_records_the_edited_assessment(api: Api) -> None:
+    client = api.client
+    with api.session_factory() as session:
+        _seed_stub_clause(session)
+
+    assessment_id = _submit(client)
+
+    body = client.post(
+        f"/v1/assessments/{assessment_id}/decision",
+        json={
+            "decision": "edit",
+            "edited": {
+                "verdict": "incompatible",
+                "reasoning": "Exclusao aplicavel.",
+                "recommended_action": "Negar o sinistro.",
+                "confidence": 0.55,
+                "citations": [
+                    {
+                        "clause_id": CLAUSE_ID,
+                        "document_id": CLAUSE_ID.split(":")[0],
+                        "susep_process": "15414.900000/2013-00",
+                        "clause_type": "coverage",
+                        "excerpt": "A seguradora cobre colisao.",
+                    }
+                ],
+            },
+        },
+    )
+    assert body.status_code == 200, body.text
+    edited = body.json()["decision"]["edited_assessment"]
+    assert edited["verdict"] == "incompatible"
+    assert body.json()["verdict"] == "compatible"  # system opinion untouched
+
+
+def test_edit_citing_an_unknown_clause_is_422(api: Api) -> None:
+    client = api.client
+    assessment_id = _submit(client)
+
+    response = client.post(
+        f"/v1/assessments/{assessment_id}/decision",
+        json={
+            "decision": "edit",
+            "edited": {
+                "verdict": "incompatible",
+                "reasoning": "x",
+                "recommended_action": "y",
+                "confidence": 0.5,
+                "citations": [
+                    {
+                        "clause_id": "ghost:9",
+                        "document_id": "ghost",
+                        "susep_process": "15414.900000/2013-00",
+                        "clause_type": "exclusion",
+                        "excerpt": "t",
+                    }
+                ],
+            },
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "unknown_clause"
+
+
+def test_get_unknown_assessment_is_404(api: Api) -> None:
+    response = api.client.get("/v1/assessments/does-not-exist")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "assessment_not_found"
+
+
+def test_the_audit_trail_and_the_record_are_written_atomically(api: Api) -> None:
+    assessment_id = _submit(api.client)
+    api.client.post(
+        f"/v1/assessments/{assessment_id}/decision", json={"decision": "approve"}
+    )
+
+    with api.session_factory() as session:
+        rows = session.execute(
+            text("SELECT count(*) FROM audit_event WHERE thread_id = :tid"),
+            {"tid": assessment_id},
+        ).scalar_one()
+    assert rows > 0  # the fold committed the trail alongside the DECIDED record

--- a/tests/unit/application/fakes.py
+++ b/tests/unit/application/fakes.py
@@ -8,9 +8,11 @@ from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime, timedelta
 
 from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.audit_trail_entry import AuditTrailEntry
 from application.consistency_flag import ConsistencyFlag
 from application.orchestrator_result import OrchestratorResult
 from application.ports.assessment_repository import AssessmentRepository
+from application.ports.audit_trail_writer import AuditTrailWriter
 from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
 from domain.citation import Citation
 from domain.claim import Claim
@@ -98,6 +100,18 @@ def abstain_result(**overrides: object) -> OrchestratorResult:
     }
     fields.update(overrides)
     return make_orchestrator_result(**fields)
+
+
+def make_audit_entry(**overrides: object) -> AuditTrailEntry:
+    fields: dict[str, object] = {
+        "sequence": 0,
+        "timestamp": FIXED_NOW,
+        "node": "recommendation",
+        "action": "consolidate",
+        "node_input": "posture=compatible verdict=compatible n_clauses=1",
+    }
+    fields.update(overrides)
+    return AuditTrailEntry(**fields)  # type: ignore[arg-type]
 
 
 def make_record(**overrides: object) -> AssessmentRecord:
@@ -222,17 +236,70 @@ class InMemoryAssessmentRepository:
         return tuple(rows[offset : offset + limit])
 
 
-class InMemoryUnitOfWork:
-    """A transaction with real rollback: it snapshots the store on entry."""
+AuditStore = dict[str, list[AuditTrailEntry]]
 
-    def __init__(self, store: dict[str, AssessmentRecord]) -> None:
+
+class InMemoryAuditTrailWriter:
+    """Append captured audit entries to a shared store, idempotent on sequence."""
+
+    def __init__(self, store: AuditStore) -> None:
         self._store = store
-        self.assessments: AssessmentRepository = InMemoryAssessmentRepository(store)
+
+    def append(
+        self,
+        *,
+        claim_id: str,
+        thread_id: str,
+        entries: Sequence[AuditTrailEntry],
+    ) -> None:
+        trail = self._store.setdefault(thread_id, [])
+        seen = {entry.sequence for entry in trail}
+        for entry in entries:
+            if entry.sequence not in seen:
+                trail.append(entry)
+                seen.add(entry.sequence)
+        trail.sort(key=lambda entry: entry.sequence)
+
+
+class InMemoryAuditTrailReader:
+    """Read a thread's captured audit trail from a shared store."""
+
+    def __init__(self, store: AuditStore) -> None:
+        self._store = store
+
+    def get_trail(self, assessment_id: str) -> tuple[AuditTrailEntry, ...]:
+        return tuple(
+            sorted(
+                self._store.get(assessment_id, ()),
+                key=lambda entry: entry.sequence,
+            )
+        )
+
+
+class InMemoryUnitOfWork:
+    """A transaction with real rollback: it snapshots both stores on entry."""
+
+    assessments: AssessmentRepository
+    audit: AuditTrailWriter
+
+    def __init__(
+        self,
+        store: dict[str, AssessmentRecord],
+        audit_store: AuditStore | None = None,
+    ) -> None:
+        self._store = store
+        self._audit_store: AuditStore = {} if audit_store is None else audit_store
+        self.assessments = InMemoryAssessmentRepository(store)
+        self.audit = InMemoryAuditTrailWriter(self._audit_store)
         self._snapshot: dict[str, AssessmentRecord] | None = None
+        self._audit_snapshot: AuditStore | None = None
         self.committed = False
 
     def __enter__(self) -> "UnitOfWork":
         self._snapshot = dict(self._store)
+        self._audit_snapshot = {
+            thread: list(trail) for thread, trail in self._audit_store.items()
+        }
         self.committed = False
         return self
 
@@ -240,6 +307,7 @@ class InMemoryUnitOfWork:
         if not self.committed:
             self.rollback()
         self._snapshot = None
+        self._audit_snapshot = None
 
     def commit(self) -> None:
         self.committed = True
@@ -248,11 +316,19 @@ class InMemoryUnitOfWork:
         if self._snapshot is not None:
             self._store.clear()
             self._store.update(self._snapshot)
+        if self._audit_snapshot is not None:
+            self._audit_store.clear()
+            self._audit_store.update(self._audit_snapshot)
 
 
-def make_uow_factory(store: dict[str, AssessmentRecord]) -> UnitOfWorkFactory:
+def make_uow_factory(
+    store: dict[str, AssessmentRecord],
+    audit_store: AuditStore | None = None,
+) -> UnitOfWorkFactory:
+    shared_audit: AuditStore = {} if audit_store is None else audit_store
+
     def _open() -> InMemoryUnitOfWork:
-        return InMemoryUnitOfWork(store)
+        return InMemoryUnitOfWork(store, shared_audit)
 
     return _open
 

--- a/tests/unit/application/test_get_audit_trail.py
+++ b/tests/unit/application/test_get_audit_trail.py
@@ -1,0 +1,42 @@
+"""The GetAuditTrail use case [M5-04]."""
+
+import pytest
+
+from application.audit_trail_entry import AuditTrailEntry
+from application.errors import AssessmentNotFoundError
+from application.use_cases.get_audit_trail import GetAuditTrail
+from tests.unit.application.fakes import (
+    InMemoryAssessmentRepository,
+    InMemoryAuditTrailReader,
+    make_audit_entry,
+    make_record,
+)
+
+
+def _use_case(
+    *, seeded: bool, trail: list[AuditTrailEntry] | None = None
+) -> GetAuditTrail:
+    store = {"a1": make_record(assessment_id="a1")} if seeded else {}
+    return GetAuditTrail(
+        assessments=InMemoryAssessmentRepository(store),
+        audit=InMemoryAuditTrailReader({"a1": trail or []}),
+    )
+
+
+@pytest.mark.unit
+def test_unknown_id_raises_not_found() -> None:
+    with pytest.raises(AssessmentNotFoundError):
+        _use_case(seeded=False)("a1")
+
+
+@pytest.mark.unit
+def test_awaiting_review_assessment_has_an_empty_trail() -> None:
+    assert _use_case(seeded=True)("a1") == ()
+
+
+@pytest.mark.unit
+def test_returns_the_trail_in_sequence_order() -> None:
+    trail = [make_audit_entry(sequence=1), make_audit_entry(sequence=0)]
+    result = _use_case(seeded=True, trail=trail)("a1")
+
+    assert [e.sequence for e in result] == [0, 1]

--- a/tests/unit/application/use_cases/test_submit_human_decision.py
+++ b/tests/unit/application/use_cases/test_submit_human_decision.py
@@ -16,10 +16,13 @@ from domain.human_decision import DecisionOutcome, HumanDecision
 from domain.verdict import Verdict
 from tests.unit.application.fakes import (
     FIXED_NOW,
+    AuditStore,
     FakeClaimAssessmentOrchestrator,
     FixedClock,
     InMemoryAssessmentRepository,
     InMemoryClauseRepository,
+    InMemoryUnitOfWork,
+    make_audit_entry,
     make_citation,
     make_orchestrator_result,
     make_policy_clause,
@@ -35,6 +38,7 @@ def _build(
     record: AssessmentRecord | None = None,
     orchestrator: FakeClaimAssessmentOrchestrator | None = None,
     clauses: InMemoryClauseRepository | None = None,
+    audit_store: AuditStore | None = None,
 ) -> tuple[
     SubmitHumanDecision, dict[str, AssessmentRecord], FakeClaimAssessmentOrchestrator
 ]:
@@ -49,7 +53,7 @@ def _build(
         assessments=InMemoryAssessmentRepository(store),
         clauses=clauses
         or InMemoryClauseRepository([make_policy_clause(clause_id=_KNOWN_CLAUSE_ID)]),
-        uow_factory=make_uow_factory(store),
+        uow_factory=make_uow_factory(store, audit_store),
     )
     return use_case, store, resolved_orch
 
@@ -232,6 +236,60 @@ def test_resume_that_re_pauses_is_a_contract_error() -> None:
         submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.APPROVE)
 
     assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_the_captured_audit_trail_is_persisted_with_the_record() -> None:
+    audit_store: AuditStore = {}
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        resume_result=make_orchestrator_result(
+            awaiting_review=False,
+            audit_records=(
+                make_audit_entry(sequence=0, node="retrieval"),
+                make_audit_entry(
+                    sequence=1, node="human_review", action="human_decision:approve"
+                ),
+            ),
+        )
+    )
+    submit_decision, _, _ = _build(orchestrator=orchestrator, audit_store=audit_store)
+
+    submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.APPROVE)
+
+    assert [e.sequence for e in audit_store["assessment-1"]] == [0, 1]
+
+
+@pytest.mark.unit
+def test_the_fold_is_atomic_record_and_trail_roll_back_together() -> None:
+    seed = make_record(assessment_id="assessment-1")
+    store: dict[str, AssessmentRecord] = {seed.assessment_id: seed}
+    audit_store: AuditStore = {}
+
+    class _FailingUow(InMemoryUnitOfWork):
+        def commit(self) -> None:
+            raise RuntimeError("disk full")
+
+    orchestrator = FakeClaimAssessmentOrchestrator(
+        resume_result=make_orchestrator_result(
+            awaiting_review=False,
+            audit_records=(make_audit_entry(sequence=0),),
+        )
+    )
+    submit_decision = SubmitHumanDecision(
+        clock=FixedClock(),
+        orchestrator=orchestrator,
+        assessments=InMemoryAssessmentRepository(store),
+        clauses=InMemoryClauseRepository([make_policy_clause()]),
+        uow_factory=lambda: _FailingUow(store, audit_store),
+    )
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        submit_decision(assessment_id="assessment-1", decision=DecisionOutcome.APPROVE)
+
+    # both the record update and the audit append ran, then commit failed:
+    # __exit__ rolls both stores back.
+    assert store["assessment-1"].status is AssessmentStatus.AWAITING_REVIEW
+    assert audit_store == {}
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/graph/test_orchestrator.py
+++ b/tests/unit/infrastructure/graph/test_orchestrator.py
@@ -1,0 +1,54 @@
+"""The LangGraph orchestrator adapter's framework-free seams [M5-04].
+
+The compile/invoke/checkpointer path needs a real Postgres and is covered by
+``tests/integration/test_assessment_api.py``. Here: the policy-header prepend and
+the capturing sink, which are pure.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.claim import Claim
+from domain.susep_process import SusepProcess
+from infrastructure.graph.orchestrator import (
+    LangGraphClaimAssessmentOrchestrator,
+    _CapturingAuditSink,
+)
+from infrastructure.graph.state import AuditEvent, AuditRecord
+
+_NOW = datetime(2026, 9, 3, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_claim_text_is_the_narrative_when_no_policy_ref() -> None:
+    claim = Claim(claim_id="c1", raw_text="Bati o carro.", submitted_at=_NOW)
+    assert LangGraphClaimAssessmentOrchestrator._claim_text(claim) == "Bati o carro."
+
+
+@pytest.mark.unit
+def test_claim_text_prepends_the_registered_policy_header() -> None:
+    claim = Claim(
+        claim_id="c1",
+        raw_text="Bati o carro.",
+        submitted_at=_NOW,
+        policy_ref=SusepProcess("15414.610650/2024-59"),
+    )
+
+    text = LangGraphClaimAssessmentOrchestrator._claim_text(claim)
+
+    assert text == (
+        "[Apólice registrada: processo SUSEP 15414.610650/2024-59]\nBati o carro."
+    )
+
+
+@pytest.mark.unit
+def test_capturing_sink_keeps_the_last_full_trail() -> None:
+    sink = _CapturingAuditSink()
+    records = [AuditRecord(AuditEvent(node="retrieval", action="retrieve"))]
+
+    written = sink.record(claim_id="c1", thread_id="a1", records=records)
+
+    assert written == 1
+    assert sink.records == records
+    assert sink.calls == [("c1", "a1")]

--- a/tests/unit/infrastructure/graph/test_state_mapper.py
+++ b/tests/unit/infrastructure/graph/test_state_mapper.py
@@ -1,0 +1,182 @@
+"""The graph state <-> application boundary mapper [M5-04]."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.assessment import Assessment
+from domain.citation import Citation as DomainCitation
+from domain.clause_classification import ClauseType
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+from infrastructure.graph import state
+from infrastructure.graph.state_mapper import (
+    audit_entries_from_records,
+    result_from_final_state,
+    resume_payload,
+)
+
+_SUSEP = "15414.610650/2024-59"
+
+
+def _state_citation(clause_id: str = "doc:1.1") -> state.Citation:
+    return state.Citation(
+        clause_id=clause_id,
+        document_id="doc",
+        susep_process=_SUSEP,
+        clause_type=ClauseType.COVERAGE,
+        relevance_score=0.9,
+        excerpt="A cobertura compreende colisao.",
+    )
+
+
+def _recommendation(**overrides: object) -> state.Recommendation:
+    fields: dict[str, object] = {
+        "recommended_action": "Encaminhar para analise.",
+        "justification": "A colisao esta coberta pela clausula 1.1.",
+        "citations": [_state_citation()],
+        "consistency_flags": [],
+        "confidence": 0.7,
+    }
+    fields.update(overrides)
+    return state.Recommendation(**fields)
+
+
+def _rec_event(
+    verdict: str = "compatible", posture: str = "compatible"
+) -> state.AuditEvent:
+    return state.AuditEvent(
+        node="recommendation",
+        action="consolidate",
+        node_input=f"posture={posture} verdict={verdict} n_clauses=1",
+    )
+
+
+@pytest.mark.unit
+def test_result_from_finished_state() -> None:
+    final_state = {
+        "recommendation": _recommendation(),
+        "audit_trail": [_rec_event()],
+        "context_sufficient": True,
+        "clarification_exhausted": False,
+        "missing_information": [],
+    }
+
+    result = result_from_final_state(final_state, awaiting_review=False)
+
+    assert result.verdict is Verdict.COMPATIBLE
+    assert result.awaiting_review is False
+    assert result.reasoning == "A colisao esta coberta pela clausula 1.1."
+    assert result.recommended_action == "Encaminhar para analise."
+    assert isinstance(result.citations[0].susep_process, SusepProcess)
+    assert result.citations[0].susep_process.value == _SUSEP
+
+
+@pytest.mark.unit
+def test_missing_recommendation_is_a_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="no recommendation"):
+        result_from_final_state({"audit_trail": []}, awaiting_review=True)
+
+
+@pytest.mark.unit
+def test_verdict_falls_back_to_insufficient_information() -> None:
+    final_state = {"recommendation": _recommendation(), "audit_trail": []}
+
+    result = result_from_final_state(final_state, awaiting_review=True)
+
+    assert result.verdict is Verdict.INSUFFICIENT_INFORMATION
+
+
+@pytest.mark.unit
+def test_abstain_recommendation_maps_to_empty_citations() -> None:
+    final_state = {
+        "recommendation": _recommendation(citations=[]),
+        "audit_trail": [_rec_event("insufficient_information", "retrieval_miss")],
+        "context_sufficient": False,
+    }
+
+    result = result_from_final_state(final_state, awaiting_review=True)
+
+    assert result.citations == ()
+    assert result.context_sufficient is False
+
+
+@pytest.mark.unit
+def test_audit_entries_from_records_number_and_flatten() -> None:
+    records = [
+        state.AuditRecord(state.AuditEvent(node="retrieval", action="retrieve")),
+        state.AuditRecord(
+            state.AuditEvent(
+                node="compatibility",
+                action="assess",
+                token_usage=state.TokenUsage(
+                    input_tokens=10, output_tokens=5, total_tokens=15
+                ),
+            ),
+            {"detail": 1},
+        ),
+    ]
+
+    entries = audit_entries_from_records(records)
+
+    assert [e.sequence for e in entries] == [0, 1]
+    assert entries[1].input_tokens == 10
+    assert entries[1].total_tokens == 15
+    assert entries[1].payload == {"detail": 1}
+    assert entries[0].input_tokens is None
+
+
+@pytest.mark.unit
+def test_resume_payload_for_approve() -> None:
+    decision = HumanDecision(
+        assessment_id="a1",
+        decision=DecisionOutcome.APPROVE,
+        decided_at=datetime(2026, 9, 3, tzinfo=UTC),
+        notes="ok",
+    )
+
+    payload = resume_payload(decision)
+
+    assert payload == {
+        "decision": "approve",
+        "notes": "ok",
+        "decided_at": "2026-09-03T00:00:00+00:00",
+    }
+
+
+@pytest.mark.unit
+def test_resume_payload_for_edit_carries_a_flat_recommendation() -> None:
+    edited = Assessment(
+        assessment_id="a1",
+        claim_id="c1",
+        verdict=Verdict.INCOMPATIBLE,
+        reasoning="Exclusao aplicavel.",
+        citations=(
+            DomainCitation(
+                clause_id="doc:3.1",
+                document_id="doc",
+                susep_process=SusepProcess(_SUSEP),
+                clause_type=ClauseType.EXCLUSION,
+                excerpt="trecho",
+            ),
+        ),
+        confidence=0.6,
+        recommended_action="Negar.",
+    )
+    decision = HumanDecision(
+        assessment_id="a1",
+        decision=DecisionOutcome.EDIT,
+        decided_at=datetime(2026, 9, 3, tzinfo=UTC),
+        edited_assessment=edited,
+    )
+
+    payload = resume_payload(decision)
+    edited_rec = payload["edited_recommendation"]
+
+    assert isinstance(edited_rec, dict)
+    assert edited_rec["justification"] == "Exclusao aplicavel."
+    assert edited_rec["consistency_flags"] == []
+    # the mapping round-trips through the graph twin's validator
+    graph_decision = state.HumanDecision.model_validate(payload)
+    assert graph_decision.edited_recommendation is not None

--- a/tests/unit/infrastructure/graph/test_verdict_readout.py
+++ b/tests/unit/infrastructure/graph/test_verdict_readout.py
@@ -1,0 +1,48 @@
+"""Reading the effective verdict from the recommendation node's audit event [M4-08]."""
+
+import pytest
+
+from domain.verdict import Verdict
+from infrastructure.graph.state import AuditEvent
+from infrastructure.graph.verdict_readout import effective_verdict, posture_of
+
+
+def _rec(node_input: str) -> AuditEvent:
+    return AuditEvent(
+        node="recommendation", action="consolidate", node_input=node_input
+    )
+
+
+@pytest.mark.unit
+def test_reads_the_explicit_verdict_token() -> None:
+    trail = [_rec("posture=incompatible verdict=incompatible n_clauses=2")]
+    assert effective_verdict(trail) is Verdict.INCOMPATIBLE
+
+
+@pytest.mark.unit
+def test_falls_back_to_the_posture_map() -> None:
+    trail = [_rec("posture=retrieval_miss n_clauses=0")]
+    assert effective_verdict(trail) is Verdict.INSUFFICIENT_INFORMATION
+
+
+@pytest.mark.unit
+def test_uses_the_last_recommendation_event() -> None:
+    trail = [
+        _rec("posture=compatible verdict=compatible"),
+        AuditEvent(node="human_review", action="human_decision:approve"),
+        _rec("posture=incompatible verdict=incompatible"),
+    ]
+    assert effective_verdict(trail) is Verdict.INCOMPATIBLE
+
+
+@pytest.mark.unit
+def test_none_when_no_recommendation_event() -> None:
+    trail = [AuditEvent(node="retrieval", action="retrieve_clauses", node_input="x")]
+    assert effective_verdict(trail) is None
+    assert posture_of(trail) is None
+
+
+@pytest.mark.unit
+def test_posture_of_extracts_the_posture() -> None:
+    trail = [_rec("posture=claimant_gaps verdict=insufficient_information")]
+    assert posture_of(trail) == "claimant_gaps"

--- a/tests/unit/infrastructure/test_clock.py
+++ b/tests/unit/infrastructure/test_clock.py
@@ -1,0 +1,18 @@
+"""The SystemClock [M5-04]."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from infrastructure.clock import SystemClock
+
+
+@pytest.mark.unit
+def test_now_is_timezone_aware_utc_and_current() -> None:
+    before = datetime.now(UTC)
+    now = SystemClock().now()
+    after = datetime.now(UTC)
+
+    assert now.tzinfo is not None
+    assert now.utcoffset() == UTC.utcoffset(None)
+    assert before <= now <= after

--- a/tests/unit/presentation/conftest.py
+++ b/tests/unit/presentation/conftest.py
@@ -1,0 +1,100 @@
+"""A ``TestClient`` wired to the in-memory application fakes -- [M5-04].
+
+The FastAPI app is built with its production lifespan intact but never entered
+(``TestClient`` runs lifespan only as a context manager), so the composition
+root never touches Postgres, LLMs or the retriever. Every use-case provider is
+overridden to build the interactor against ``tests/unit/application/fakes.py``.
+A test can reassign ``harness.orchestrator`` before a request to change the
+canned graph behaviour.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+import pytest
+from fastapi.testclient import TestClient
+
+from application.assessment_record import AssessmentRecord
+from application.audit_trail_entry import AuditTrailEntry
+from application.use_cases.get_assessment import GetAssessment
+from application.use_cases.get_audit_trail import GetAuditTrail
+from application.use_cases.list_assessments import ListAssessments
+from application.use_cases.submit_claim import SubmitClaim
+from application.use_cases.submit_human_decision import SubmitHumanDecision
+from domain.policy_clause import PolicyClause
+from presentation.app import create_app
+from presentation.dependencies import (
+    get_get_assessment,
+    get_get_audit_trail,
+    get_list_assessments,
+    get_submit_claim,
+    get_submit_human_decision,
+)
+from tests.unit.application.fakes import (
+    FakeClaimAssessmentOrchestrator,
+    FixedClock,
+    InMemoryAssessmentRepository,
+    InMemoryAuditTrailReader,
+    InMemoryClauseRepository,
+    SequentialIds,
+    make_uow_factory,
+)
+
+
+@dataclass
+class Harness:
+    """Everything a presentation test needs to drive and inspect the API."""
+
+    client: TestClient
+    store: dict[str, AssessmentRecord]
+    audit_store: dict[str, list[AuditTrailEntry]]
+    clauses: dict[str, PolicyClause] = field(default_factory=dict)
+    clock: FixedClock = field(default_factory=FixedClock)
+    ids: SequentialIds = field(default_factory=lambda: SequentialIds("api"))
+    orchestrator: FakeClaimAssessmentOrchestrator = field(
+        default_factory=FakeClaimAssessmentOrchestrator
+    )
+
+
+@pytest.fixture
+def harness() -> Iterator[Harness]:
+    app = create_app()
+    store: dict[str, AssessmentRecord] = {}
+    audit_store: dict[str, list[AuditTrailEntry]] = {}
+    h = Harness(
+        client=TestClient(app, raise_server_exceptions=False),
+        store=store,
+        audit_store=audit_store,
+    )
+
+    def _assessments() -> InMemoryAssessmentRepository:
+        return InMemoryAssessmentRepository(store)
+
+    app.dependency_overrides[get_submit_claim] = lambda: SubmitClaim(
+        clock=h.clock,
+        orchestrator=h.orchestrator,
+        uow_factory=make_uow_factory(store, audit_store),
+        new_id=h.ids,
+    )
+    app.dependency_overrides[get_get_assessment] = lambda: GetAssessment(
+        assessments=_assessments()
+    )
+    app.dependency_overrides[get_list_assessments] = lambda: ListAssessments(
+        assessments=_assessments()
+    )
+    app.dependency_overrides[get_submit_human_decision] = lambda: SubmitHumanDecision(
+        clock=h.clock,
+        orchestrator=h.orchestrator,
+        assessments=_assessments(),
+        clauses=InMemoryClauseRepository(h.clauses.values()),
+        uow_factory=make_uow_factory(store, audit_store),
+    )
+    app.dependency_overrides[get_get_audit_trail] = lambda: GetAuditTrail(
+        assessments=_assessments(),
+        audit=InMemoryAuditTrailReader(audit_store),
+    )
+
+    yield h
+    app.dependency_overrides.clear()

--- a/tests/unit/presentation/test_assessments_api.py
+++ b/tests/unit/presentation/test_assessments_api.py
@@ -1,0 +1,435 @@
+"""Endpoint behaviour and the error -> HTTP mapping -- [M5-04].
+
+Driven through ``tests/unit/presentation/conftest.py``'s ``TestClient`` wired to
+the in-memory application fakes: no Postgres, no graph, no LLM.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from domain.citation import Citation
+from domain.clause_classification import ClauseType
+from domain.human_decision import DecisionOutcome, HumanDecision
+from domain.susep_process import SusepProcess
+from domain.verdict import Verdict
+from tests.unit.application.fakes import (
+    FIXED_NOW,
+    SUSEP,
+    FakeClaimAssessmentOrchestrator,
+    make_audit_entry,
+    make_citation,
+    make_orchestrator_result,
+    make_policy_clause,
+    make_record,
+)
+from tests.unit.presentation.conftest import Harness
+
+_CANONICAL_SUSEP = "15414.610650/2024-59"
+
+
+# --------------------------------------------------------------------------- #
+# POST /v1/assessments
+# --------------------------------------------------------------------------- #
+
+
+def test_submit_claim_returns_202_with_id_and_location(harness: Harness) -> None:
+    response = harness.client.post(
+        "/v1/assessments", json={"raw_text": "Bati o carro."}
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assessment_id = body["assessment_id"]
+    assert body["status"] == "awaiting_review"
+    assert response.headers["location"] == f"/v1/assessments/{assessment_id}"
+    stored = harness.store[assessment_id]
+    assert stored.status is AssessmentStatus.AWAITING_REVIEW
+
+
+def test_submit_claim_empty_narrative_is_422_validation(harness: Harness) -> None:
+    response = harness.client.post("/v1/assessments", json={"raw_text": ""})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "request_validation_error"
+
+
+def test_submit_claim_bad_policy_ref_is_422(harness: Harness) -> None:
+    response = harness.client.post(
+        "/v1/assessments", json={"raw_text": "x", "policy_ref": "not-a-susep"}
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_susep_process"
+
+
+def test_submit_claim_threads_policy_ref_into_the_claim(harness: Harness) -> None:
+    harness.client.post(
+        "/v1/assessments", json={"raw_text": "x", "policy_ref": _CANONICAL_SUSEP}
+    )
+
+    _, claim = harness.orchestrator.started[0]
+    assert claim.policy_ref == SusepProcess(_CANONICAL_SUSEP)
+
+
+def test_submit_claim_orchestrator_not_pausing_is_502(harness: Harness) -> None:
+    harness.orchestrator = FakeClaimAssessmentOrchestrator(
+        start_result=make_orchestrator_result(awaiting_review=False)
+    )
+
+    response = harness.client.post("/v1/assessments", json={"raw_text": "x"})
+
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "orchestrator_contract_error"
+
+
+# --------------------------------------------------------------------------- #
+# GET /v1/assessments/{id}  +  GET /v1/assessments
+# --------------------------------------------------------------------------- #
+
+
+def test_get_assessment_returns_structured_citations(harness: Harness) -> None:
+    harness.store["a1"] = make_record(assessment_id="a1")
+
+    body = harness.client.get("/v1/assessments/a1").json()
+
+    assert body["verdict"] == "compatible"
+    assert body["is_grounded"] is True
+    citation = body["citations"][0]
+    assert set(citation) == {
+        "clause_id",
+        "document_id",
+        "susep_process",
+        "clause_type",
+        "excerpt",
+        "relevance_score",
+    }
+    assert body["decision"] is None
+
+
+def test_get_assessment_abstain_record_has_empty_citations(harness: Harness) -> None:
+    harness.store["a1"] = make_record(
+        assessment_id="a1",
+        citations=(),
+        verdict=Verdict.INSUFFICIENT_INFORMATION,
+    )
+
+    body = harness.client.get("/v1/assessments/a1").json()
+
+    assert body["citations"] == []
+    assert body["is_grounded"] is False
+
+
+def test_get_unknown_assessment_is_404(harness: Harness) -> None:
+    response = harness.client.get("/v1/assessments/nope")
+
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == "assessment_not_found"
+    assert error["details"] == {"assessment_id": "nope"}
+
+
+def test_list_assessments_newest_first_with_filters(harness: Harness) -> None:
+    harness.store["old"] = make_record(
+        assessment_id="old", claim_id="c1", created_at=FIXED_NOW - timedelta(hours=1)
+    )
+    harness.store["new"] = make_record(
+        assessment_id="new", claim_id="c1", created_at=FIXED_NOW
+    )
+    harness.store["other"] = make_record(assessment_id="other", claim_id="c2")
+
+    rows = harness.client.get("/v1/assessments", params={"claim_id": "c1"}).json()
+
+    assert [r["assessment_id"] for r in rows] == ["new", "old"]
+
+
+def test_list_assessments_rejects_bad_paging(harness: Harness) -> None:
+    assert harness.client.get("/v1/assessments", params={"limit": 0}).status_code == 422
+    assert (
+        harness.client.get("/v1/assessments", params={"offset": -1}).status_code == 422
+    )
+
+
+# --------------------------------------------------------------------------- #
+# POST /v1/assessments/{id}/decision
+# --------------------------------------------------------------------------- #
+
+
+def _awaiting(assessment_id: str = "a1", **overrides: object) -> AssessmentRecord:
+    return make_record(assessment_id=assessment_id, **overrides)
+
+
+def test_decision_approve_settles_the_record(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    body = harness.client.post(
+        "/v1/assessments/a1/decision",
+        json={"decision": "approve", "notes": "conferido"},
+    ).json()
+
+    assert body["status"] == "decided"
+    assert body["decision"]["decision"] == "approve"
+    assert body["decision"]["notes"] == "conferido"
+    assert harness.orchestrator.resumed[0][0] == "a1"
+    # system opinion unchanged
+    assert body["verdict"] == "compatible"
+
+
+def test_decision_reject_settles_the_record(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    body = harness.client.post(
+        "/v1/assessments/a1/decision", json={"decision": "reject"}
+    ).json()
+
+    assert body["decision"]["decision"] == "reject"
+
+
+def test_decision_edit_records_the_edited_assessment(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+    harness.clauses["c:1"] = make_policy_clause(clause_id="c:1")
+
+    payload = {
+        "decision": "edit",
+        "edited": {
+            "verdict": "incompatible",
+            "reasoning": "Exclusão aplicável.",
+            "recommended_action": "Negar.",
+            "confidence": 0.6,
+            "citations": [
+                {
+                    "clause_id": "c:1",
+                    "document_id": "doc",
+                    "susep_process": _CANONICAL_SUSEP,
+                    "clause_type": "exclusion",
+                    "excerpt": "trecho",
+                }
+            ],
+        },
+    }
+    body = harness.client.post("/v1/assessments/a1/decision", json=payload).json()
+
+    assert body["decision"]["edited_assessment"]["verdict"] == "incompatible"
+    # the system's own verdict is untouched
+    assert body["verdict"] == "compatible"
+
+
+def test_decision_edit_without_payload_is_422(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision", json={"decision": "edit"}
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_decision_non_edit_carrying_payload_is_422(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision",
+        json={
+            "decision": "approve",
+            "edited": {
+                "verdict": "compatible",
+                "reasoning": "x",
+                "recommended_action": "y",
+                "confidence": 0.5,
+                "citations": [],
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_decision_edit_citing_unknown_clause_is_422(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision",
+        json={
+            "decision": "edit",
+            "edited": {
+                "verdict": "incompatible",
+                "reasoning": "x",
+                "recommended_action": "y",
+                "confidence": 0.5,
+                "citations": [
+                    {
+                        "clause_id": "ghost:9",
+                        "document_id": "doc",
+                        "susep_process": _CANONICAL_SUSEP,
+                        "clause_type": "exclusion",
+                        "excerpt": "t",
+                    }
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error["code"] == "unknown_clause"
+    assert error["details"] == {"clause_ids": ["ghost:9"]}
+
+
+def test_decision_edit_citing_nothing_is_422_citation_required(
+    harness: Harness,
+) -> None:
+    harness.store["a1"] = _awaiting()
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision",
+        json={
+            "decision": "edit",
+            "edited": {
+                "verdict": "incompatible",
+                "reasoning": "x",
+                "recommended_action": "y",
+                "confidence": 0.5,
+                "citations": [],
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error["code"] == "citation_required"
+    assert error["details"] == {"assessment_id": "a1"}
+
+
+def test_decision_on_decided_assessment_is_409(harness: Harness) -> None:
+    decision = HumanDecision(
+        assessment_id="a1",
+        decision=DecisionOutcome.APPROVE,
+        decided_at=FIXED_NOW,
+    )
+    harness.store["a1"] = make_record(
+        assessment_id="a1", status=AssessmentStatus.DECIDED, decision=decision
+    )
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision", json={"decision": "approve"}
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "assessment_already_decided"
+
+
+def test_decision_on_unknown_assessment_is_404(harness: Harness) -> None:
+    response = harness.client.post(
+        "/v1/assessments/ghost/decision", json={"decision": "approve"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_decision_orchestrator_not_finishing_is_502(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+    harness.orchestrator = FakeClaimAssessmentOrchestrator(
+        resume_result=make_orchestrator_result(awaiting_review=True)
+    )
+
+    response = harness.client.post(
+        "/v1/assessments/a1/decision", json={"decision": "approve"}
+    )
+
+    assert response.status_code == 502
+
+
+# --------------------------------------------------------------------------- #
+# GET /v1/assessments/{id}/audit
+# --------------------------------------------------------------------------- #
+
+
+def test_audit_unknown_assessment_is_404(harness: Harness) -> None:
+    assert harness.client.get("/v1/assessments/ghost/audit").status_code == 404
+
+
+def test_audit_empty_before_a_decision(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+
+    body = harness.client.get("/v1/assessments/a1/audit").json()
+
+    assert body == {"assessment_id": "a1", "entries": []}
+
+
+def test_audit_returns_the_trail_in_sequence_order(harness: Harness) -> None:
+    harness.store["a1"] = _awaiting()
+    harness.audit_store["a1"] = [
+        make_audit_entry(
+            sequence=1,
+            node="human_review",
+            action="human_decision:approve",
+            payload={"decision": "approve"},
+        ),
+        make_audit_entry(sequence=0, node="retrieval", action="retrieve_clauses"),
+    ]
+
+    body = harness.client.get("/v1/assessments/a1/audit").json()
+
+    assert [e["sequence"] for e in body["entries"]] == [0, 1]
+    assert body["entries"][-1]["node"] == "human_review"
+    assert body["entries"][-1]["payload"] == {"decision": "approve"}
+
+
+# --------------------------------------------------------------------------- #
+# the error envelope / catch-all
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("path", ["/v1/assessments/x", "/v1/assessments/x/audit"])
+def test_error_envelope_shape(harness: Harness, path: str) -> None:
+    body = harness.client.get(path).json()
+
+    assert set(body) == {"error"}
+    assert set(body["error"]) == {"code", "message", "details"}
+
+
+def test_unexpected_error_is_logged_500_without_traceback(harness: Harness) -> None:
+    boom = RuntimeError("kaboom")
+    harness.orchestrator = FakeClaimAssessmentOrchestrator(raise_on_start=boom)
+
+    response = harness.client.post("/v1/assessments", json={"raw_text": "x"})
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"]["code"] == "internal_error"
+    assert "kaboom" not in body["error"]["message"]
+
+
+def test_health_is_ok(harness: Harness) -> None:
+    assert harness.client.get("/health").json() == {"status": "ok"}
+
+
+def test_citation_value_objects_render_as_canonical_strings(harness: Harness) -> None:
+    harness.store["a1"] = make_record(
+        assessment_id="a1",
+        citations=(
+            make_citation(
+                clause_id="c:2",
+                susep_process=SUSEP,
+                clause_type=ClauseType.EXCLUSION,
+            ),
+        ),
+    )
+
+    citation = harness.client.get("/v1/assessments/a1").json()["citations"][0]
+
+    assert citation["susep_process"] == SUSEP.value
+    assert citation["clause_type"] == "exclusion"
+    # sanity: the value object round-trips
+    assert Citation(
+        clause_id="c:2",
+        document_id="d",
+        susep_process=SusepProcess(citation["susep_process"]),
+        clause_type=ClauseType(citation["clause_type"]),
+        excerpt="e",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -523,6 +541,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
 name = "fastjsonschema"
 version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +698,42 @@ wheels = [
 ]
 
 [[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -756,6 +826,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "fastapi" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
@@ -774,10 +845,12 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "ipykernel" },
     { name = "langchain-anthropic" },
     { name = "mypy" },
@@ -794,6 +867,7 @@ embed = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.19.1" },
+    { name = "fastapi", specifier = ">=0.128.0" },
     { name = "langchain-core", specifier = ">=1.5.5" },
     { name = "langchain-openai", specifier = ">=1.5.1" },
     { name = "langgraph", specifier = ">=1.2" },
@@ -812,10 +886,12 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.52" },
     { name = "tokenizers", specifier = ">=0.20" },
     { name = "tqdm", specifier = ">=4.67" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "ipykernel", specifier = ">=7.3.0" },
     { name = "langchain-anthropic", specifier = ">=0.3" },
     { name = "mypy", specifier = ">=2.3.0" },
@@ -2942,6 +3018,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3281,6 +3370,61 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3293,6 +3437,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the HTTP surface over the [M5-02] use cases, plus the three infrastructure
pieces the application layer was designed around but deliberately left unbuilt.

**Presentation (`app/src/presentation/`)**
- `app.py` — `create_app(*, lifespan=None)` + `_default_lifespan` composition
  root; module-level `app` for `uvicorn presentation.app:app`.
- `routes/assessments.py` — five endpoints:
  - `POST /v1/assessments` → **202** + `Location` + `{assessment_id}`
  - `GET /v1/assessments` (list, newest first) and `GET /v1/assessments/{id}`
  - `POST /v1/assessments/{id}/decision` → 200 (resumes the paused run)
  - `GET /v1/assessments/{id}/audit`
- `routes/health.py` — `GET /health` (no dependency access; `/ready` is [M5-06]).
- `schemas.py` / `mappers.py` — Pydantic models; citations are structured
  objects, enums/value objects render as canonical strings.
- `errors.py` — one Starlette exception-handler layer mapping every
  `application.errors` / `domain.errors` type to an HTTP status + a stable
  string `code` in the envelope `{"error": {"code","message","details"}}`.
- `dependencies.py` — `Annotated[T, Depends(...)]` providers, one use case per
  request, each overridable in tests.

**Infrastructure**
- `graph/orchestrator.py` — `LangGraphClaimAssessmentOrchestrator`, the concrete
  `ClaimAssessmentOrchestrator` (`assessment_id` == `thread_id`, one checkpointer
  connection + one session per call, `_CapturingAuditSink`).
- `graph/state_mapper.py` — the deferred `state.py` ↔ domain mapper
  (`result_from_final_state`, `resume_payload`, `audit_entries_from_records`).
- `graph/verdict_readout.py` — verdict-from-audit-event, extracted from
  `scripts/eval_end_to_end.py` (which now imports it).
- `clock.py` — `SystemClock`.
- `rag/retriever_factory.py` — the shared retrieval-stack builder;
  `eval_end_to_end.py` and `eval_retrieval_node._build_adapter` refactored onto
  it.
- `database/audit_trail_{reader,writer}

**Config** — `fastapi` + `uvicorn[standard]` added to deps, `httpx` to the dev
group, `uv.lock` regenerated, `.pre-commit-config.yaml` mypy deps updated,
`make serve` target added.

## Related issue

[M5-04]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
      — `tests/unit/presentation/**` (every endpoint's happy path and every
      error→status mapping, via `app.dependency_overrides` against the in-memory
      fakes — no Postgres/graph/LLM);
      `tests/unit/infrastructure/graph/test_{state_mapper,verdict_readout,orchestrator}.py`;
      `tests/unit/infrastructure/test_clock.py`;
      `tests/unit/application/test_get_audit_trail.py`;
      `tests/unit/application/use_cases/test_submit_human_decision.py` extended
      for the fold (record + trail roll back together);
      `tests/integration/test_assessment_api.py` — full flow against real
      Postgres + the LangGraph checkpointer with a fake model and stub retriever
      (submit → 202 → read state/recommendation/citations → submit a decision →
      observe the resumed run and its durable trail; reject / edit / unknown-
      clause / unknown-id / fold-atomicity). 1281 unit + 72 integration pass.
- [x] Docs updated — new `docs/API.md`; new `## The HTTP surface …` section in
      `docs/ARCHITECTURE.md`; `docs/DATABASE.md`, `docs/DOMAIN.md`,
      `docs/HUMAN_CHECKPOINT.md` "deferred / leaves for later" lines updated;
      `README.md` "Run the assessment API" section.
- [x] Evaluation impact considered — none. `policy_ref` uses the existing
      measured text-header path (no graph change); `verdict_readout.py` and
      `retriever_factory.py` are pure extractions of existing eval-script logic,
      exercised by the unchanged `make eval-*` targets.
- [x] `make check` passes locally (ruff, ruff format, mypy --strict, unit
      tests); `pre-commit run --all-files` and `make test-integration` also pass.