### PR TITLE
feat(infrastructure): run assessments on a Redis/RQ queue behind the …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,8 +82,23 @@ RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base
 # LLM_CLASSIFICATION_MAX_WORKERS. Lower it on a memory-constrained machine.
 EMBEDDING_BATCH_SIZE=
 
-# Redis configuration
+# Asynchronous processing -- [M5-05]
+# The queue `make worker` drains and `POST /v1/assessments` writes to.
 REDIS_URL=redis://localhost:6379/0
+# Redis `make test-integration` uses (defaults to REDIS_URL's host if unset).
+TEST_REDIS_URL=redis://localhost:6379/0
+# Concurrent assessment runs (== worker processes). This is the parallelism
+# bound on the LLM provider. Keep at 1 on a memory-constrained box -- each
+# worker loads the embedder + cross-encoder. Default: 2.
+ASSESSMENT_WORKER_CONCURRENCY=
+# Total attempt budget for a job on *transient* provider failures (429 / 5xx /
+# dropped connection). Real errors are never retried. Default: 3.
+ASSESSMENT_MAX_RETRIES=
+# Wait before each retry, seconds, as a JSON list (repeats its last value if
+# shorter than the retry count). Default: [30, 120, 300].
+ASSESSMENT_RETRY_BACKOFF_SECONDS=
+# How long one queued assessment may run before RQ kills it. Default: 1800.
+ASSESSMENT_JOB_TIMEOUT_SECONDS=
 
 # Text extraction
 # A page with fewer extracted characters than this is flagged as a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,21 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        # [M5-05]: the assessment queue's integration test does a real Redis
+        # round-trip. Same major as compose.yaml.
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     env:
       TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/insurance_claims_test
+      TEST_REDIS_URL: redis://127.0.0.1:6379/0
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,10 @@ repos:
           - alembic>=1.19.1
           - pgvector>=0.5.0
           - tokenizers>=0.20
+          # [M5-05]: infrastructure/queue/* and infrastructure/llm_errors.py.
+          - rq>=2.0
+          - redis>=5.0
+          - openai>=3.0
   - repo: https://github.com/kynan/nbstripout
     rev: 0.9.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check serve migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check serve worker migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -14,6 +14,7 @@ help:
 	@echo "  test-eval         - Run the eval-marked pytest suite (requires build/parsed_clauses.jsonl; run fetch-corpus-artifacts or parse first)"
 	@echo "  check             - Run all checks (lint, format-check, typecheck, test)"
 	@echo "  serve             - M5-04: run the assessment API locally (uvicorn presentation.app:app on :8000; needs make migrate + setup-checkpointer + build-index and LLM_* in .env)"
+	@echo "  worker            - M5-05: run the assessment worker pool draining the Redis queue (ASSESSMENT_WORKER_CONCURRENCY workers; needs the same setup as serve + a running Redis)"
 	@echo "  migrate           - Apply Alembic migrations to the configured database"
 	@echo "  migrate-down      - Roll back the latest Alembic migration"
 	@echo "  setup-checkpointer - M4-09: run the LangGraph Postgres checkpointer's own migrations (its tables live outside Alembic); idempotent, acts on the same DATABASE_URL as make migrate"
@@ -98,6 +99,9 @@ check: lint format-check typecheck test
 
 serve:
 	PYTHONPATH=app/src uv run --group embed uvicorn presentation.app:app --reload --port 8000
+
+worker:
+	PYTHONPATH=app/src uv run --group embed python -m scripts.run_assessment_worker
 
 migrate:
 	PYTHONPATH=app/src uv run alembic upgrade head

--- a/README.md
+++ b/README.md
@@ -52,19 +52,20 @@ Copy the example file and fill in the values for your environment:
 cp .env.example .env
 ```
 
-### Database (Postgres + pgvector)
+### Database (Postgres + pgvector) and Redis
 
 Postgres is required by the retrieval index, the LangGraph checkpointer and
-the audit trail. Bring it up locally, in this order, on a clean clone:
+the audit trail; Redis backs the asynchronous assessment queue ([M5-05]).
+Bring both up locally, in this order, on a clean clone:
 
 ```bash
 cp .env.example .env
-docker compose up -d postgres
+docker compose up -d          # postgres + redis
 make migrate
 make setup-checkpointer
 ```
 
-The `.env.example` defaults match the Compose service, so the sequence works
+The `.env.example` defaults match the Compose services, so the sequence works
 as written without editing anything first. `make migrate` applies the Alembic
 migrations (the first one enables the `vector` extension); `make migrate-down`
 rolls the latest one back. `make setup-checkpointer` is the second half of the
@@ -116,19 +117,24 @@ Score every retrieval configuration on the golden set with
 `make eval-retrieval-matrix` — the committed comparison table and verdict are in
 [`docs/RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md).
 
-### Run the assessment API
+### Run the assessment API and the worker
 
 Once the schema, the checkpointer and the index are in place:
 
 ```bash
-make serve           # uvicorn presentation.app:app on :8000
+make serve           # the API: uvicorn presentation.app:app on :8000
+make worker          # the queue workers (a second shell)
 ```
 
-`POST /v1/assessments` submits a claim, `GET /v1/assessments/{id}` reads its
-state and recommendation, `POST /v1/assessments/{id}/decision` submits the human
-decision and resumes the run, `GET /v1/assessments/{id}/audit` returns the audit
-trail. Endpoint shapes, the error codes and the design notes are in
-[`docs/API.md`](docs/API.md). The Docker Compose stack is [M5-09].
+`POST /v1/assessments` submits a claim (202, `status: "pending"`); a worker runs
+the graph in the background. `GET /v1/assessments/{id}` reads its lifecycle state
+(`pending` → `running` → `awaiting_review`, or `failed`) and, once ready, the
+recommendation. `POST /v1/assessments/{id}/decision` submits the human decision
+and resumes the run; `GET /v1/assessments/{id}/audit` returns the audit trail.
+Endpoint shapes and error codes are in [`docs/API.md`](docs/API.md); the queue,
+the retry/back-off policy and the dead-letter path are in
+[`docs/ASYNC_PROCESSING.md`](docs/ASYNC_PROCESSING.md). The `api` / `worker`
+Compose services (and their Dockerfile) are [M5-09].
 
 ### Pre-commit hooks
 

--- a/alembic/versions/20260904_01_create_assessment_job_table.py
+++ b/alembic/versions/20260904_01_create_assessment_job_table.py
@@ -1,0 +1,74 @@
+"""Create the assessment_job table.
+
+[M5-05]'s queued-run lifecycle: the persistence side of
+[application.assessment_job.AssessmentJob]. ``POST /v1/assessments`` no longer
+runs the graph in the request -- it writes one of these rows in ``pending`` and a
+Redis worker picks it up. The row carries the run state a caller polls
+(``pending`` -> ``running`` -> ``succeeded`` / ``failed``) and everything a
+worker needs to rebuild the domain ``Claim`` after a retry or a redelivery.
+
+``failure`` is ``JSONB`` (``kind`` / ``error_type`` / ``message`` /
+``failed_at``): a frozen value object read whole with the row, never queried by
+field. ``status`` is ``TEXT`` + a named CHECK (chunk / assessment precedent). No
+FK to ``assessment``: the job row exists before any assessment does, and a failed
+run keeps its job row without ever producing one.
+
+The status value list is a plain literal here (like ``20260903_01``) so the
+migration imports no app code; ``tests/unit/infrastructure/database/test_models.py``
+ties the model's CHECK back to ``JobStatus``.
+
+Revision ID: 20260904_01
+Revises: 20260903_02
+Create Date: 2026-09-04 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260904_01"
+down_revision: str | None = "20260903_02"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_STATUS_VALUES = ("pending", "running", "succeeded", "failed")
+
+
+def _in_check(column: str, values: Sequence[str]) -> str:
+    """Render ``column IN ('a', 'b', ...)`` for a CHECK constraint."""
+    rendered = ", ".join(f"'{value}'" for value in values)
+    return f"{column} IN ({rendered})"
+
+
+def upgrade() -> None:
+    """Create `assessment_job` and its two query indexes."""
+    op.create_table(
+        "assessment_job",
+        sa.Column("assessment_id", sa.Text(), nullable=False),
+        sa.Column("claim_id", sa.Text(), nullable=False),
+        sa.Column("raw_text", sa.Text(), nullable=False),
+        sa.Column("policy_ref", sa.Text(), nullable=True),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False),
+        sa.Column("failure", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        # Bare name: the metadata naming_convention expands it to
+        # `ck_assessment_job_status_valid`, matching the model.
+        sa.CheckConstraint(_in_check("status", _STATUS_VALUES), name="status_valid"),
+        sa.PrimaryKeyConstraint("assessment_id"),
+    )
+    op.create_index("ix_assessment_job_status", "assessment_job", ["status"])
+    op.create_index("ix_assessment_job_claim_id", "assessment_job", ["claim_id"])
+
+
+def downgrade() -> None:
+    """Drop `assessment_job`."""
+    op.drop_index("ix_assessment_job_claim_id", table_name="assessment_job")
+    op.drop_index("ix_assessment_job_status", table_name="assessment_job")
+    op.drop_table("assessment_job")

--- a/app/src/application/assessment_job.py
+++ b/app/src/application/assessment_job.py
@@ -1,0 +1,116 @@
+"""The queued assessment run -- its lifecycle before a recommendation exists [M5-05].
+
+A 207-page policy is not an HTTP request. ``POST /v1/assessments`` no longer runs
+the graph in the handler: it persists an ``AssessmentJob`` in ``PENDING`` and
+hands the id back behind a 202. A Redis worker picks the job up, runs the graph
+to the human checkpoint, and -- on success -- writes the
+[application.assessment_record.AssessmentRecord] the read endpoints already serve.
+
+``AssessmentJob`` is a deliberately separate aggregate from ``AssessmentRecord``:
+the record is invariant-laden (a non-empty verdict, prose, a >=1-citation
+projection) and cannot represent a claim that has not been assessed yet. The job
+carries only what the worker needs to (re)build the domain ``Claim`` plus the run
+state a caller polls: ``status``, ``attempts`` and, on failure, the preserved
+``JobFailure`` cause.
+
+``submitted_at`` is stamped once, at submission, and is stable across retries --
+it feeds ``Claim.submitted_at``, which the consistency checks compare the loss
+date against, so a retry must not move it.
+
+Standard library and domain/application types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+
+class JobStatus(Enum):
+    """Where a queued assessment run sits.
+
+    ``SUCCEEDED`` means the graph paused at the human checkpoint and an
+    ``AssessmentRecord`` now exists -- that record (``AWAITING_REVIEW`` ->
+    ``DECIDED``) is the source of truth from then on; the job row is kept for its
+    attempt history. ``FAILED`` is the dead-letter state: the cause is in
+    ``failure`` and, operationally, in RQ's ``FailedJobRegistry``.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class JobFailure:
+    """Why a run did not complete -- preserved on the job, readable through the API.
+
+    ``kind`` is the transient/real split the DoD asks for: ``transient`` failures
+    (a provider rate limit, a 5xx, a dropped connection) are retried with
+    backoff; ``permanent`` failures (a malformed claim, a contract breach, a bug)
+    go straight to the dead-letter with no wasted retries.
+    """
+
+    kind: Literal["transient", "permanent"]
+    error_type: str
+    message: str
+    failed_at: datetime
+
+    def __post_init__(self) -> None:
+        """Reject an out-of-vocabulary kind, an empty type, or a naive timestamp."""
+        if self.kind not in ("transient", "permanent"):
+            raise ValueError(
+                f"JobFailure.kind must be 'transient' or 'permanent', got {self.kind!r}"
+            )
+        if not self.error_type:
+            raise ValueError("JobFailure.error_type must not be empty")
+        if self.failed_at.tzinfo is None or self.failed_at.utcoffset() is None:
+            raise ValueError("JobFailure.failed_at must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class AssessmentJob:
+    """One queued assessment run across its lifecycle -- the persisted unit."""
+
+    assessment_id: str
+    claim_id: str
+    raw_text: str
+    policy_ref: str | None
+    submitted_at: datetime
+    status: JobStatus
+    attempts: int
+    created_at: datetime
+    updated_at: datetime
+    failure: JobFailure | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the non-empty fields, the types, and the status/failure pairing."""
+        for name in ("assessment_id", "claim_id", "raw_text"):
+            if not getattr(self, name):
+                raise ValueError(f"AssessmentJob.{name} must not be empty")
+        if not isinstance(self.status, JobStatus):
+            raise ValueError(
+                f"AssessmentJob.status must be a JobStatus, got {self.status!r}"
+            )
+        if self.attempts < 0:
+            raise ValueError(
+                f"AssessmentJob.attempts must not be negative, got {self.attempts}"
+            )
+        for name in ("submitted_at", "created_at", "updated_at"):
+            value: datetime = getattr(self, name)
+            if value.tzinfo is None or value.utcoffset() is None:
+                raise ValueError(f"AssessmentJob.{name} must be timezone-aware")
+        if self.failure is not None and self.status in (
+            JobStatus.RUNNING,
+            JobStatus.SUCCEEDED,
+        ):
+            raise ValueError(
+                f"a {self.status.value!r} job must not carry a failure cause"
+            )
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the worker should treat this job as done (idempotent redelivery)."""
+        return self.status in (JobStatus.SUCCEEDED, JobStatus.FAILED)

--- a/app/src/application/assessment_read_model.py
+++ b/app/src/application/assessment_read_model.py
@@ -1,0 +1,78 @@
+"""What ``GET /v1/assessments/{id}`` returns across the whole lifecycle [M5-05].
+
+Before M5-05 the read endpoint could only answer once an ``AssessmentRecord``
+existed. With the queue, the id in the 202 must resolve immediately -- while the
+run is still ``pending`` or ``running``, and after it has ``failed``. This is the
+unified projection the presentation layer renders: a lifecycle ``status``, the
+failure cause when there is one, and the full ``AssessmentRecord`` once the graph
+has produced it.
+
+``status`` is the five-value union a caller polls:
+
+- ``pending`` / ``running`` -- from the [application.assessment_job.AssessmentJob]
+  (queued, or a worker is on it);
+- ``failed`` -- the job dead-lettered; ``error`` carries the preserved cause;
+- ``awaiting_review`` / ``decided`` -- from the ``AssessmentRecord`` once it
+  exists (the job, now ``SUCCEEDED``, stops being the source of truth).
+
+Standard library and domain/application types only (enforced by
+tests/architecture/test_layer_boundaries.py).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from application.assessment_job import AssessmentJob, JobStatus
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+
+ReadStatus = Literal["pending", "running", "awaiting_review", "decided", "failed"]
+
+_RECORD_STATUS_TO_READ: dict[AssessmentStatus, ReadStatus] = {
+    AssessmentStatus.AWAITING_REVIEW: "awaiting_review",
+    AssessmentStatus.DECIDED: "decided",
+}
+
+# A job that is SUCCEEDED but whose record we somehow could not read is shown as
+# still running rather than inventing a terminal state -- an atomic write makes
+# this unreachable in practice.
+_JOB_STATUS_TO_READ: dict[JobStatus, ReadStatus] = {
+    JobStatus.PENDING: "pending",
+    JobStatus.RUNNING: "running",
+    JobStatus.SUCCEEDED: "running",
+    JobStatus.FAILED: "failed",
+}
+
+
+@dataclass(frozen=True)
+class AssessmentReadModel:
+    """One assessment as a caller sees it: lifecycle status + the record if ready."""
+
+    assessment_id: str
+    claim_id: str
+    status: ReadStatus
+    created_at: datetime
+    error: str | None = None
+    record: AssessmentRecord | None = None
+
+    @classmethod
+    def from_record(cls, record: AssessmentRecord) -> "AssessmentReadModel":
+        """The completed view -- ``awaiting_review`` or ``decided``."""
+        return cls(
+            assessment_id=record.assessment_id,
+            claim_id=record.claim_id,
+            status=_RECORD_STATUS_TO_READ[record.status],
+            created_at=record.created_at,
+            record=record,
+        )
+
+    @classmethod
+    def from_job(cls, job: AssessmentJob) -> "AssessmentReadModel":
+        """The in-flight or failed view -- no record yet."""
+        return cls(
+            assessment_id=job.assessment_id,
+            claim_id=job.claim_id,
+            status=_JOB_STATUS_TO_READ[job.status],
+            created_at=job.created_at,
+            error=job.failure.message if job.failure is not None else None,
+        )

--- a/app/src/application/errors.py
+++ b/app/src/application/errors.py
@@ -64,3 +64,22 @@ class OrchestratorContractError(ApplicationError):
     that breaks either is an adapter bug, surfaced here rather than silently
     persisted.
     """
+
+
+class AssessmentRunError(ApplicationError):
+    """Base for a background assessment run that did not complete [M5-05].
+
+    ``RunAssessment`` raises one of the two subclasses so the queue layer can
+    tell a retryable failure from a dead-letter one without re-classifying the
+    cause: ``TransientAssessmentError`` -> RQ retries with backoff;
+    ``PermanentAssessmentError`` -> straight to the dead-letter. The original
+    exception is always chained (``raise ... from cause``).
+    """
+
+
+class TransientAssessmentError(AssessmentRunError):
+    """A run failed on a transient provider fault -- a rate limit, a 5xx, a drop."""
+
+
+class PermanentAssessmentError(AssessmentRunError):
+    """A run failed on a real error -- a bad claim, a contract breach, a bug."""

--- a/app/src/application/ports/assessment_job_repository.py
+++ b/app/src/application/ports/assessment_job_repository.py
@@ -1,0 +1,31 @@
+"""Port for persisting and reading the queued-run lifecycle [M5-05].
+
+The stored unit is [application.assessment_job.AssessmentJob] -- the run state a
+caller polls (``PENDING`` -> ``RUNNING`` -> ``SUCCEEDED`` / ``FAILED``) plus what
+the worker needs to rebuild the domain ``Claim``.
+
+``add`` / ``update`` run inside a ``UnitOfWork`` (the worker's success path writes
+the settled ``AssessmentRecord`` and flips the job to ``SUCCEEDED`` in one
+transaction). ``get`` needs no transaction -- the read endpoints call it on a
+bare repository, like ``AssessmentRepository.get``.
+"""
+
+from typing import Protocol
+
+from application.assessment_job import AssessmentJob
+
+
+class AssessmentJobRepository(Protocol):
+    """Store queued assessment runs and read one back by id."""
+
+    def add(self, job: AssessmentJob) -> None:
+        """Persist a new job. The ``assessment_id`` is assumed unused."""
+        ...
+
+    def update(self, job: AssessmentJob) -> None:
+        """Replace the stored job with the same ``assessment_id``."""
+        ...
+
+    def get(self, assessment_id: str) -> AssessmentJob | None:
+        """Return the job for ``assessment_id``, or ``None`` if there is none."""
+        ...

--- a/app/src/application/ports/assessment_queue.py
+++ b/app/src/application/ports/assessment_queue.py
@@ -1,0 +1,21 @@
+"""Port for handing a persisted assessment run to the worker pool [M5-05].
+
+``SubmitClaim`` persists an ``AssessmentJob`` in ``PENDING`` and then calls this
+port to schedule it. The application layer knows nothing of Redis or RQ -- the
+adapter ([infrastructure.queue.rq_queue.RqAssessmentQueue]) turns ``enqueue`` into
+a Redis-backed job with the retry policy and timeout attached.
+
+``enqueue`` takes only the ``assessment_id``: the worker reloads everything else
+from the job row, so a redelivered or retried job always runs against the current
+persisted state.
+"""
+
+from typing import Protocol
+
+
+class AssessmentQueue(Protocol):
+    """Schedule a persisted assessment run for background processing."""
+
+    def enqueue(self, assessment_id: str) -> None:
+        """Queue the ``PENDING`` job ``assessment_id`` for a worker to pick up."""
+        ...

--- a/app/src/application/ports/unit_of_work.py
+++ b/app/src/application/ports/unit_of_work.py
@@ -1,10 +1,12 @@
 """Port for the transactional boundary around assessment writes [M5-02].
 
-A ``UnitOfWork`` is one transaction. It exposes the two writers the use cases
-need in one atomic step -- ``assessments`` (the record) and ``audit`` (the trail
-the resume path captured, [M5-04]'s transactional fold) -- and nothing else: the
-clause corpus is read-only reference data with its own lifecycle, so
-``ClauseRepository`` is not part of it.
+A ``UnitOfWork`` is one transaction. It exposes the writers the use cases need in
+one atomic step -- ``assessments`` (the record), ``audit`` (the trail the resume
+path captured, [M5-04]'s transactional fold) and ``jobs`` (the queued-run
+lifecycle, [M5-05]: the worker flips a job to ``SUCCEEDED`` in the same
+transaction that persists the settled record) -- and nothing else: the clause
+corpus is read-only reference data with its own lifecycle, so ``ClauseRepository``
+is not part of it.
 
 The use cases take a ``UnitOfWorkFactory`` (``Callable[[], UnitOfWork]``), not a
 ``UnitOfWork``, so each call opens its own transaction -- which is what
@@ -20,15 +22,17 @@ from collections.abc import Callable
 from types import TracebackType
 from typing import Protocol
 
+from application.ports.assessment_job_repository import AssessmentJobRepository
 from application.ports.assessment_repository import AssessmentRepository
 from application.ports.audit_trail_writer import AuditTrailWriter
 
 
 class UnitOfWork(Protocol):
-    """One transaction over the assessment store and the audit trail."""
+    """One transaction over the assessment store, the audit trail and the job log."""
 
     assessments: AssessmentRepository
     audit: AuditTrailWriter
+    jobs: AssessmentJobRepository
 
     def __enter__(self) -> "UnitOfWork":
         """Begin the unit and return it."""

--- a/app/src/application/use_cases/get_assessment.py
+++ b/app/src/application/use_cases/get_assessment.py
@@ -1,34 +1,44 @@
-"""Use case: fetch one assessment by id [M5-02].
+"""Use case: fetch one assessment by id [M5-02, M5-05].
 
-The read behind ``GET /v1/assessments/{id}`` ([M5-04]). It returns the stored
-``AssessmentRecord`` -- system verdict, recommendation, citations, the
-retrieval/clarification signals and, once settled, the analyst's decision -- so
-the API never re-enters the graph to answer a read.
+The read behind ``GET /v1/assessments/{id}``. It returns an
+``AssessmentReadModel``: the lifecycle ``status`` a caller polls, plus the full
+``AssessmentRecord`` once the graph has produced it.
 
-An abstain record (no citations) is returned like any other; only an unknown id
-is an error.
+[M5-05] made the read span the whole lifecycle. The id handed back in the 202
+must resolve immediately -- while the run is ``pending`` / ``running``, and after
+it has ``failed`` -- so this checks the ``AssessmentRepository`` first (a
+completed run, ``awaiting_review`` / ``decided``) and falls back to the
+``AssessmentJobRepository`` (still queued, or dead-lettered). Only an id neither
+store knows is an error.
 """
 
 from dataclasses import dataclass
 
-from application.assessment_record import AssessmentRecord
+from application.assessment_read_model import AssessmentReadModel
 from application.errors import AssessmentNotFoundError
+from application.ports.assessment_job_repository import AssessmentJobRepository
 from application.ports.assessment_repository import AssessmentRepository
 
 
 @dataclass(frozen=True)
 class GetAssessment:
-    """Return the assessment record for an id, or raise if there is none."""
+    """Return the lifecycle view for an assessment id, or raise if it is unknown."""
 
     assessments: AssessmentRepository
+    jobs: AssessmentJobRepository
 
-    def __call__(self, assessment_id: str) -> AssessmentRecord:
-        """Fetch the record for ``assessment_id``.
+    def __call__(self, assessment_id: str) -> AssessmentReadModel:
+        """Fetch the read model for ``assessment_id``.
 
         Raises:
-            AssessmentNotFoundError: no record exists for the id.
+            AssessmentNotFoundError: neither a record nor a job exists for the id.
         """
         record = self.assessments.get(assessment_id)
-        if record is None:
-            raise AssessmentNotFoundError(assessment_id)
-        return record
+        if record is not None:
+            return AssessmentReadModel.from_record(record)
+
+        job = self.jobs.get(assessment_id)
+        if job is not None:
+            return AssessmentReadModel.from_job(job)
+
+        raise AssessmentNotFoundError(assessment_id)

--- a/app/src/application/use_cases/get_audit_trail.py
+++ b/app/src/application/use_cases/get_audit_trail.py
@@ -1,18 +1,21 @@
 """Use case: fetch one assessment run's durable audit trail [M5-04].
 
-The read behind ``GET /v1/assessments/{id}/audit``. It resolves the id against
-``AssessmentRepository`` first -- an unknown id is a 404, not an empty trail --
-then returns the entries the ``AuditTrailReader`` holds for it.
+The read behind ``GET /v1/assessments/{id}/audit``. It resolves the id first --
+an unknown id is a 404, not an empty trail -- then returns the entries the
+``AuditTrailReader`` holds for it.
 
-An assessment still ``AWAITING_REVIEW`` has an empty trail: the durable trail is
-written once, in the ``human_review`` node, after the analyst decides. That is a
-valid answer (an empty list), not an error.
+An assessment still ``AWAITING_REVIEW`` (or still ``pending`` / ``running`` on the
+queue, [M5-05]) has an empty trail: the durable trail is written once, in the
+``human_review`` node, after the analyst decides. That is a valid answer (an empty
+list), not an error -- so a known-but-not-yet-completed id resolves through the
+``AssessmentJobRepository`` too.
 """
 
 from dataclasses import dataclass
 
 from application.audit_trail_entry import AuditTrailEntry
 from application.errors import AssessmentNotFoundError
+from application.ports.assessment_job_repository import AssessmentJobRepository
 from application.ports.assessment_repository import AssessmentRepository
 from application.ports.audit_trail_reader import AuditTrailReader
 
@@ -22,14 +25,19 @@ class GetAuditTrail:
     """Return the audit trail for an assessment id, or raise if the id is unknown."""
 
     assessments: AssessmentRepository
+    jobs: AssessmentJobRepository
     audit: AuditTrailReader
 
     def __call__(self, assessment_id: str) -> tuple[AuditTrailEntry, ...]:
         """Fetch the trail for ``assessment_id``.
 
         Raises:
-            AssessmentNotFoundError: no assessment exists for the id.
+            AssessmentNotFoundError: neither a record nor a job exists for the id.
         """
-        if self.assessments.get(assessment_id) is None:
+        known = (
+            self.assessments.get(assessment_id) is not None
+            or self.jobs.get(assessment_id) is not None
+        )
+        if not known:
             raise AssessmentNotFoundError(assessment_id)
         return self.audit.get_trail(assessment_id)

--- a/app/src/application/use_cases/run_assessment.py
+++ b/app/src/application/use_cases/run_assessment.py
@@ -1,0 +1,167 @@
+"""Use case: run one queued assessment on a worker [M5-05].
+
+The background half of ``POST /v1/assessments``. A Redis worker calls this with
+an ``assessment_id``; it loads the ``AssessmentJob``, runs the graph to the human
+checkpoint through the orchestrator port, and -- on success -- writes the
+``AssessmentRecord`` the read endpoints serve, flipping the job to ``SUCCEEDED``
+in the *same* transaction.
+
+Failure handling is the DoD's "distinguish transient from real":
+
+- a transient provider fault (rate limit, 5xx, dropped connection -- decided by
+  the injected ``is_transient`` predicate) with attempts left: the job goes back
+  to ``PENDING`` and a ``TransientAssessmentError`` is raised so the queue
+  reschedules it with backoff;
+- the same fault with no attempts left, or any real error / contract breach: the
+  job is marked ``FAILED`` with the cause preserved on ``JobFailure`` and a
+  ``PermanentAssessmentError`` (or ``TransientAssessmentError`` when the budget
+  simply ran out) is raised -- the queue dead-letters it.
+
+Idempotent: a redelivered job whose row already reads ``SUCCEEDED`` / ``FAILED``
+is a no-op. A job stuck at ``RUNNING`` (the worker died mid-run) is re-run -- the
+LangGraph checkpoint means that resumes from the last completed node, not from
+scratch.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+from application.assessment_job import AssessmentJob, JobFailure, JobStatus
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.errors import (
+    AssessmentRunError,
+    PermanentAssessmentError,
+    TransientAssessmentError,
+)
+from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.ports.clock import Clock
+from application.ports.unit_of_work import UnitOfWorkFactory
+from domain.claim import Claim
+from domain.susep_process import SusepProcess
+
+_MAX_CAUSE_CHARS = 2000
+
+
+@dataclass(frozen=True)
+class RunAssessment:
+    """Process one queued assessment run to the human checkpoint, or fail it."""
+
+    clock: Clock
+    orchestrator: ClaimAssessmentOrchestrator
+    uow_factory: UnitOfWorkFactory
+    is_transient: Callable[[BaseException], bool]
+    max_attempts: int
+
+    def __call__(self, assessment_id: str) -> None:
+        """Run the job ``assessment_id``; persist the record or the failure.
+
+        Raises:
+            PermanentAssessmentError: the job is unknown, the run hit a real
+                error, or the orchestrator broke its contract.
+            TransientAssessmentError: the run hit a transient provider fault --
+                the queue reschedules (attempts left) or dead-letters it.
+        """
+        job = self._load(assessment_id)
+        if job is None:
+            raise PermanentAssessmentError(
+                f"no assessment job found for id {assessment_id!r}"
+            )
+        if job.is_terminal:
+            return
+
+        running = self._mark_running(job)
+        claim = self._rebuild_claim(running)
+
+        try:
+            result = self.orchestrator.start(assessment_id=assessment_id, claim=claim)
+        except Exception as exc:  # noqa: BLE001 - re-raised as a typed run error below
+            raise self._record_failure(running, exc) from exc
+
+        if not result.awaiting_review:
+            breach = _ContractBreachError(
+                f"start did not pause at the human checkpoint for "
+                f"assessment {assessment_id!r}"
+            )
+            raise self._record_failure(running, breach) from breach
+
+        record = AssessmentRecord.from_orchestrator_result(
+            result,
+            assessment_id=assessment_id,
+            claim_id=running.claim_id,
+            created_at=running.created_at,
+            status=AssessmentStatus.AWAITING_REVIEW,
+        )
+        succeeded = replace(
+            running,
+            status=JobStatus.SUCCEEDED,
+            failure=None,
+            updated_at=self.clock.now(),
+        )
+        with self.uow_factory() as uow:
+            uow.assessments.add(record)
+            uow.jobs.update(succeeded)
+            uow.commit()
+
+    def _load(self, assessment_id: str) -> AssessmentJob | None:
+        with self.uow_factory() as uow:
+            return uow.jobs.get(assessment_id)
+
+    def _mark_running(self, job: AssessmentJob) -> AssessmentJob:
+        running = replace(
+            job,
+            status=JobStatus.RUNNING,
+            attempts=job.attempts + 1,
+            failure=None,
+            updated_at=self.clock.now(),
+        )
+        with self.uow_factory() as uow:
+            uow.jobs.update(running)
+            uow.commit()
+        return running
+
+    def _rebuild_claim(self, job: AssessmentJob) -> Claim:
+        return Claim(
+            claim_id=job.claim_id,
+            raw_text=job.raw_text,
+            submitted_at=job.submitted_at,
+            policy_ref=(
+                SusepProcess.parse(job.policy_ref)
+                if job.policy_ref is not None
+                else None
+            ),
+        )
+
+    def _record_failure(
+        self, running: AssessmentJob, exc: BaseException
+    ) -> AssessmentRunError:
+        """Persist the job's failure state and return the typed error to raise."""
+        transient = not isinstance(exc, _ContractBreachError) and self.is_transient(exc)
+        retryable = transient and running.attempts < self.max_attempts
+        now = self.clock.now()
+        failure = JobFailure(
+            kind="transient" if transient else "permanent",
+            error_type=type(exc).__name__,
+            message=str(exc)[:_MAX_CAUSE_CHARS] or type(exc).__name__,
+            failed_at=now,
+        )
+        failed = replace(
+            running,
+            status=JobStatus.PENDING if retryable else JobStatus.FAILED,
+            failure=failure,
+            updated_at=now,
+        )
+        with self.uow_factory() as uow:
+            uow.jobs.update(failed)
+            uow.commit()
+
+        error: AssessmentRunError = (
+            TransientAssessmentError(str(exc))
+            if transient
+            else PermanentAssessmentError(str(exc))
+        )
+        error.__cause__ = exc
+        return error
+
+
+class _ContractBreachError(Exception):
+    """``start`` returned a non-paused result -- a permanent failure."""

--- a/app/src/application/use_cases/submit_claim.py
+++ b/app/src/application/use_cases/submit_claim.py
@@ -1,31 +1,33 @@
-"""Use case: submit a claim for assessment [M5-02].
+"""Use case: submit a claim for assessment [M5-02, M5-05].
 
-Behind ``POST /v1/assessments`` ([M5-04]). It mints the identifiers, builds the
-domain ``Claim`` (whose construction validates the narrative and the
-timestamp), runs it through the orchestrator up to the human checkpoint, and
-persists the result as an ``AssessmentRecord`` in status ``AWAITING_REVIEW``.
+Behind ``POST /v1/assessments``. It mints the identifiers, builds the domain
+``Claim`` (whose construction validates the narrative and the timestamp),
+persists an ``AssessmentJob`` in ``PENDING``, and hands it to the queue -- then
+returns. The graph runs later, on a worker (``RunAssessment``), behind the 202.
 
 Two identifiers, minted separately: a ``claim_id`` (the narrative) and an
 ``assessment_id`` (this run of it). Re-submitting the same claim is a fresh
-``assessment_id`` -- a second run, a second record.
+``assessment_id`` -- a second run, a second job.
 
-The orchestrator runs *before* the transaction opens: the graph is a long call
-and must not hold a database transaction open, and it must pause at the
-checkpoint before there is anything worth persisting. A failure to persist after
-the graph has paused leaves the run recoverable from its checkpoint but without
-a record. Nothing folds that window shut on the ``start`` path -- the graph
-pauses before it writes any audit trail, so there is no second write to share a
-transaction with, and the checkpoint itself is a separate connection. [M5-05]'s
-run-status tracking closes it; the [M5-04] fold is on the ``resume`` path, in
-``SubmitHumanDecision``.
+[M5-05] changed the shape: M5-04's version ran ``orchestrator.start`` inline
+before responding (a multi-minute call held in the request handler). Now the only
+synchronous work is a single-row insert. ``submitted_at`` is stamped here, once,
+and stored on the job so a retry re-runs the graph against the *same* loss-date
+baseline the consistency checks compare against.
+
+The job is committed *before* it is enqueued: a consumer polling
+``GET /v1/assessments/{id}`` must always find the row. The reverse would leave a
+window where the id is queued but unreadable. The residual window -- committed but
+never enqueued, e.g. Redis is down between the commit and the ``enqueue`` call --
+leaves the job ``PENDING`` forever; a reconciler that re-enqueues stale
+``PENDING`` jobs is left to operations (noted in ``docs/ASYNC_PROCESSING.md``).
 """
 
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from application.assessment_record import AssessmentRecord, AssessmentStatus
-from application.errors import OrchestratorContractError
-from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
+from application.assessment_job import AssessmentJob, JobStatus
+from application.ports.assessment_queue import AssessmentQueue
 from application.ports.clock import Clock
 from application.ports.unit_of_work import UnitOfWorkFactory
 from domain.claim import Claim
@@ -34,10 +36,10 @@ from domain.susep_process import SusepProcess
 
 @dataclass(frozen=True)
 class SubmitClaim:
-    """Assess a submitted claim and persist the pending result."""
+    """Accept a submitted claim, persist it as a pending job, and queue it."""
 
     clock: Clock
-    orchestrator: ClaimAssessmentOrchestrator
+    queue: AssessmentQueue
     uow_factory: UnitOfWorkFactory
     new_id: Callable[[], str]
 
@@ -47,43 +49,42 @@ class SubmitClaim:
         raw_text: str,
         policy_ref: SusepProcess | None = None,
         claim_id: str | None = None,
-    ) -> AssessmentRecord:
-        """Run the claim through assessment and store the awaiting-review record.
+    ) -> AssessmentJob:
+        """Store a ``PENDING`` job for the claim and enqueue it for a worker.
 
         Raises:
             ValueError: the narrative is empty or the clock returned a naive
                 datetime (both surface from ``Claim`` construction).
-            OrchestratorContractError: the orchestrator did not pause at the
-                human checkpoint.
         """
         submitted_at = self.clock.now()
         resolved_claim_id = claim_id or self.new_id()
         assessment_id = self.new_id()
 
-        claim = Claim(
+        # Constructed for its validation side effects (empty narrative, naive
+        # timestamp); the worker rebuilds it from the persisted fields.
+        Claim(
             claim_id=resolved_claim_id,
             raw_text=raw_text,
             submitted_at=submitted_at,
             policy_ref=policy_ref,
         )
 
-        result = self.orchestrator.start(assessment_id=assessment_id, claim=claim)
-        if not result.awaiting_review:
-            raise OrchestratorContractError(
-                f"start did not pause at the human checkpoint for "
-                f"assessment {assessment_id!r}"
-            )
-
-        record = AssessmentRecord.from_orchestrator_result(
-            result,
+        job = AssessmentJob(
             assessment_id=assessment_id,
             claim_id=resolved_claim_id,
+            raw_text=raw_text,
+            policy_ref=policy_ref.value if policy_ref is not None else None,
+            submitted_at=submitted_at,
+            status=JobStatus.PENDING,
+            attempts=0,
             created_at=submitted_at,
-            status=AssessmentStatus.AWAITING_REVIEW,
+            updated_at=submitted_at,
         )
 
         with self.uow_factory() as uow:
-            uow.assessments.add(record)
+            uow.jobs.add(job)
             uow.commit()
 
-        return record
+        self.queue.enqueue(assessment_id)
+
+        return job

--- a/app/src/infrastructure/bootstrap.py
+++ b/app/src/infrastructure/bootstrap.py
@@ -1,0 +1,112 @@
+"""The shared composition root for the API and the worker -- [M5-05].
+
+Before M5-05 the FastAPI ``lifespan`` was the only place the heavy process-wide
+singletons were built (the DB engine, the two chat models, the retrieval stack,
+the LangGraph orchestrator). The worker (``make worker``) needs the same set, so
+that construction lives here and both entry points call it.
+
+``build_core_components`` is deliberately framework-free: no FastAPI, no RQ. The
+API wraps its result with the request-scoped bits (the clock, the id minter, the
+queue); the worker wraps it with a ``RunAssessment``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.ports.unit_of_work import UnitOfWorkFactory
+from infrastructure.config.llm_client_factory import build_chat_model
+from infrastructure.config.settings import (
+    DatabaseSettings,
+    LlmSettings,
+    get_database_settings,
+    get_llm_settings,
+)
+from infrastructure.database import (
+    create_engine_from_settings,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.context import GraphContext
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.rag.retriever_factory import (
+    build_graph_retriever,
+    load_retriever_components,
+)
+
+
+@dataclass
+class CoreComponents:
+    """The process-wide singletons the API and the worker both need."""
+
+    engine: Engine
+    session_factory: sessionmaker[Session]
+    orchestrator: LangGraphClaimAssessmentOrchestrator
+    uow_factory: UnitOfWorkFactory
+
+    def dispose(self) -> None:
+        """Release the connection pool -- call on shutdown."""
+        self.engine.dispose()
+
+
+def build_core_components(
+    *,
+    database_settings: DatabaseSettings | None = None,
+    llm_settings: LlmSettings | None = None,
+    probe_checkpointer: bool = True,
+) -> CoreComponents:
+    """Build the DB engine, the chat models, the retriever and the orchestrator.
+
+    ``probe_checkpointer`` opens the LangGraph Postgres checkpointer once so a
+    missing schema fails fast with an actionable "run ``make setup-checkpointer``"
+    message rather than on the first job.
+    """
+    db = database_settings or get_database_settings()
+    llm = llm_settings or get_llm_settings()
+
+    engine = create_engine_from_settings(db)
+    session_factory = create_session_factory(engine=engine)
+
+    if probe_checkpointer:
+        with open_claim_checkpointer(db.sqlalchemy_database_url):
+            pass
+
+    fast_model = build_chat_model(
+        llm,
+        llm.llm_model_fast,
+        provider_order=llm.llm_fast_provider_order,
+        allow_fallbacks=llm.llm_fast_allow_fallbacks,
+    )
+    reasoning_model = build_chat_model(
+        llm,
+        llm.llm_model_reasoning,
+        provider_order=llm.llm_reasoning_provider_order,
+        allow_fallbacks=llm.llm_reasoning_allow_fallbacks,
+    )
+    retriever_components = load_retriever_components()
+
+    def context_factory(session: Session) -> GraphContext:
+        return GraphContext(
+            fast_model=fast_model,
+            reasoning_model=reasoning_model,
+            retriever=build_graph_retriever(session, retriever_components),
+            llm_settings=llm,
+            audit_sink=None,
+        )
+
+    orchestrator = LangGraphClaimAssessmentOrchestrator(
+        context_factory=context_factory,
+        session_factory=session_factory,
+        database_url=db.sqlalchemy_database_url,
+    )
+
+    return CoreComponents(
+        engine=engine,
+        session_factory=session_factory,
+        orchestrator=orchestrator,
+        uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+    )

--- a/app/src/infrastructure/config/settings.py
+++ b/app/src/infrastructure/config/settings.py
@@ -319,10 +319,58 @@ class EmbeddingSettings(BaseSettings):
     embedding_batch_size: int = Field(alias="EMBEDDING_BATCH_SIZE", default=64)
 
 
-class Settings(DatabaseSettings, LlmSettings):
-    """Application settings loaded from environment variables."""
+class QueueSettings(BaseSettings):
+    """Settings for the [M5-05] asynchronous-processing queue.
+
+    ``assessment_worker_concurrency`` is the DoD's configurable parallelism bound:
+    each RQ worker runs one assessment at a time, so N workers == N concurrent
+    graph runs against the LLM provider. It is the direct analog of
+    ``LLM_CLASSIFICATION_MAX_WORKERS`` -- an operator knob, tuned to the
+    provider's tolerance (and to VRAM: on the 4 GB-VRAM dev box, keep it at 1 --
+    see ``docs/ASYNC_PROCESSING.md``).
+
+    ``assessment_max_retries`` is the total attempt budget (initial try +
+    retries) a job gets on *transient* failures; ``assessment_retry_backoff_seconds``
+    is the wait before each retry (RQ's ``Retry(interval=...)``). Real errors are
+    not retried at all.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_ignore_empty=True,
+        extra="ignore",
+    )
 
     redis_url: str = Field(alias="REDIS_URL", default="redis://localhost:6379/0")
+    test_redis_url: str | None = Field(alias="TEST_REDIS_URL", default=None)
+
+    assessment_worker_concurrency: int = Field(
+        alias="ASSESSMENT_WORKER_CONCURRENCY", default=2, gt=0
+    )
+    assessment_max_retries: int = Field(alias="ASSESSMENT_MAX_RETRIES", default=3, gt=0)
+    assessment_retry_backoff_seconds: list[int] = Field(
+        alias="ASSESSMENT_RETRY_BACKOFF_SECONDS",
+        default_factory=lambda: [30, 120, 300],
+    )
+    assessment_job_timeout_seconds: int = Field(
+        alias="ASSESSMENT_JOB_TIMEOUT_SECONDS", default=1800, gt=0
+    )
+
+    @property
+    def rq_retry_intervals(self) -> list[int]:
+        """The per-retry wait list, padded/truncated to ``assessment_max_retries - 1``.
+
+        RQ needs one interval per retry (attempts beyond the first). A shorter
+        list repeats its last value; a longer one is truncated.
+        """
+        retries = max(self.assessment_max_retries - 1, 0)
+        backoff = self.assessment_retry_backoff_seconds or [30]
+        return [backoff[min(i, len(backoff) - 1)] for i in range(retries)]
+
+
+class Settings(DatabaseSettings, LlmSettings):
+    """Application settings loaded from environment variables."""
 
     # Logging
     log_level: str = Field(alias="LOG_LEVEL", default="INFO")
@@ -355,6 +403,12 @@ def get_llm_settings() -> LlmSettings:
 def get_settings() -> Settings:
     """Get cached application settings."""
     return Settings()
+
+
+@lru_cache
+def get_queue_settings() -> QueueSettings:
+    """Get cached settings for the asynchronous-processing queue."""
+    return QueueSettings()
 
 
 @lru_cache

--- a/app/src/infrastructure/database/__init__.py
+++ b/app/src/infrastructure/database/__init__.py
@@ -4,6 +4,13 @@ SQLAlchemy models, repositories, session management, and the pgvector
 integration.
 """
 
+from infrastructure.database.assessment_job_mapper import (
+    job_to_row,
+    row_to_job,
+)
+from infrastructure.database.assessment_job_repository import (
+    SqlAlchemyAssessmentJobRepository,
+)
 from infrastructure.database.assessment_mapper import (
     record_to_rows,
     rows_to_record,
@@ -27,6 +34,7 @@ from infrastructure.database.chunk_repository import (
 from infrastructure.database.clause_repository import SqlAlchemyClauseRepository
 from infrastructure.database.graph_audit_sink import SqlAlchemyAuditTrailSink
 from infrastructure.database.models import (
+    AssessmentJobRow,
     AssessmentRow,
     AuditEventRow,
     ChunkRow,
@@ -44,11 +52,13 @@ from infrastructure.database.unit_of_work import (
 )
 
 __all__ = [
+    "AssessmentJobRow",
     "AssessmentRow",
     "AuditEventRow",
     "Base",
     "ChunkRow",
     "HumanDecisionRow",
+    "SqlAlchemyAssessmentJobRepository",
     "SqlAlchemyAssessmentRepository",
     "SqlAlchemyAuditTrailReader",
     "SqlAlchemyAuditTrailSink",
@@ -63,7 +73,9 @@ __all__ = [
     "create_session_factory",
     "fetch_chunks_missing_embedding",
     "is_database_reachable",
+    "job_to_row",
     "record_to_rows",
+    "row_to_job",
     "rows_to_record",
     "sqlalchemy_unit_of_work_factory",
     "upsert_chunks",

--- a/app/src/infrastructure/database/assessment_job_mapper.py
+++ b/app/src/infrastructure/database/assessment_job_mapper.py
@@ -1,0 +1,81 @@
+"""Map the queued-run aggregate to and from its database row -- [M5-05].
+
+Pure functions, no session, between [application.assessment_job.AssessmentJob]
+(plus its [application.assessment_job.JobFailure]) and
+[infrastructure.database.models.AssessmentJobRow]. Mirrors
+``assessment_mapper.py``: the ``JobStatus`` enum and the ``failure`` value object
+are written as their canonical JSON shape and rebuilt on read (the domain
+constructors re-validate, so a corrupted row fails loudly here rather than
+several layers up).
+"""
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Literal, cast
+
+from application.assessment_job import AssessmentJob, JobFailure, JobStatus
+from infrastructure.database.models import AssessmentJobRow
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Guard: a ``timestamptz`` column must never hand back a naive datetime."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"expected a timezone-aware datetime, got {value!r}")
+    return value
+
+
+def _require_str(data: Mapping[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str):
+        raise TypeError(f"expected a string for {key!r}, got {value!r}")
+    return value
+
+
+def _failure_to_json(failure: JobFailure) -> dict[str, object]:
+    return {
+        "kind": failure.kind,
+        "error_type": failure.error_type,
+        "message": failure.message,
+        "failed_at": failure.failed_at.isoformat(),
+    }
+
+
+def _failure_from_json(data: Mapping[str, object]) -> JobFailure:
+    return JobFailure(
+        kind=cast(Literal["transient", "permanent"], _require_str(data, "kind")),
+        error_type=_require_str(data, "error_type"),
+        message=_require_str(data, "message"),
+        failed_at=_as_aware(datetime.fromisoformat(_require_str(data, "failed_at"))),
+    )
+
+
+def job_to_row(job: AssessmentJob) -> AssessmentJobRow:
+    """Build the ``assessment_job`` row for a job aggregate."""
+    return AssessmentJobRow(
+        assessment_id=job.assessment_id,
+        claim_id=job.claim_id,
+        raw_text=job.raw_text,
+        policy_ref=job.policy_ref,
+        submitted_at=job.submitted_at,
+        status=job.status.value,
+        attempts=job.attempts,
+        failure=_failure_to_json(job.failure) if job.failure is not None else None,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )
+
+
+def row_to_job(row: AssessmentJobRow) -> AssessmentJob:
+    """Rebuild a job aggregate from its row (the aggregate re-validates)."""
+    return AssessmentJob(
+        assessment_id=row.assessment_id,
+        claim_id=row.claim_id,
+        raw_text=row.raw_text,
+        policy_ref=row.policy_ref,
+        submitted_at=_as_aware(row.submitted_at),
+        status=JobStatus(row.status),
+        attempts=row.attempts,
+        created_at=_as_aware(row.created_at),
+        updated_at=_as_aware(row.updated_at),
+        failure=_failure_from_json(row.failure) if row.failure is not None else None,
+    )

--- a/app/src/infrastructure/database/assessment_job_repository.py
+++ b/app/src/infrastructure/database/assessment_job_repository.py
@@ -1,0 +1,50 @@
+"""The SQLAlchemy ``AssessmentJobRepository`` -- [M5-05].
+
+Implements [application.ports.assessment_job_repository.AssessmentJobRepository]
+over the ``assessment_job`` table. Constructed with a ``Session``:
+
+* ``add`` / ``update`` are used through a
+  [infrastructure.database.unit_of_work.SqlAlchemyUnitOfWork] -- this class
+  flushes, never commits;
+* ``get`` works on any ``Session`` (the read endpoints build a short-lived
+  instance on a fresh session, like ``SqlAlchemyAssessmentRepository``).
+
+Row <-> aggregate translation is entirely in
+[infrastructure.database.assessment_job_mapper].
+"""
+
+from sqlalchemy.orm import Session
+
+from application.assessment_job import AssessmentJob
+from infrastructure.database.assessment_job_mapper import job_to_row, row_to_job
+from infrastructure.database.models import AssessmentJobRow
+
+
+class SqlAlchemyAssessmentJobRepository:
+    """Persist and read ``AssessmentJob`` aggregates in Postgres."""
+
+    def __init__(self, session: Session) -> None:
+        """Bind the repository to a session (the unit of work owns its lifecycle)."""
+        self._session = session
+
+    def add(self, job: AssessmentJob) -> None:
+        """Persist a new job. A duplicate id raises ``IntegrityError`` on flush."""
+        self._session.add(job_to_row(job))
+        self._session.flush()
+
+    def update(self, job: AssessmentJob) -> None:
+        """Replace the stored job with the same ``assessment_id``.
+
+        Raises:
+            KeyError: no job exists for ``job.assessment_id`` -- matching the
+                in-memory fake's contract.
+        """
+        if self._session.get(AssessmentJobRow, job.assessment_id) is None:
+            raise KeyError(f"assessment job {job.assessment_id!r} does not exist")
+        self._session.merge(job_to_row(job))
+        self._session.flush()
+
+    def get(self, assessment_id: str) -> AssessmentJob | None:
+        """Return the job for ``assessment_id``, or ``None`` if there is none."""
+        row = self._session.get(AssessmentJobRow, assessment_id)
+        return row_to_job(row) if row is not None else None

--- a/app/src/infrastructure/database/models.py
+++ b/app/src/infrastructure/database/models.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
+from application.assessment_job import JobStatus
 from application.assessment_record import AssessmentStatus
 from domain.chunk import ChunkRule
 from domain.clause_classification import ClauseType, TypeSource
@@ -278,6 +279,60 @@ class AssessmentRow(Base):
         Index("ix_assessment_claim_id", "claim_id"),
         Index("ix_assessment_status", "status"),
         Index("ix_assessment_created_at", "created_at"),
+    )
+
+
+class AssessmentJobRow(Base):
+    """One queued assessment run's lifecycle -- [M5-05].
+
+    The persistence representation of [application.assessment_job.AssessmentJob]:
+    the run state a caller polls (``pending`` -> ``running`` -> ``succeeded`` /
+    ``failed``) plus what a worker needs to rebuild the domain ``Claim`` after a
+    redelivery or a retry (``raw_text``, ``policy_ref``, and ``submitted_at`` --
+    stamped once at submission so a retry keeps the same loss-date baseline).
+
+    ``failure`` is ``JSONB`` (``kind`` / ``error_type`` / ``message`` /
+    ``failed_at``): a frozen value object read whole with the job, never queried
+    by field -- the same call as ``AuditEventRow.payload``. ``status`` is
+    ``TEXT`` + a named CHECK from ``JobStatus`` (chunk/assessment precedent -- no
+    native PG enums here). No FK to ``assessment``: the job row is created before
+    any assessment exists, and outlives a failed run that never produces one.
+    """
+
+    __tablename__ = "assessment_job"
+
+    assessment_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    claim_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    raw_text: Mapped[str] = mapped_column(Text, nullable=False)
+    # The SUSEP process the claim is filed against, canonical form -- or NULL when
+    # the submission carried none (intake extracts it from the narrative instead).
+    policy_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    submitted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False)
+    failure: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            _in_clause("status", (member.value for member in JobStatus)),
+            name="status_valid",
+        ),
+        # `status` -- the worker scans for `pending`; `claim_id` -- what a human
+        # searches by (every run of one claim). `created_at` is not indexed:
+        # unlike `assessment`, jobs are not listed newest-first through the API.
+        Index("ix_assessment_job_status", "status"),
+        Index("ix_assessment_job_claim_id", "claim_id"),
     )
 
 

--- a/app/src/infrastructure/database/unit_of_work.py
+++ b/app/src/infrastructure/database/unit_of_work.py
@@ -16,9 +16,13 @@ from types import TracebackType
 
 from sqlalchemy.orm import Session, sessionmaker
 
+from application.ports.assessment_job_repository import AssessmentJobRepository
 from application.ports.assessment_repository import AssessmentRepository
 from application.ports.audit_trail_writer import AuditTrailWriter
 from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
+from infrastructure.database.assessment_job_repository import (
+    SqlAlchemyAssessmentJobRepository,
+)
 from infrastructure.database.assessment_repository import SqlAlchemyAssessmentRepository
 from infrastructure.database.audit_trail_writer import SqlAlchemyAuditTrailWriter
 
@@ -30,6 +34,7 @@ class SqlAlchemyUnitOfWork:
     # the `UnitOfWork` protocol (matching `tests/unit/application/fakes.py`).
     assessments: AssessmentRepository
     audit: AuditTrailWriter
+    jobs: AssessmentJobRepository
 
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         """Bind the unit to a session factory; the session opens on ``__enter__``."""
@@ -43,6 +48,7 @@ class SqlAlchemyUnitOfWork:
         self._committed = False
         self.assessments = SqlAlchemyAssessmentRepository(self._session)
         self.audit = SqlAlchemyAuditTrailWriter(self._session)
+        self.jobs = SqlAlchemyAssessmentJobRepository(self._session)
         return self
 
     def __exit__(

--- a/app/src/infrastructure/llm_errors.py
+++ b/app/src/infrastructure/llm_errors.py
@@ -1,0 +1,60 @@
+"""Tell a transient provider fault from a real error [M5-05].
+
+Every LLM call in the graph goes through ``langchain-openai`` -- and so the
+``openai`` SDK -- to an OpenAI-compatible gateway (OpenRouter). When a background
+assessment run raises, the worker has to decide: reschedule with backoff, or
+dead-letter. That decision is *transient vs real*, and this module is the single
+place it is made.
+
+Transient -- worth retrying after a wait:
+
+- ``openai.RateLimitError`` (HTTP 429) -- the documented failure mode for this
+  project's pinned single-provider routes under sustained load
+  (``docs/END_TO_END_EVALUATION.md``);
+- ``openai.APITimeoutError`` / ``openai.APIConnectionError`` -- the call never
+  got a usable response (the SDK wraps every transport-level fault in one of
+  these);
+- ``openai.InternalServerError`` and any other ``openai.APIStatusError`` whose
+  status is 429 or 5xx -- the upstream is briefly unwell.
+
+Everything else -- a 4xx that is not 429 (a malformed request, auth, a model
+that does not exist), a schema-validation error, a bug -- is real: retrying it
+just burns the budget.
+
+The raised exception is often wrapped (LangChain re-raises, ``RunAssessment``
+re-raises as a typed error), so the whole ``__cause__`` / ``__context__`` chain
+is walked.
+"""
+
+from __future__ import annotations
+
+import openai
+
+_TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
+    openai.RateLimitError,
+    openai.APITimeoutError,
+    openai.APIConnectionError,
+    openai.InternalServerError,
+)
+
+_TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient_single(exc: BaseException) -> bool:
+    if isinstance(exc, _TRANSIENT_TYPES):
+        return True
+    if isinstance(exc, openai.APIStatusError):
+        return exc.status_code in _TRANSIENT_STATUS_CODES
+    return False
+
+
+def is_transient_llm_error(exc: BaseException) -> bool:
+    """Whether ``exc`` (or anything it wraps) is a retryable provider fault."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if _is_transient_single(current):
+            return True
+        current = current.__cause__ or current.__context__
+    return False

--- a/app/src/infrastructure/queue/__init__.py
+++ b/app/src/infrastructure/queue/__init__.py
@@ -1,0 +1,20 @@
+"""The [M5-05] asynchronous-processing queue: RQ over Redis.
+
+``RqAssessmentQueue`` is the ``AssessmentQueue`` port's adapter (used by the API
+composition root); ``tasks.run_assessment_job`` is the function RQ runs on a
+worker; ``worker.run_worker`` is ``make worker``.
+"""
+
+from infrastructure.queue.rq_queue import (
+    DEFAULT_JOB_PATH,
+    QUEUE_NAME,
+    RqAssessmentQueue,
+    build_assessment_queue,
+)
+
+__all__ = [
+    "DEFAULT_JOB_PATH",
+    "QUEUE_NAME",
+    "RqAssessmentQueue",
+    "build_assessment_queue",
+]

--- a/app/src/infrastructure/queue/rq_queue.py
+++ b/app/src/infrastructure/queue/rq_queue.py
@@ -1,0 +1,76 @@
+"""The ``AssessmentQueue`` adapter -- an RQ job on a Redis-backed queue [M5-05].
+
+``RqAssessmentQueue.enqueue`` turns a persisted ``PENDING`` job into an RQ job:
+
+- ``job_id`` == ``assessment_id`` -- the id a caller polls is the queue key, so a
+  re-submission (a fresh ``assessment_id``) is a distinct job and a redelivery
+  reuses the same one;
+- ``retry`` -- RQ's native retry-with-backoff, sized from
+  ``QueueSettings.assessment_max_retries`` / ``rq_retry_intervals``. RQ retries on
+  *any* exception; the worker's ``stop_retry_on_permanent`` handler cancels the
+  budget for a real (non-transient) failure so it dead-letters immediately;
+- ``job_timeout`` -- a 207-page assessment is minutes of work, not the RQ default.
+"""
+
+from __future__ import annotations
+
+import redis
+from rq import Queue, Retry
+
+from infrastructure.config.settings import QueueSettings
+
+QUEUE_NAME = "assessments"
+DEFAULT_JOB_PATH = "infrastructure.queue.tasks.run_assessment_job"
+
+
+class RqAssessmentQueue:
+    """Schedule assessment runs on an RQ queue. Implements ``AssessmentQueue``."""
+
+    def __init__(
+        self,
+        queue: Queue,
+        *,
+        job_path: str = DEFAULT_JOB_PATH,
+        max_attempts: int,
+        retry_intervals: list[int],
+        job_timeout: int,
+    ) -> None:
+        """Wire the adapter to its RQ queue and retry/timeout policy."""
+        self._queue = queue
+        self._job_path = job_path
+        self._max_attempts = max_attempts
+        self._retry_intervals = retry_intervals
+        self._job_timeout = job_timeout
+
+    def enqueue(self, assessment_id: str) -> None:
+        """Queue ``assessment_id`` for a worker, with retry + timeout attached."""
+        retry: Retry | None = None
+        if self._max_attempts > 1:
+            retry = Retry(
+                max=self._max_attempts - 1,
+                interval=self._retry_intervals or 0,
+            )
+        self._queue.enqueue(
+            self._job_path,
+            assessment_id,
+            job_id=assessment_id,
+            job_timeout=self._job_timeout,
+            retry=retry,
+        )
+
+
+def build_assessment_queue(
+    settings: QueueSettings,
+    *,
+    connection: redis.Redis | None = None,
+    job_path: str = DEFAULT_JOB_PATH,
+) -> RqAssessmentQueue:
+    """Build the queue adapter from settings (opening a Redis connection if needed)."""
+    conn = connection or redis.Redis.from_url(settings.redis_url)
+    return RqAssessmentQueue(
+        Queue(QUEUE_NAME, connection=conn),
+        job_path=job_path,
+        max_attempts=settings.assessment_max_retries,
+        retry_intervals=settings.rq_retry_intervals,
+        job_timeout=settings.assessment_job_timeout_seconds,
+    )

--- a/app/src/infrastructure/queue/tasks.py
+++ b/app/src/infrastructure/queue/tasks.py
@@ -1,0 +1,53 @@
+"""The function RQ runs on a worker for one queued assessment [M5-05].
+
+RQ enqueues a dotted path (``infrastructure.queue.tasks.run_assessment_job``) and
+each worker process imports and calls it. The heavy dependencies -- the chat
+models, the retrieval stack, the LangGraph orchestrator -- are built once per
+worker process and reused across jobs, behind a lazy, thread-safe singleton. The
+build is deferred to the first job (not import time) so it happens *after* the
+worker pool has forked: torch and sentence-transformers do not survive a fork
+cleanly, and each worker loading its own copy post-fork is the safe shape.
+
+Tests substitute a different job path (``tests.integration._queue_fakes``) rather
+than reaching in here, so this module has no test seam.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from application.use_cases.run_assessment import RunAssessment
+from infrastructure.bootstrap import build_core_components
+from infrastructure.clock import SystemClock
+from infrastructure.config.settings import get_queue_settings
+from infrastructure.llm_errors import is_transient_llm_error
+
+_lock = threading.Lock()
+_runner: RunAssessment | None = None
+
+
+def build_runner() -> RunAssessment:
+    """Build a fully-wired ``RunAssessment`` from the process-wide composition root."""
+    core = build_core_components()
+    settings = get_queue_settings()
+    return RunAssessment(
+        clock=SystemClock(),
+        orchestrator=core.orchestrator,
+        uow_factory=core.uow_factory,
+        is_transient=is_transient_llm_error,
+        max_attempts=settings.assessment_max_retries,
+    )
+
+
+def _runner_singleton() -> RunAssessment:
+    global _runner
+    if _runner is None:
+        with _lock:
+            if _runner is None:
+                _runner = build_runner()
+    return _runner
+
+
+def run_assessment_job(assessment_id: str) -> None:
+    """RQ entry point: process one queued assessment run to the human checkpoint."""
+    _runner_singleton()(assessment_id)

--- a/app/src/infrastructure/queue/worker.py
+++ b/app/src/infrastructure/queue/worker.py
@@ -1,0 +1,70 @@
+"""Run the assessment worker pool -- ``make worker`` [M5-05].
+
+``run_worker`` starts ``QueueSettings.assessment_worker_concurrency`` RQ workers
+against the ``assessments`` queue. That number is the DoD's configurable
+parallelism bound: each worker runs one assessment at a time, so it is also the
+count of concurrent graph runs hitting the LLM provider.
+
+``SimpleWorker`` (no fork per job) is deliberate: the retrieval stack is
+expensive to load, and a forking worker would reload it for every job. Each pool
+worker loads it once (lazily, in ``tasks._runner_singleton``) and reuses it.
+
+``stop_retry_on_permanent`` is the transient/real split at the queue boundary:
+RQ's ``Retry`` reschedules on any exception, so a real
+``PermanentAssessmentError`` has its retry budget zeroed here and drops straight
+into the ``FailedJobRegistry`` (the dead-letter), traceback preserved. A
+``TransientAssessmentError`` is left alone -- RQ retries it with backoff until the
+budget runs out, then dead-letters it too.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import TracebackType
+
+import redis
+from rq import SimpleWorker
+from rq.job import Job
+from rq.worker_pool import WorkerPool
+
+from application.errors import PermanentAssessmentError
+from infrastructure.config.settings import (
+    get_observability_settings,
+    get_queue_settings,
+)
+from infrastructure.queue.rq_queue import QUEUE_NAME
+
+logger = logging.getLogger(__name__)
+
+
+def stop_retry_on_permanent(
+    job: Job,
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    traceback: TracebackType | None,
+) -> bool:
+    """Cancel the retry budget for a real failure so it dead-letters now."""
+    if isinstance(exc_value, PermanentAssessmentError):
+        job.retries_left = 0
+    return True  # let RQ's default failure handling proceed
+
+
+def run_worker() -> None:
+    """Start the worker pool and block until it is stopped."""
+    logging.basicConfig(level=get_observability_settings().log_level)
+    settings = get_queue_settings()
+    connection = redis.Redis.from_url(settings.redis_url)
+
+    pool = WorkerPool(
+        [QUEUE_NAME],
+        connection=connection,
+        num_workers=settings.assessment_worker_concurrency,
+        worker_class=SimpleWorker,
+        exception_handlers=[stop_retry_on_permanent],
+    )
+    logger.info(
+        "assessment worker pool starting: %d worker(s) on %r",
+        settings.assessment_worker_concurrency,
+        QUEUE_NAME,
+    )
+    pool.start()

--- a/app/src/presentation/app.py
+++ b/app/src/presentation/app.py
@@ -1,13 +1,13 @@
 """The FastAPI app and its composition root -- [M5-04].
 
 ``create_app()`` mounts the routers and the error edge. ``_default_lifespan``
-is the composition root: it builds the process-wide singletons (the DB engine
-and session factory, the two chat models, the retrieval components, the
-LangGraph orchestrator, the clock, the id minter), stashes them on
-``app.state.components`` for the dependency layer, and disposes the engine on
-shutdown. A checkpointer probe at startup turns a missing checkpointer schema
-into an actionable "run ``make setup-checkpointer``" message before the first
-request rather than after it.
+is the composition root: it calls ``infrastructure.bootstrap.build_core_components``
+(the heavy singletons -- DB engine, chat models, retrieval stack, LangGraph
+orchestrator -- shared with the [M5-05] worker), adds the request-scoped bits
+(the clock, the id minter, the Redis-backed ``AssessmentQueue``), stashes them on
+``app.state.components``, and disposes the engine on shutdown. ``build_core_components``
+probes the checkpointer at startup so a missing schema is an actionable "run
+``make setup-checkpointer``" message before the first request, not after.
 
 ``lifespan`` is injectable so a test can supply its own composition (real
 Postgres, a fake-context orchestrator) without the heavy model / retriever load
@@ -26,27 +26,14 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from uuid import uuid4
 
 from fastapi import FastAPI
-from sqlalchemy.orm import Session
 
+from infrastructure.bootstrap import build_core_components
 from infrastructure.clock import SystemClock
-from infrastructure.config.llm_client_factory import build_chat_model
 from infrastructure.config.settings import (
-    get_database_settings,
-    get_llm_settings,
     get_observability_settings,
+    get_queue_settings,
 )
-from infrastructure.database import (
-    create_engine_from_settings,
-    create_session_factory,
-    sqlalchemy_unit_of_work_factory,
-)
-from infrastructure.graph.checkpointer import open_claim_checkpointer
-from infrastructure.graph.context import GraphContext
-from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
-from infrastructure.rag.retriever_factory import (
-    build_graph_retriever,
-    load_retriever_components,
-)
+from infrastructure.queue import build_assessment_queue
 from presentation.dependencies import AppComponents
 from presentation.errors import register_exception_handlers
 from presentation.routes import assessments, health
@@ -59,57 +46,24 @@ _LifespanFactory = Callable[[FastAPI], AbstractAsyncContextManager[None]]
 @asynccontextmanager
 async def _default_lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Build the production composition root and tear it down on shutdown."""
-    obs = get_observability_settings()
-    logging.basicConfig(level=obs.log_level)
+    logging.basicConfig(level=get_observability_settings().log_level)
 
-    db = get_database_settings()
-    engine = create_engine_from_settings(db)
-    session_factory = create_session_factory(engine=engine)
-
-    # Fail fast with the actionable message if the checkpointer schema is absent.
-    with open_claim_checkpointer(db.sqlalchemy_database_url):
-        pass
-
-    llm = get_llm_settings()
-    fast_model = build_chat_model(
-        llm,
-        llm.llm_model_fast,
-        provider_order=llm.llm_fast_provider_order,
-        allow_fallbacks=llm.llm_fast_allow_fallbacks,
-    )
-    reasoning_model = build_chat_model(
-        llm,
-        llm.llm_model_reasoning,
-        provider_order=llm.llm_reasoning_provider_order,
-        allow_fallbacks=llm.llm_reasoning_allow_fallbacks,
-    )
-    retriever_components = load_retriever_components()
-
-    def context_factory(session: Session) -> GraphContext:
-        return GraphContext(
-            fast_model=fast_model,
-            reasoning_model=reasoning_model,
-            retriever=build_graph_retriever(session, retriever_components),
-            llm_settings=llm,
-            audit_sink=None,
-        )
+    core = build_core_components()
+    queue = build_assessment_queue(get_queue_settings())
 
     app.state.components = AppComponents(
         clock=SystemClock(),
-        orchestrator=LangGraphClaimAssessmentOrchestrator(
-            context_factory=context_factory,
-            session_factory=session_factory,
-            database_url=db.sqlalchemy_database_url,
-        ),
-        uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
-        session_factory=session_factory,
+        queue=queue,
+        orchestrator=core.orchestrator,
+        uow_factory=core.uow_factory,
+        session_factory=core.session_factory,
         new_id=lambda: str(uuid4()),
     )
     logger.info("assessment API composition root ready")
     try:
         yield
     finally:
-        engine.dispose()
+        core.dispose()
 
 
 def create_app(*, lifespan: _LifespanFactory | None = None) -> FastAPI:

--- a/app/src/presentation/dependencies.py
+++ b/app/src/presentation/dependencies.py
@@ -21,6 +21,7 @@ from typing import Annotated, cast
 from fastapi import Depends, Request
 from sqlalchemy.orm import Session, sessionmaker
 
+from application.ports.assessment_queue import AssessmentQueue
 from application.ports.claim_assessment_orchestrator import ClaimAssessmentOrchestrator
 from application.ports.clock import Clock
 from application.ports.unit_of_work import UnitOfWorkFactory
@@ -30,6 +31,7 @@ from application.use_cases.list_assessments import ListAssessments
 from application.use_cases.submit_claim import SubmitClaim
 from application.use_cases.submit_human_decision import SubmitHumanDecision
 from infrastructure.database import (
+    SqlAlchemyAssessmentJobRepository,
     SqlAlchemyAssessmentRepository,
     SqlAlchemyAuditTrailReader,
     SqlAlchemyClauseRepository,
@@ -41,6 +43,7 @@ class AppComponents:
     """The process-wide singletons the composition root builds once."""
 
     clock: Clock
+    queue: AssessmentQueue
     orchestrator: ClaimAssessmentOrchestrator
     uow_factory: UnitOfWorkFactory
     session_factory: sessionmaker[Session]
@@ -64,8 +67,13 @@ def get_clock(request: Request) -> Clock:
 
 
 def get_orchestrator(request: Request) -> ClaimAssessmentOrchestrator:
-    """The LangGraph-backed assessment orchestrator."""
+    """The LangGraph-backed assessment orchestrator (resume path)."""
     return _components(request).orchestrator
+
+
+def get_queue(request: Request) -> AssessmentQueue:
+    """The Redis-backed queue ``SubmitClaim`` hands a new job to."""
+    return _components(request).queue
 
 
 def get_uow_factory(request: Request) -> UnitOfWorkFactory:
@@ -81,20 +89,21 @@ def get_new_id(request: Request) -> Callable[[], str]:
 _Session = Annotated[Session, Depends(get_read_session)]
 _Clock = Annotated[Clock, Depends(get_clock)]
 _Orchestrator = Annotated[ClaimAssessmentOrchestrator, Depends(get_orchestrator)]
+_Queue = Annotated[AssessmentQueue, Depends(get_queue)]
 _UowFactory = Annotated[UnitOfWorkFactory, Depends(get_uow_factory)]
 _NewId = Annotated[Callable[[], str], Depends(get_new_id)]
 
 
 def get_submit_claim(
     clock: _Clock,
-    orchestrator: _Orchestrator,
+    queue: _Queue,
     uow_factory: _UowFactory,
     new_id: _NewId,
 ) -> SubmitClaim:
     """Wire ``SubmitClaim`` for one request."""
     return SubmitClaim(
         clock=clock,
-        orchestrator=orchestrator,
+        queue=queue,
         uow_factory=uow_factory,
         new_id=new_id,
     )
@@ -102,7 +111,10 @@ def get_submit_claim(
 
 def get_get_assessment(session: _Session) -> GetAssessment:
     """Wire ``GetAssessment`` for one request."""
-    return GetAssessment(assessments=SqlAlchemyAssessmentRepository(session))
+    return GetAssessment(
+        assessments=SqlAlchemyAssessmentRepository(session),
+        jobs=SqlAlchemyAssessmentJobRepository(session),
+    )
 
 
 def get_list_assessments(session: _Session) -> ListAssessments:
@@ -130,5 +142,6 @@ def get_get_audit_trail(session: _Session) -> GetAuditTrail:
     """Wire ``GetAuditTrail`` for one request."""
     return GetAuditTrail(
         assessments=SqlAlchemyAssessmentRepository(session),
+        jobs=SqlAlchemyAssessmentJobRepository(session),
         audit=SqlAlchemyAuditTrailReader(session),
     )

--- a/app/src/presentation/mappers.py
+++ b/app/src/presentation/mappers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from application.assessment_record import AssessmentRecord
+from application.assessment_read_model import AssessmentReadModel
 from application.audit_trail_entry import AuditTrailEntry
 from application.consistency_flag import ConsistencyFlag
 from application.edited_assessment_input import EditedAssessmentInput
@@ -80,12 +80,25 @@ def _decision_schema(decision: HumanDecision) -> HumanDecisionSchema:
     )
 
 
-def assessment_response(record: AssessmentRecord) -> AssessmentResponse:
-    """Render an ``AssessmentRecord`` as the API response model."""
+def assessment_response(model: AssessmentReadModel) -> AssessmentResponse:
+    """Render the lifecycle view as the API response model.
+
+    A ``pending`` / ``running`` / ``failed`` model has no ``record`` yet -- the
+    recommendation fields stay at their defaults and ``error`` carries the cause.
+    """
+    record = model.record
+    if record is None:
+        return AssessmentResponse(
+            assessment_id=model.assessment_id,
+            claim_id=model.claim_id,
+            status=model.status,
+            error=model.error,
+            created_at=model.created_at,
+        )
     return AssessmentResponse(
         assessment_id=record.assessment_id,
         claim_id=record.claim_id,
-        status=record.status.value,
+        status=model.status,
         verdict=record.verdict.value,
         reasoning=record.reasoning,
         recommended_action=record.recommended_action,

--- a/app/src/presentation/routes/assessments.py
+++ b/app/src/presentation/routes/assessments.py
@@ -2,13 +2,14 @@
 
 Five routes over the four use cases:
 
-- ``POST /v1/assessments`` -> ``SubmitClaim``. Returns **202** with the id in the
-  body and in ``Location``. The graph runs synchronously in the handler for now
-  (minutes, LLM calls); [M5-05]'s queue makes it truly non-blocking and adds
-  ``PENDING/RUNNING/FAILED`` run states.
-- ``GET /v1/assessments`` -> ``ListAssessments`` (newest first).
-- ``GET /v1/assessments/{id}`` -> ``GetAssessment`` (state, recommendation,
-  structured citations).
+- ``POST /v1/assessments`` -> ``SubmitClaim``. Persists a ``pending`` job,
+  enqueues it, returns **202** with the id in the body and in ``Location``. The
+  graph runs later on a worker ([M5-05]).
+- ``GET /v1/assessments`` -> ``ListAssessments`` (completed assessments, newest
+  first -- queued/failed jobs are not listed here).
+- ``GET /v1/assessments/{id}`` -> ``GetAssessment``. The lifecycle view:
+  ``pending`` / ``running`` / ``failed`` while the run is in flight, then the
+  recommendation and structured citations once ``awaiting_review``.
 - ``POST /v1/assessments/{id}/decision`` -> ``SubmitHumanDecision``. Resumes the
   paused run and returns the settled record (200 -- the resume completes).
 - ``GET /v1/assessments/{id}/audit`` -> ``GetAuditTrail``. Empty until a decision
@@ -24,6 +25,7 @@ from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query, Response
 
+from application.assessment_read_model import AssessmentReadModel
 from application.assessment_record import AssessmentStatus
 from application.use_cases.get_assessment import GetAssessment
 from application.use_cases.get_audit_trail import GetAuditTrail
@@ -71,16 +73,17 @@ def submit_claim(
     response: Response,
     use_case: _SubmitClaim,
 ) -> SubmitClaimResponse:
-    """Accept a claim, run it to the human checkpoint, return 202 + the id."""
-    record = use_case(
+    """Accept a claim, queue it for assessment, return 202 + the id.
+
+    The graph runs later on a worker ([M5-05]); poll ``GET /v1/assessments/{id}``.
+    """
+    job = use_case(
         raw_text=body.raw_text,
         policy_ref=to_policy_ref(body.policy_ref),
         claim_id=body.claim_id,
     )
-    response.headers["Location"] = f"/v1/assessments/{record.assessment_id}"
-    return SubmitClaimResponse(
-        assessment_id=record.assessment_id, status=record.status.value
-    )
+    response.headers["Location"] = f"/v1/assessments/{job.assessment_id}"
+    return SubmitClaimResponse(assessment_id=job.assessment_id, status="pending")
 
 
 @router.get("", response_model=list[AssessmentResponse])
@@ -98,7 +101,10 @@ def list_assessments(
         limit=limit,
         offset=offset,
     )
-    return [assessment_response(record) for record in records]
+    return [
+        assessment_response(AssessmentReadModel.from_record(record))
+        for record in records
+    ]
 
 
 @router.get("/{assessment_id}", response_model=AssessmentResponse)
@@ -106,7 +112,7 @@ def get_assessment(
     assessment_id: str,
     use_case: _GetAssessment,
 ) -> AssessmentResponse:
-    """Return one assessment's state, recommendation and citations."""
+    """Return one assessment's lifecycle state -- and its recommendation once ready."""
     return assessment_response(use_case(assessment_id))
 
 
@@ -123,7 +129,7 @@ def submit_decision(
         notes=body.notes,
         edited=edited_from_request(body),
     )
-    return assessment_response(record)
+    return assessment_response(AssessmentReadModel.from_record(record))
 
 
 @router.get("/{assessment_id}/audit", response_model=AuditTrailResponse)

--- a/app/src/presentation/schemas.py
+++ b/app/src/presentation/schemas.py
@@ -23,6 +23,10 @@ from pydantic import BaseModel, Field
 
 _VERDICTS = Literal["compatible", "incompatible", "insufficient_information"]
 _DECISIONS = Literal["approve", "edit", "reject"]
+# The lifecycle a caller polls ([M5-05]): `pending` / `running` while the queued
+# run is in flight, `failed` if it dead-lettered, then `awaiting_review` /
+# `decided` once the graph has produced a recommendation.
+_READ_STATUS = Literal["pending", "running", "awaiting_review", "decided", "failed"]
 
 
 class CitationSchema(BaseModel):
@@ -66,21 +70,28 @@ class HumanDecisionSchema(BaseModel):
 
 
 class AssessmentResponse(BaseModel):
-    """One claim's assessment across its whole lifecycle -- the servable aggregate."""
+    """One claim's assessment across its whole lifecycle -- the servable view.
+
+    While the run is still ``pending`` / ``running`` (or has ``failed``), no
+    recommendation exists yet: the verdict/prose/citation fields are ``null`` /
+    empty and ``error`` carries the failure cause. They are populated once
+    ``status`` reaches ``awaiting_review``.
+    """
 
     assessment_id: str
     claim_id: str
-    status: Literal["awaiting_review", "decided"]
-    verdict: _VERDICTS
-    reasoning: str
-    recommended_action: str
-    confidence: float
-    citations: list[CitationSchema]
-    consistency_flags: list[ConsistencyFlagSchema]
-    context_sufficient: bool | None
-    clarification_exhausted: bool
-    missing_information: list[str]
-    is_grounded: bool
+    status: _READ_STATUS
+    error: str | None = None
+    verdict: _VERDICTS | None = None
+    reasoning: str | None = None
+    recommended_action: str | None = None
+    confidence: float | None = None
+    citations: list[CitationSchema] = Field(default_factory=list)
+    consistency_flags: list[ConsistencyFlagSchema] = Field(default_factory=list)
+    context_sufficient: bool | None = None
+    clarification_exhausted: bool = False
+    missing_information: list[str] = Field(default_factory=list)
+    is_grounded: bool = False
     created_at: datetime
     decision: HumanDecisionSchema | None = None
 
@@ -129,10 +140,14 @@ class SubmitClaimRequest(BaseModel):
 
 
 class SubmitClaimResponse(BaseModel):
-    """The 202 body of ``POST /v1/assessments``; the id also rides in ``Location``."""
+    """The 202 body of ``POST /v1/assessments``; the id also rides in ``Location``.
+
+    ``status`` is ``pending`` -- the run is queued. Poll ``GET /v1/assessments/{id}``
+    for ``running`` -> ``awaiting_review`` (or ``failed``).
+    """
 
     assessment_id: str
-    status: Literal["awaiting_review", "decided"]
+    status: _READ_STATUS
 
 
 class CitationInput(BaseModel):

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,10 @@
-# Local database for development and integration tests.
+# Local infrastructure for development and integration tests.
 #
-# [M0-08] brings up the database *capability* only. [M5-09] adds the api,
-# redis and langfuse services to this same file -- the service block below is
-# self-contained and reads its configuration from the same `${DATABASE_*}`
-# variables those services will, so they are appended rather than requiring a
-# rewrite.
+# [M0-08] brought up the database. [M5-05] adds `redis` -- the asynchronous
+# assessment queue (`make worker`) needs it, and so does `make test-integration`.
+# [M5-09] still adds the `api` / `worker` / `langfuse` services (once there is a
+# Dockerfile to run them from). Every block reads its configuration from the same
+# `${...}` variables those services will, so they are appended, not rewritten.
 services:
   postgres:
     # Postgres major and pgvector version are both explicit: the floating
@@ -31,6 +31,21 @@ services:
         ]
       interval: 5s
       timeout: 5s
+      retries: 12
+
+  redis:
+    # Pinned major like postgres above. The queue is transient work state, not a
+    # store of record: persistence is disabled so a restart is a clean slate.
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      # `make worker` and pytest connect from the host.
+      - ${REDIS_PORT:-6379}:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
       retries: 12
 
 volumes:

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,13 +5,19 @@ envelope, citations as structured objects. The graph stays entirely behind
 `ClaimAssessmentOrchestrator` — no route, schema or mapper imports LangGraph.
 
 ```
-POST   /v1/assessments                     submit a claim            -> 202 + id
-GET    /v1/assessments                      list, newest first       -> 200
-GET    /v1/assessments/{id}                 state + recommendation   -> 200
+POST   /v1/assessments                     submit a claim (queued)  -> 202 + id
+GET    /v1/assessments                      list completed, newest   -> 200
+GET    /v1/assessments/{id}                 lifecycle + recommendation -> 200
 POST   /v1/assessments/{id}/decision        approve / edit / reject  -> 200
 GET    /v1/assessments/{id}/audit           durable audit trail      -> 200
 GET    /health                              liveness                 -> 200
 ```
+
+Since [M5-05] the graph runs on a background worker, not in the request. `POST`
+persists a job and returns; `GET /v1/assessments/{id}` reports a lifecycle
+`status` — `pending` → `running` → `awaiting_review` (or `failed`) — and fills in
+the recommendation once it reaches `awaiting_review`. See
+[`ASYNC_PROCESSING.md`](ASYNC_PROCESSING.md).
 
 Code:
 
@@ -61,17 +67,28 @@ is missing. The checkpointer schema is probed at startup too.
 ```
 
 `202 Accepted`, `Location: /v1/assessments/<id>`, body `{"assessment_id": "<id>",
-"status": "awaiting_review"}`. The graph runs synchronously to the human
-checkpoint before the response returns (see *Findings*). `policy_ref` is
-prepended to the narrative as `[Apólice registrada: processo SUSEP …]` so intake
-extracts it and retrieval pre-filters on it.
+"status": "pending"}`. The claim is queued; a worker runs the graph. Poll
+`GET /v1/assessments/{id}`. `policy_ref` is stored on the job and prepended to the
+narrative as `[Apólice registrada: processo SUSEP …]` so intake extracts it and
+retrieval pre-filters on it.
 
-### `GET /v1/assessments/{id}` and `GET /v1/assessments`
+### `GET /v1/assessments/{id}`
 
-The full servable aggregate:
+The lifecycle view. While the run is queued or failed there is no
+recommendation yet — the verdict/prose/citation fields are `null` / `[]` and
+`error` carries the failure cause:
+
+```json
+{ "assessment_id": "...", "claim_id": "...", "status": "pending",
+  "error": null, "verdict": null, "citations": [], "is_grounded": false,
+  "created_at": "2026-09-04T12:00:00Z", "decision": null }
+```
+
+Once `status` reaches `awaiting_review` (or `decided`) it is the full aggregate:
 
 ```json
 { "assessment_id": "...", "claim_id": "...", "status": "awaiting_review",
+  "error": null,
   "verdict": "compatible", "reasoning": "...", "recommended_action": "...",
   "confidence": 0.72, "is_grounded": true,
   "citations": [ { "clause_id": "...", "document_id": "...",
@@ -85,8 +102,14 @@ The full servable aggregate:
   "decision": null }
 ```
 
-The collection endpoint takes `claim_id`, `status`, `limit` (>0, default 50) and
-`offset` (>=0), newest first.
+`status` is one of `pending`, `running`, `awaiting_review`, `decided`, `failed`.
+
+### `GET /v1/assessments`
+
+The collection endpoint lists **completed** assessments (`awaiting_review` /
+`decided`) — queued and failed jobs are not here. Takes `claim_id`, `status`
+(`awaiting_review` / `decided`), `limit` (>0, default 50) and `offset` (>=0),
+newest first.
 
 ### `POST /v1/assessments/{id}/decision`
 
@@ -140,29 +163,34 @@ Uniform envelope; `code` is stable, branch on it:
 | `invalid_susep_process` / `invalid_value_object` / `verdict_not_permitted` | 422 | a malformed `policy_ref` or `edited` payload |
 | `invalid_request` | 422 | an `edit` without a payload, a non-`edit` carrying one, bad paging |
 | `request_validation_error` | 422 | the body failed schema validation (`details.errors`) |
-| `orchestrator_contract_error` | 502 | `start` did not pause / `resume` did not finish |
+| `orchestrator_contract_error` | 502 | `resume` did not finish (a bad `start` is a `failed` job, not an error here) |
 | `internal_error` | 500 | anything unexpected — logged, no traceback in the body |
 
 ## Results
 
-`tests/integration/test_assessment_api.py` runs the whole flow against real
-Postgres (the assessment/decision/audit tables and the LangGraph checkpointer)
-with a canned-output model and a one-clause stub retriever: `POST` → 202 + id →
-`GET` shows `awaiting_review` + a `compatible` recommendation + a structured
-citation → `GET …/audit` is empty → `POST …/decision {approve}` → 200 `decided`
-→ `GET` shows the system verdict unchanged beside the decision → `GET …/audit`
-shows the trail ending in `human_review` / `human_decision:approve` with the
-decision in `payload`. A second decision returns 409. The `reject` and `edit`
-paths, the unknown-clause 422, the unknown-id 404, and the transactional fold
-(a `SELECT count(*) FROM audit_event` proving the trail committed with the
-`DECIDED` record) are covered too.
+`tests/integration/test_assessment_api.py` runs the decision flow against real
+Postgres (the assessment/decision/audit/job tables and the LangGraph
+checkpointer) with a canned-output model and a one-clause stub retriever. It
+stubs the [M5-05] queue with an *inline* one that runs `RunAssessment`
+synchronously on enqueue, so `POST` → `GET awaiting_review` + a `compatible`
+recommendation + a structured citation → `GET …/audit` is empty → `POST
+…/decision {approve}` → 200 `decided` → `GET` shows the system verdict unchanged
+beside the decision → `GET …/audit` ends in `human_review` /
+`human_decision:approve` with the decision in `payload`. A second decision
+returns 409. The `reject` and `edit` paths, the unknown-clause 422, the
+unknown-id 404, and the transactional fold (a `SELECT count(*) FROM audit_event`
+proving the trail committed with the `DECIDED` record) are covered too. The real
+Redis round-trip — submission → worker → completion, transient retry, dead-letter
+— is `tests/integration/test_assessment_queue.py` (see
+[`ASYNC_PROCESSING.md`](ASYNC_PROCESSING.md)).
 
 ## Findings
 
-1. **`POST` is synchronous behind its 202.** The handler blocks for the whole
-   graph run (minutes, many LLM calls). This is the interim: [M5-05] owns the
-   Redis queue and the `PENDING/RUNNING/FAILED` run states that make it truly
-   non-blocking. The 202 + `Location` contract does not change.
+1. **`POST` is non-blocking as of [M5-05].** It persists an `AssessmentJob` in
+   `pending` and enqueues it; a worker (`make worker`) runs the graph. `GET
+   /v1/assessments/{id}` reports `pending` → `running` → `awaiting_review` (or
+   `failed`, with the cause in `error`). Details, the retry/back-off policy and
+   the dead-letter path: [`ASYNC_PROCESSING.md`](ASYNC_PROCESSING.md).
 2. **The audit trail is empty before a decision.** By [M4-09] design the durable
    trail is written once, in `human_review`, after the analyst decides. `GET
    …/audit` on an `AWAITING_REVIEW` assessment is `200 {"entries": []}`, not a
@@ -181,12 +209,14 @@ paths, the unknown-clause 422, the unknown-id 404, and the transactional fold
 
 ## What this leaves for later
 
-- **[M5-05]** — Redis-backed queue, bounded concurrency, retry/back-off,
-  dead-letter, and the `PENDING/RUNNING/FAILED` run states behind a non-blocking
-  202.
+- **[M5-05] done** — Redis/RQ queue, `ASSESSMENT_WORKER_CONCURRENCY`,
+  retry-with-backoff on transient provider faults, dead-letter, and the
+  `pending` / `running` / `failed` lifecycle behind the non-blocking 202.
+  See [`ASYNC_PROCESSING.md`](ASYNC_PROCESSING.md).
 - **[M5-06]** — `GET /ready` with per-check detail, JSON logs to stdout, and
   correlation-id propagation from the request into every node and LLM call.
-- **[M5-09]** — the Compose `api` service, the Dockerfile, the CI image build,
-  and the proxy-header / trusted-host middleware from `ObservabilitySettings`.
+- **[M5-09]** — the Compose `api` / `worker` services, the Dockerfile, the CI
+  image build, and the proxy-header / trusted-host middleware from
+  `ObservabilitySettings`.
 - A pooled checkpointer connection (`docs/DATABASE.md` "the M5 shape") — the
   adapter opens one per `start` / `resume` today.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -859,7 +859,63 @@ LangGraph checkpointer) with a fake model and stub retriever: submit → 202 →
 runs the presentation unit tests.
 
 **Downstream.** [M5-05] replaces the synchronous 202 with a Redis queue and adds
-run-status states. [M5-06] adds `/ready`, JSON logging and correlation-id
-propagation. [M5-09] adds the Compose `api` service, the Dockerfile and the CI
-image build, and wires the proxy-header / trusted-host middleware from
+run-status states (below). [M5-06] adds `/ready`, JSON logging and correlation-id
+propagation. [M5-09] adds the Compose `api` / `worker` services, the Dockerfile
+and the CI image build, and wires the proxy-header / trusted-host middleware from
 `ObservabilitySettings`.
+
+---
+
+## Asynchronous assessment: an RQ/Redis queue behind a non-blocking 202 — [M5-05]
+
+**Decision.** `POST /v1/assessments` no longer runs the graph. `SubmitClaim`
+persists an `application.assessment_job.AssessmentJob` (`PENDING`) and enqueues
+it on an RQ queue; `RunAssessment` (a new use case) runs on
+`ASSESSMENT_WORKER_CONCURRENCY` workers (`make worker` / `scripts/run_assessment_worker.py`),
+drives the claim to the human checkpoint through the orchestrator port, and — on
+success — writes the `AssessmentRecord` and flips the job to `SUCCEEDED` in one
+transaction. New ports: `AssessmentQueue`, `AssessmentJobRepository` (added to
+`UnitOfWork`). New infra: `infrastructure/queue/` (the RQ adapter, the job
+function, the worker pool), `infrastructure/llm_errors.py` (the transient
+classifier), `infrastructure/bootstrap.py` (the heavy singletons, now shared by
+the API `lifespan` and the worker). `GET /v1/assessments/{id}` returns an
+`AssessmentReadModel` spanning the lifecycle. Full walkthrough:
+`docs/ASYNC_PROCESSING.md`.
+
+**Why RQ, and why a separate aggregate.** RQ is the sync Redis-backed queue the
+"reuse the queue pattern professionally" framing points at — native
+`Retry(interval=[…])` for backoff, `FailedJobRegistry` for the dead-letter, and
+`WorkerPool` for concurrency, with no second broker. The codebase is sync
+throughout (SQLAlchemy/psycopg3, `compiled.invoke`, sentence-transformers), so a
+sync worker is the honest shape. `AssessmentJob` is deliberately **not** part of
+`AssessmentRecord`: the record's invariants (non-empty verdict/prose, the
+≥1-citation projection) can't represent a claim that has not been assessed yet,
+and weakening them to bolt on a `PENDING` state would undo M5-01/02. Two
+aggregates, two tables; the read path composes them.
+
+**Why retry stays at the job boundary.** The transient/real split
+(`is_transient_llm_error` + RQ `Retry` + the `stop_retry_on_permanent` handler)
+lives entirely in the queue layer. The six per-node `_invoke_with_retry` helpers
+are untouched — they cover a mid-run blip (seconds); a sustained 429 now bubbles
+past them to the job, which backs off for minutes, which is what
+`docs/END_TO_END_EVALUATION.md` measured a rate limit needs. Keeping M4 node code
+out of scope also keeps the M4 eval baselines reproducible.
+
+**Deviations on record.** (a) `GET /v1/assessments` (list) stays record-only —
+queued/failed jobs are not in the collection; the per-id `GET` is "status
+tracking per assessment id". (b) `SubmitClaim` commits the job before enqueueing
+it, so a crash in that window leaves a `PENDING` job that is never picked up — a
+reconciler is left to operations. (c) The checkpointer connection is still
+per-call, not pooled (`docs/DATABASE.md` "the M5 shape"). (d) `compose.yaml`
+gains `redis`; the `api` / `worker` services and the Dockerfile are [M5-09].
+
+**Enforcement.** `tests/unit/application/use_cases/test_run_assessment.py` (the
+state machine), `test_submit_claim.py` (persist-then-enqueue),
+`tests/unit/infrastructure/test_llm_errors.py` (the classifier truth table),
+`tests/unit/infrastructure/queue/**` (the adapter and the retry gate),
+`tests/unit/infrastructure/database/test_assessment_job_mapper.py`.
+`tests/integration/test_assessment_job_repository.py` (real Postgres) and
+`tests/integration/test_assessment_queue.py` (real Postgres + real Redis: submit
+→ burst worker → completion, transient retry, dead-letter). `test_layer_boundaries.py`
+adds `rq` / `redis` to the forbidden roots. CI's `integration` job gains a
+`redis` service.

--- a/docs/ASYNC_PROCESSING.md
+++ b/docs/ASYNC_PROCESSING.md
@@ -1,0 +1,133 @@
+# Asynchronous processing — [M5-05]
+
+A 207-page policy filing is not an HTTP request. Before M5-05, `POST
+/v1/assessments` returned **202** but ran the whole LangGraph assessment —
+minutes, many LLM calls — synchronously in the request handler. This milestone
+puts a Redis-backed queue behind that 202: the request persists a job and
+returns; a worker pool runs the graph.
+
+```
+POST /v1/assessments ─▶ SubmitClaim ─▶ persist AssessmentJob(PENDING) ─▶ RQ enqueue ─▶ 202 {id, status:"pending"}
+                                                                              │
+  make worker ── run_assessment_job(id) ──▶ RunAssessment                     ▼
+     job ─▶ RUNNING (attempts += 1)
+     orchestrator.start(assessment_id=id, claim=<rebuilt from the job row>)
+       ├─ paused at the human checkpoint ─▶ one txn: assessments.add(record, AWAITING_REVIEW) + jobs.update(SUCCEEDED)
+       ├─ transient provider fault ───────▶ jobs.update(PENDING, failure{transient});  raise TransientAssessmentError ─▶ RQ retries (backoff)
+       │                                     …budget exhausted ─▶ jobs.update(FAILED); ─▶ RQ FailedJobRegistry
+       └─ real error / contract breach ───▶ jobs.update(FAILED, failure{permanent});  raise PermanentAssessmentError
+                                             ─▶ worker zeroes the retry budget ─▶ RQ FailedJobRegistry (traceback preserved)
+```
+
+The `202` + `Location` contract does not change. `GET /v1/assessments/{id}`
+resolves for the whole lifecycle now — see `docs/API.md`.
+
+## Code
+
+- `app/src/application/assessment_job.py` — `AssessmentJob` / `JobStatus` /
+  `JobFailure`. A separate aggregate from `AssessmentRecord`: the record is
+  invariant-laden (a non-empty verdict, prose, a ≥1-citation projection) and
+  cannot represent a claim that has not been assessed yet.
+- `app/src/application/use_cases/submit_claim.py` — persists the `PENDING` job,
+  then enqueues. Committed **before** enqueued, so a poller always finds the row.
+- `app/src/application/use_cases/run_assessment.py` — `RunAssessment`, the
+  worker's half: idempotent (a redelivered `SUCCEEDED`/`FAILED` job is a no-op; a
+  job stuck at `RUNNING` re-runs and LangGraph resumes from its last checkpoint).
+- `app/src/application/use_cases/get_assessment.py` — returns an
+  `AssessmentReadModel` spanning the lifecycle (record if it exists, else the
+  job's `pending`/`running`/`failed` state).
+- `app/src/infrastructure/llm_errors.py` — `is_transient_llm_error`: the single
+  transient-vs-real decision, over the `openai` SDK exception hierarchy, walked
+  through the whole `__cause__` chain.
+- `app/src/infrastructure/queue/` — `rq_queue.py` (`RqAssessmentQueue`, the port
+  adapter), `tasks.py` (`run_assessment_job`, the function RQ runs), `worker.py`
+  (`run_worker` + the `stop_retry_on_permanent` exception handler).
+- `app/src/infrastructure/bootstrap.py` — `build_core_components`, the heavy
+  singletons (DB engine, chat models, retrieval stack, orchestrator) shared by
+  the API `lifespan` and the worker.
+- `app/src/infrastructure/database/{models,assessment_job_mapper,assessment_job_repository}.py`
+  + `alembic/versions/20260904_01_create_assessment_job_table.py` — the
+  `assessment_job` table.
+- `scripts/run_assessment_worker.py` — `make worker`.
+
+## Bring-up
+
+```bash
+docker compose up -d          # postgres + redis
+make migrate                  # …now includes assessment_job
+make setup-checkpointer
+make build-index
+make serve                    # the API   (one shell)
+make worker                   # the queue (another shell)
+```
+
+`make worker` runs under the `embed` uv group like `make serve` — each worker
+loads the sentence-transformers embedder and the cross-encoder reranker once.
+
+## Bounded parallelism
+
+`ASSESSMENT_WORKER_CONCURRENCY` (default **2**) is the number of RQ workers. Each
+worker runs one assessment at a time, so it is also the count of concurrent graph
+runs hitting the LLM provider — the DoD's configurable parallelism bound, the
+direct analog of `LLM_CLASSIFICATION_MAX_WORKERS`. Raise it to use more of the
+provider's throughput; lower it if the provider rate-limits.
+
+**On the 4 GB-VRAM dev box, set it to 1.** One eval process holding the embedder
++ cross-encoder uses ~3.1 GB of VRAM; two workers on the GPU give `CUDA out of
+memory`. `SimpleWorker` (no fork per job) keeps each worker's models loaded for
+the life of the process, so a single worker is not reloading them per job.
+
+## Retry, back-off, dead-letter
+
+| failure | classified | what happens |
+| --- | --- | --- |
+| `openai.RateLimitError` (429), `APITimeoutError`, `APIConnectionError`, `InternalServerError`, any `APIStatusError` 429/5xx | **transient** | job → `PENDING`, `TransientAssessmentError` raised → RQ reschedules after the next `ASSESSMENT_RETRY_BACKOFF_SECONDS` interval (`[30, 120, 300]` by default) |
+| the same, on the last of `ASSESSMENT_MAX_RETRIES` (default 3) attempts | transient, exhausted | job → `FAILED`; RQ moves it to `FailedJobRegistry` |
+| a 4xx that is not 429, a schema-validation error, a malformed claim, a graph contract breach, a bug | **real** | job → `FAILED` immediately, `PermanentAssessmentError` raised; the worker's `stop_retry_on_permanent` handler zeroes the RQ retry budget so it dead-letters now instead of burning retries |
+
+RQ's `Retry` retries on *any* exception, so the transient/real split is enforced
+by the exception type `RunAssessment` raises plus that one exception handler.
+
+**The dead-letter has two faces**, both preserving the cause: the
+`assessment_job` row (`status = failed`, `failure.kind` / `failure.message`,
+readable through `GET /v1/assessments/{id}` as `error`), and RQ's
+`FailedJobRegistry` (the full traceback, for an operator with `rq info` / the
+RQ dashboard).
+
+The node-level retry helpers in `infrastructure/graph/nodes/*` are **unchanged**:
+they still absorb a mid-run network blip (3× 5 s). A *sustained* 429 now bubbles
+past them to the job, which backs off for minutes — which is what
+`docs/END_TO_END_EVALUATION.md` observed a rate limit actually needs.
+
+## Deviations on record
+
+- **The list endpoint is record-only.** `GET /v1/assessments` still lists
+  completed `AssessmentRecord`s; `pending` / `failed` jobs are not in the
+  collection. The per-id `GET` covers "status tracking per assessment id".
+- **The commit-then-enqueue window.** If the process dies between the job commit
+  and the RQ `enqueue`, the job sits at `PENDING` forever. A reconciler that
+  re-enqueues stale `PENDING` jobs is left to operations.
+- **A connection pool for the checkpointer** ("the M5 shape", `docs/DATABASE.md`)
+  is still deferred — each `RunAssessment` opens its own.
+- **`api` / `worker` Compose services + the Dockerfile + the CI image** are
+  [M5-09]. M5-05 adds only the `redis` service to `compose.yaml`.
+
+## Results
+
+`tests/integration/test_assessment_queue.py` runs the whole thing against real
+Postgres + real Redis, with an in-process burst `SimpleWorker` and the fake graph
+context (canned model, one-clause retriever):
+
+- **submission → completion**: `POST` → `202 pending` → `GET` `pending` → drain
+  the queue → `GET` `awaiting_review` + `compatible` + a structured citation →
+  `POST …/decision {approve}` → `200 decided` → the audit trail ends in
+  `human_decision:approve`.
+- **transient → recovery**: the first attempt hits a wrapped 429, RQ retries, the
+  second attempt completes; the job is *not* in `FailedJobRegistry`.
+- **real failure → dead-letter**: a `ValueError` from the run → `GET` `failed`
+  with the cause in `error`, and the id present in `FailedJobRegistry`.
+
+`tests/unit/application/use_cases/test_run_assessment.py` covers the state
+machine directly (transient-with-budget, transient-exhausted, permanent,
+contract breach, idempotent redelivery, transactional rollback);
+`tests/unit/infrastructure/test_llm_errors.py` is the classifier truth table.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -27,9 +27,9 @@ make setup-checkpointer
 `make setup-checkpointer` is the second half of the schema, and it is separate
 for a reason — see "The checkpointer owns its own schema" below.
 
-`compose.yaml` currently holds one service. [M5-09] adds `api`, `redis`
-and `langfuse` to that same file; the Postgres block is written so they are
-appended rather than requiring it to be rewritten.
+`compose.yaml` holds `postgres` and — since [M5-05] — `redis` (the async
+assessment queue). [M5-09] adds `api`, `worker` and `langfuse` to the same file;
+every block is written so they are appended rather than requiring a rewrite.
 
 Roll a migration back with `make migrate-down` (one step). Both targets read
 the same settings loader the application does, so they act on whatever
@@ -293,8 +293,10 @@ before building the API).
 `LangGraphClaimAssessmentOrchestrator.start` / `.resume` each open
 `open_claim_checkpointer` (its own autocommit psycopg connection) and a fresh
 SQLAlchemy session for the run, then close both. Concurrent API requests never
-share either. A pooled connection (`ConnectionPool`) is still the M5 shape; the
-[M5-05] worker model revisits it. On `resume`, the `human_review` node's audit
+share either. A pooled connection (`ConnectionPool`) is still the M5 shape;
+[M5-05] moved the graph run onto a worker but did **not** pool the checkpointer —
+each `RunAssessment` still opens its own, one per job. On `resume`, the
+`human_review` node's audit
 write no longer commits on its own — the orchestrator captures the trail and
 `SubmitHumanDecision` writes it through `UnitOfWork.audit`
 (`append_audit_entries`, same `ON CONFLICT DO NOTHING` insert path) in the same
@@ -371,6 +373,27 @@ existing `chunk` table, reassembling a clause from every row whose
 `display_text` in `chunk_index` order). This is the same reconstruction
 `infrastructure.rag.graph_retrieval_adapter.build_clause_index` does, and the
 id it matches is the one a `Citation` carries.
+
+## The assessment_job table ([M5-05])
+
+`AssessmentJobRow` (`models.py`) is the persistence side of
+`application.assessment_job.AssessmentJob` — the queued-run lifecycle a caller
+polls. Migration `20260904_01`; mapper in
+`infrastructure.database.assessment_job_mapper`.
+
+- Column per field. `status` is `TEXT` + a named `CHECK` against `JobStatus`
+  (`pending` / `running` / `succeeded` / `failed`), tied back to the enum by
+  `test_models.py`. `failure` is `JSONB` (`kind` / `error_type` / `message` /
+  `failed_at`) — a frozen value object, read whole, same reasoning as
+  `assessment.citations`. `raw_text` / `policy_ref` / `submitted_at` are what a
+  worker needs to rebuild the domain `Claim` after a retry or a redelivery;
+  `submitted_at` is stamped once so a retry keeps the same loss-date baseline.
+- Indexed on `status` (the worker scans for `pending`) and `claim_id` (what a
+  human searches by). Not on `created_at` — jobs are not listed newest-first.
+- **No foreign key to `assessment`.** The job row is created before any
+  assessment exists, and a `failed` run keeps its job row without ever producing
+  one. The worker's success path writes the `assessment` row and flips the job to
+  `succeeded` in **one** transaction (`SqlAlchemyUnitOfWork.jobs`).
 
 ## Append-only enforcement ([M5-03])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = [
     # server bits (uvloop, httptools, websockets, watchfiles for `--reload`).
     "fastapi>=0.128.0",
     "uvicorn[standard]>=0.34.0",
+    # [M5-05] the asynchronous-processing queue. `rq` is the sync Redis-backed
+    # worker queue (native Retry-with-backoff + FailedJobRegistry dead-letter);
+    # it pulls `redis` but we pin it directly since the queue adapter and the
+    # readiness checks import the client.
+    "rq>=2.0",
+    "redis>=5.0",
 ]
 
 [dependency-groups]

--- a/scripts/run_assessment_worker.py
+++ b/scripts/run_assessment_worker.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Run the assessment worker pool -- ``make worker`` [M5-05].
+
+The background half of the assessment API. ``POST /v1/assessments`` persists a
+job and returns 202; this process drains the ``assessments`` Redis queue,
+running each claim through the graph to the human checkpoint.
+
+    make migrate            # the application schema, incl. `assessment_job`
+    make setup-checkpointer # the checkpointer's own tables
+    make serve              # the API (one shell)
+    make worker             # the workers (another shell)
+
+Concurrency is ``ASSESSMENT_WORKER_CONCURRENCY`` (default 2). On a
+memory-constrained box keep it at 1 -- each worker loads the embedder and the
+cross-encoder. See ``docs/ASYNC_PROCESSING.md``.
+"""
+
+from infrastructure.queue.worker import run_worker
+
+if __name__ == "__main__":
+    run_worker()

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -30,6 +30,13 @@ if [[ -z "${TEST_DATABASE_URL:-}" ]]; then
   exit 1
 fi
 
+# [M5-05]: the queue integration test needs a real Redis. Same .env fallback as
+# above; the test skips (rather than fails) when it is unset.
+if [[ -z "${TEST_REDIS_URL:-}" && -f .env ]]; then
+  TEST_REDIS_URL="$(grep -m1 -E '^TEST_REDIS_URL=' .env | cut -d= -f2-)"
+fi
+export TEST_REDIS_URL="${TEST_REDIS_URL:-redis://localhost:6379/0}"
+
 # Exported, not just set: the test fixtures read TEST_DATABASE_URL from the
 # environment and skip when it is absent.
 export TEST_DATABASE_URL

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -34,6 +34,10 @@ FORBIDDEN_ROOTS = frozenset(
         "pydantic",
         "langgraph",
         "langchain",
+        # [M5-05]: the async queue. `AssessmentQueue` is a port; the RQ/Redis
+        # adapter stays in infrastructure.
+        "rq",
+        "redis",
         "fitz",
         "pyarrow",
         "pytesseract",

--- a/tests/integration/_queue_fakes.py
+++ b/tests/integration/_queue_fakes.py
@@ -1,0 +1,123 @@
+"""RQ-importable job functions for the [M5-05] queue integration test.
+
+The real job path (``infrastructure.queue.tasks.run_assessment_job``) builds the
+whole retrieval stack. These stand-ins wire ``RunAssessment`` to the same fake
+graph context ``tests/integration/_checkpoint_fakes`` uses everywhere else -- real
+Postgres, real checkpointer, canned model + one-clause retriever -- so the test
+exercises the queue round-trip without a GPU.
+
+``RqAssessmentQueue`` is constructed with ``job_path`` pointing at one of these,
+so nothing here needs a test seam inside the production queue code.
+"""
+
+from __future__ import annotations
+
+import httpx2
+import openai
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.orchestrator_result import OrchestratorResult
+from application.use_cases.run_assessment import RunAssessment
+from domain.claim import Claim
+from domain.human_decision import HumanDecision
+from infrastructure.clock import SystemClock
+from infrastructure.config.settings import get_database_settings
+from infrastructure.database import (
+    create_engine_from_database_url,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.llm_errors import is_transient_llm_error
+from tests.integration._checkpoint_fakes import build_fake_context
+
+_MAX_ATTEMPTS = 3
+# State survives across job executions in the same process (the burst
+# SimpleWorker the test drives is in-process).
+_flaky_state = {"transient_failures": 0}
+
+
+def reset_flaky_state() -> None:
+    """Call at the start of a test that uses ``run_flaky_assessment_job``."""
+    _flaky_state["transient_failures"] = 0
+
+
+def _database_url() -> str:
+    return get_database_settings().sqlalchemy_database_url
+
+
+def _session_factory() -> sessionmaker[Session]:
+    return create_session_factory(
+        engine=create_engine_from_database_url(_database_url())
+    )
+
+
+def _fake_orchestrator(
+    session_factory: sessionmaker[Session],
+) -> LangGraphClaimAssessmentOrchestrator:
+    return LangGraphClaimAssessmentOrchestrator(
+        context_factory=lambda _session: build_fake_context(),
+        session_factory=session_factory,
+        database_url=_database_url(),
+    )
+
+
+def _run(orchestrator: object, assessment_id: str) -> None:
+    session_factory = _session_factory()
+    RunAssessment(
+        clock=SystemClock(),
+        orchestrator=orchestrator,  # type: ignore[arg-type]
+        uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+        is_transient=is_transient_llm_error,
+        max_attempts=_MAX_ATTEMPTS,
+    )(assessment_id)
+
+
+def run_assessment_job(assessment_id: str) -> None:
+    """Happy-path job: run the fake graph to the human checkpoint."""
+    _run(_fake_orchestrator(_session_factory()), assessment_id)
+
+
+class _WrappingOrchestrator:
+    """Delegates ``resume`` to a real fake-context orchestrator; ``start`` varies."""
+
+    def __init__(self, inner: LangGraphClaimAssessmentOrchestrator) -> None:
+        self._inner = inner
+
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        raise NotImplementedError
+
+    def resume(
+        self, *, assessment_id: str, decision: HumanDecision
+    ) -> OrchestratorResult:
+        return self._inner.resume(assessment_id=assessment_id, decision=decision)
+
+
+class _FlakyOrchestrator(_WrappingOrchestrator):
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        if _flaky_state["transient_failures"] == 0:
+            _flaky_state["transient_failures"] += 1
+            response = httpx2.Response(
+                429, request=httpx2.Request("POST", "https://openrouter/api")
+            )
+            cause = openai.RateLimitError("429", response=response, body=None)
+            raise RuntimeError("compatibility node failed") from cause
+        return self._inner.start(assessment_id=assessment_id, claim=claim)
+
+
+class _PermanentlyFailingOrchestrator(_WrappingOrchestrator):
+    def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
+        raise ValueError("the claim narrative could not be parsed")
+
+
+def run_flaky_assessment_job(assessment_id: str) -> None:
+    """Fails transiently once, then succeeds -- exercises retry-with-backoff."""
+    _run(_FlakyOrchestrator(_fake_orchestrator(_session_factory())), assessment_id)
+
+
+def run_failing_assessment_job(assessment_id: str) -> None:
+    """Fails with a real error every time -- exercises the dead-letter path."""
+    _run(
+        _PermanentlyFailingOrchestrator(_fake_orchestrator(_session_factory())),
+        assessment_id,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ from os import getenv
 from pathlib import Path
 
 import pytest
+import redis
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import Engine, MetaData
@@ -37,6 +38,28 @@ def postgres_database_url() -> str:
     if not database_url:
         pytest.skip("Set TEST_DATABASE_URL to run PostgreSQL integration tests.")
     return database_url
+
+
+@pytest.fixture(scope="session")
+def redis_url() -> str:
+    url = getenv("TEST_REDIS_URL")
+    if not url:
+        pytest.skip("Set TEST_REDIS_URL to run the assessment-queue integration tests.")
+    try:
+        redis.Redis.from_url(url).ping()
+    except redis.RedisError as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at TEST_REDIS_URL is not reachable: {exc}")
+    return url
+
+
+@pytest.fixture
+def redis_connection(redis_url: str) -> Iterator[redis.Redis]:
+    """A flushed Redis connection -- each test starts with an empty queue."""
+    connection = redis.Redis.from_url(redis_url)
+    connection.flushdb()
+    yield connection
+    connection.flushdb()
+    connection.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_assessment_api.py
+++ b/tests/integration/test_assessment_api.py
@@ -1,12 +1,17 @@
 """The assessment API over the full stack -- [M5-04].
 
-Real Postgres (the assessment / decision / audit tables and the LangGraph
+Real Postgres (the assessment / decision / audit / job tables and the LangGraph
 Postgres checkpointer), the real use cases, the real orchestrator adapter and
 its capturing sink -- only the LLM and the retriever are faked
 (``tests/integration/_checkpoint_fakes.build_fake_context``: a canned-output
-model and a one-clause stub retriever). Proves the DoD end to end: submit ->
-202 + id, read state/recommendation/citations, submit a decision and observe the
-resumed run, read the audit trail.
+model and a one-clause stub retriever). Proves the M5-04 DoD: submit -> 202 + id,
+read state/recommendation/citations, submit a decision and observe the resumed
+run, read the audit trail.
+
+The [M5-05] queue is stubbed with an *inline* queue that runs ``RunAssessment``
+synchronously on ``enqueue`` -- these tests are about the decision / resume /
+audit-fold path, not the queue. ``tests/integration/test_assessment_queue.py``
+exercises the real Redis round-trip.
 """
 
 from __future__ import annotations
@@ -22,6 +27,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 from sqlalchemy.orm import Session, sessionmaker
 
+from application.use_cases.run_assessment import RunAssessment
 from infrastructure.clock import SystemClock
 from infrastructure.database import (
     create_engine_from_database_url,
@@ -75,19 +81,40 @@ def _seed_stub_clause(session: Session) -> None:
     session.commit()
 
 
+class _InlineQueue:
+    """Runs the assessment synchronously on ``enqueue`` (no worker, no Redis)."""
+
+    def __init__(self, run: RunAssessment) -> None:
+        self._run = run
+
+    def enqueue(self, assessment_id: str) -> None:
+        self._run(assessment_id)
+
+
 def _test_lifespan(database_url: str, session_factory: sessionmaker[Session]) -> object:
     ids = (f"it-{n}" for n in itertools.count(1))
+    orchestrator = LangGraphClaimAssessmentOrchestrator(
+        context_factory=lambda _session: build_fake_context(),
+        session_factory=session_factory,
+        database_url=database_url,
+    )
+    uow_factory = sqlalchemy_unit_of_work_factory(session_factory)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.components = AppComponents(
             clock=SystemClock(),
-            orchestrator=LangGraphClaimAssessmentOrchestrator(
-                context_factory=lambda _session: build_fake_context(),
-                session_factory=session_factory,
-                database_url=database_url,
+            queue=_InlineQueue(
+                RunAssessment(
+                    clock=SystemClock(),
+                    orchestrator=orchestrator,
+                    uow_factory=uow_factory,
+                    is_transient=lambda _exc: False,
+                    max_attempts=1,
+                )
             ),
-            uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+            orchestrator=orchestrator,
+            uow_factory=uow_factory,
             session_factory=session_factory,
             new_id=lambda: next(ids),
         )

--- a/tests/integration/test_assessment_job_repository.py
+++ b/tests/integration/test_assessment_job_repository.py
@@ -1,0 +1,114 @@
+"""The SQLAlchemy ``AssessmentJobRepository`` against a real Postgres -- [M5-05].
+
+Covers what only the database proves: the job aggregate round-trips through the
+``assessment_job`` table (pending and failed-with-cause), timestamps come back
+tz-aware, ``update`` of a missing row raises, a duplicate ``add`` hits the primary
+key, and the ``status`` CHECK rejects an out-of-vocabulary value.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.orm import Session
+
+from application.assessment_job import AssessmentJob, JobFailure, JobStatus
+from infrastructure.database.assessment_job_repository import (
+    SqlAlchemyAssessmentJobRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+
+
+def _job(**overrides: object) -> AssessmentJob:
+    fields: dict[str, object] = {
+        "assessment_id": "a1",
+        "claim_id": "c1",
+        "raw_text": "Bati o carro na traseira de outro veiculo.",
+        "policy_ref": "15414.610650/2024-59",
+        "submitted_at": _NOW,
+        "status": JobStatus.PENDING,
+        "attempts": 0,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "failure": None,
+    }
+    fields.update(overrides)
+    return AssessmentJob(**fields)  # type: ignore[arg-type]
+
+
+def test_round_trips_a_pending_job(db_session: Session) -> None:
+    repo = SqlAlchemyAssessmentJobRepository(db_session)
+    job = _job()
+    repo.add(job)
+    db_session.commit()
+
+    db_session.expunge_all()
+    assert repo.get("a1") == job
+
+
+def test_round_trips_a_failed_job_with_its_cause(db_session: Session) -> None:
+    repo = SqlAlchemyAssessmentJobRepository(db_session)
+    job = _job(
+        status=JobStatus.FAILED,
+        attempts=3,
+        policy_ref=None,
+        failure=JobFailure(
+            kind="transient",
+            error_type="RateLimitError",
+            message="429 Too Many Requests",
+            failed_at=_NOW,
+        ),
+    )
+    repo.add(job)
+    db_session.commit()
+    db_session.expunge_all()
+
+    restored = repo.get("a1")
+    assert restored == job
+    assert restored is not None and restored.failure is not None
+    assert restored.failure.failed_at == _NOW
+
+
+def test_update_of_a_missing_job_raises_keyerror(db_session: Session) -> None:
+    repo = SqlAlchemyAssessmentJobRepository(db_session)
+    with pytest.raises(KeyError):
+        repo.update(_job(assessment_id="ghost"))
+
+
+def test_a_duplicate_add_hits_the_primary_key(db_session: Session) -> None:
+    repo = SqlAlchemyAssessmentJobRepository(db_session)
+    repo.add(_job())
+    with pytest.raises(IntegrityError):
+        repo.add(_job())
+    db_session.rollback()
+
+
+def test_the_status_check_rejects_an_unknown_value(db_session: Session) -> None:
+    SqlAlchemyAssessmentJobRepository(db_session).add(_job())
+    db_session.flush()
+    with pytest.raises(DBAPIError):
+        db_session.execute(
+            text(
+                "UPDATE assessment_job SET status = 'weird' WHERE assessment_id = 'a1'"
+            )
+        )
+    db_session.rollback()
+
+
+def test_update_advances_the_lifecycle(db_session: Session) -> None:
+    repo = SqlAlchemyAssessmentJobRepository(db_session)
+    repo.add(_job())
+    db_session.commit()
+
+    running = _job(status=JobStatus.RUNNING, attempts=1)
+    repo.update(running)
+    db_session.commit()
+    db_session.expunge_all()
+
+    assert repo.get("a1") == running

--- a/tests/integration/test_assessment_queue.py
+++ b/tests/integration/test_assessment_queue.py
@@ -1,0 +1,210 @@
+"""A queued assessment from submission to completion -- the [M5-05] DoD.
+
+Real Postgres (assessment / job / audit tables + the LangGraph checkpointer) and
+real Redis (an RQ queue drained by an in-process burst ``SimpleWorker``). Only
+the LLM and the retriever are faked, through ``job_path`` pointing at
+``tests/integration/_queue_fakes``.
+
+Three paths:
+
+- submission -> 202 ``pending`` -> worker -> ``awaiting_review`` -> a decision;
+- a transient provider failure -> retry with backoff -> success;
+- a real failure -> the job dead-letters, cause preserved, RQ ``FailedJobRegistry``.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import pytest
+import redis
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from rq import Queue, SimpleWorker
+from rq.registry import FailedJobRegistry
+from sqlalchemy.orm import Session, sessionmaker
+
+from infrastructure.clock import SystemClock
+from infrastructure.database import (
+    create_engine_from_database_url,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.queue.rq_queue import QUEUE_NAME, RqAssessmentQueue
+from infrastructure.queue.worker import stop_retry_on_permanent
+from presentation.app import create_app
+from presentation.dependencies import AppComponents
+from tests.integration import _queue_fakes
+from tests.integration._checkpoint_fakes import build_fake_context
+
+pytestmark = pytest.mark.integration
+
+
+@dataclass
+class Api:
+    client: TestClient
+    connection: redis.Redis
+
+
+def _lifespan(
+    database_url: str,
+    session_factory: sessionmaker[Session],
+    connection: redis.Redis,
+    job_path: str,
+) -> object:
+    ids = (f"q-{n}" for n in itertools.count(1))
+    orchestrator = LangGraphClaimAssessmentOrchestrator(
+        context_factory=lambda _session: build_fake_context(),
+        session_factory=session_factory,
+        database_url=database_url,
+    )
+    queue = RqAssessmentQueue(
+        Queue(QUEUE_NAME, connection=connection),
+        job_path=job_path,
+        max_attempts=3,
+        retry_intervals=[0, 0],
+        job_timeout=60,
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.components = AppComponents(
+            clock=SystemClock(),
+            queue=queue,
+            orchestrator=orchestrator,
+            uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+            session_factory=session_factory,
+            new_id=lambda: next(ids),
+        )
+        yield
+
+    return lifespan
+
+
+def _api(
+    *,
+    database_url: str,
+    connection: redis.Redis,
+    job_path: str = "tests.integration._queue_fakes.run_assessment_job",
+) -> Iterator[Api]:
+    with open_claim_checkpointer(database_url, setup=True):
+        pass
+    engine = create_engine_from_database_url(database_url)
+    session_factory = create_session_factory(engine=engine)
+    app = create_app(
+        lifespan=_lifespan(database_url, session_factory, connection, job_path)  # type: ignore[arg-type]
+    )
+    with TestClient(app) as client:
+        yield Api(client=client, connection=connection)
+    engine.dispose()
+
+
+@pytest.fixture
+def api(
+    postgres_database_url: str,
+    migrated_database: None,
+    redis_connection: redis.Redis,
+) -> Iterator[Api]:
+    yield from _api(database_url=postgres_database_url, connection=redis_connection)
+
+
+def _drain(connection: redis.Redis, *, rounds: int = 6) -> None:
+    """Run burst workers until the queue is exhausted.
+
+    Retries use ``interval=0``, so a failed job is re-enqueued immediately rather
+    than scheduled -- a plain loop of burst passes drains them.
+    """
+    queue = Queue(QUEUE_NAME, connection=connection)
+    for _ in range(rounds):
+        if not queue.count:
+            break
+        SimpleWorker(
+            [QUEUE_NAME],
+            connection=connection,
+            exception_handlers=[stop_retry_on_permanent],
+        ).work(burst=True)
+
+
+def _submit(client: TestClient, **body: object) -> str:
+    response = client.post(
+        "/v1/assessments", json={"raw_text": "Bati o carro.", **body}
+    )
+    assert response.status_code == 202, response.text
+    assert response.json()["status"] == "pending"
+    return str(response.json()["assessment_id"])
+
+
+def test_submission_to_completion(api: Api) -> None:
+    assessment_id = _submit(api.client)
+
+    pending = api.client.get(f"/v1/assessments/{assessment_id}").json()
+    assert pending["status"] in {"pending", "running"}
+    assert pending["verdict"] is None
+
+    _drain(api.connection)
+
+    done = api.client.get(f"/v1/assessments/{assessment_id}").json()
+    assert done["status"] == "awaiting_review"
+    assert done["verdict"] == "compatible"
+    assert done["citations"], "the recommendation should carry a clause"
+
+    decided = api.client.post(
+        f"/v1/assessments/{assessment_id}/decision", json={"decision": "approve"}
+    )
+    assert decided.status_code == 200, decided.text
+    assert decided.json()["status"] == "decided"
+
+    trail = api.client.get(f"/v1/assessments/{assessment_id}/audit").json()["entries"]
+    assert trail[-1]["action"] == "human_decision:approve"
+
+
+def test_a_transient_failure_is_retried_then_succeeds(
+    postgres_database_url: str,
+    migrated_database: None,
+    redis_connection: redis.Redis,
+) -> None:
+    _queue_fakes.reset_flaky_state()
+    for api in _api(
+        database_url=postgres_database_url,
+        connection=redis_connection,
+        job_path="tests.integration._queue_fakes.run_flaky_assessment_job",
+    ):
+        assessment_id = _submit(api.client)
+        _drain(redis_connection)
+
+        # The first attempt hit a 429; the retry succeeded.
+        assert _queue_fakes._flaky_state["transient_failures"] == 1
+
+        recovered = api.client.get(f"/v1/assessments/{assessment_id}").json()
+        assert recovered["status"] == "awaiting_review"
+        assert recovered["verdict"] == "compatible"
+
+        # It recovered -- it did NOT dead-letter.
+        registry = FailedJobRegistry(QUEUE_NAME, connection=redis_connection)
+        assert assessment_id not in registry.get_job_ids()
+
+
+def test_a_real_failure_dead_letters_with_the_cause(
+    postgres_database_url: str,
+    migrated_database: None,
+    redis_connection: redis.Redis,
+) -> None:
+    for api in _api(
+        database_url=postgres_database_url,
+        connection=redis_connection,
+        job_path="tests.integration._queue_fakes.run_failing_assessment_job",
+    ):
+        assessment_id = _submit(api.client)
+        _drain(redis_connection)
+
+        failed = api.client.get(f"/v1/assessments/{assessment_id}").json()
+        assert failed["status"] == "failed"
+        assert "could not be parsed" in failed["error"]
+
+        registry = FailedJobRegistry(QUEUE_NAME, connection=redis_connection)
+        assert assessment_id in registry.get_job_ids()

--- a/tests/unit/application/fakes.py
+++ b/tests/unit/application/fakes.py
@@ -7,10 +7,12 @@ No mock library, no LLM, no database, no graph. Every use-case test in
 from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime, timedelta
 
+from application.assessment_job import AssessmentJob, JobStatus
 from application.assessment_record import AssessmentRecord, AssessmentStatus
 from application.audit_trail_entry import AuditTrailEntry
 from application.consistency_flag import ConsistencyFlag
 from application.orchestrator_result import OrchestratorResult
+from application.ports.assessment_job_repository import AssessmentJobRepository
 from application.ports.assessment_repository import AssessmentRepository
 from application.ports.audit_trail_writer import AuditTrailWriter
 from application.ports.unit_of_work import UnitOfWork, UnitOfWorkFactory
@@ -112,6 +114,23 @@ def make_audit_entry(**overrides: object) -> AuditTrailEntry:
     }
     fields.update(overrides)
     return AuditTrailEntry(**fields)  # type: ignore[arg-type]
+
+
+def make_job(**overrides: object) -> AssessmentJob:
+    fields: dict[str, object] = {
+        "assessment_id": "assessment-1",
+        "claim_id": "claim-1",
+        "raw_text": "Bati o carro na traseira de outro veiculo.",
+        "policy_ref": None,
+        "submitted_at": FIXED_NOW,
+        "status": JobStatus.PENDING,
+        "attempts": 0,
+        "created_at": FIXED_NOW,
+        "updated_at": FIXED_NOW,
+        "failure": None,
+    }
+    fields.update(overrides)
+    return AssessmentJob(**fields)  # type: ignore[arg-type]
 
 
 def make_record(**overrides: object) -> AssessmentRecord:
@@ -236,7 +255,38 @@ class InMemoryAssessmentRepository:
         return tuple(rows[offset : offset + limit])
 
 
+class InMemoryAssessmentJobRepository:
+    """A job store over a shared dict (so a UoW can snapshot it)."""
+
+    def __init__(self, store: dict[str, AssessmentJob]) -> None:
+        self._store = store
+
+    def add(self, job: AssessmentJob) -> None:
+        if job.assessment_id in self._store:
+            raise KeyError(f"assessment job {job.assessment_id!r} already exists")
+        self._store[job.assessment_id] = job
+
+    def update(self, job: AssessmentJob) -> None:
+        if job.assessment_id not in self._store:
+            raise KeyError(f"assessment job {job.assessment_id!r} does not exist")
+        self._store[job.assessment_id] = job
+
+    def get(self, assessment_id: str) -> AssessmentJob | None:
+        return self._store.get(assessment_id)
+
+
+class FakeAssessmentQueue:
+    """Records every ``enqueue`` call instead of touching Redis."""
+
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    def enqueue(self, assessment_id: str) -> None:
+        self.enqueued.append(assessment_id)
+
+
 AuditStore = dict[str, list[AuditTrailEntry]]
+JobStore = dict[str, AssessmentJob]
 
 
 class InMemoryAuditTrailWriter:
@@ -277,22 +327,27 @@ class InMemoryAuditTrailReader:
 
 
 class InMemoryUnitOfWork:
-    """A transaction with real rollback: it snapshots both stores on entry."""
+    """A transaction with real rollback: it snapshots every store on entry."""
 
     assessments: AssessmentRepository
     audit: AuditTrailWriter
+    jobs: AssessmentJobRepository
 
     def __init__(
         self,
         store: dict[str, AssessmentRecord],
         audit_store: AuditStore | None = None,
+        job_store: JobStore | None = None,
     ) -> None:
         self._store = store
         self._audit_store: AuditStore = {} if audit_store is None else audit_store
+        self._job_store: JobStore = {} if job_store is None else job_store
         self.assessments = InMemoryAssessmentRepository(store)
         self.audit = InMemoryAuditTrailWriter(self._audit_store)
+        self.jobs = InMemoryAssessmentJobRepository(self._job_store)
         self._snapshot: dict[str, AssessmentRecord] | None = None
         self._audit_snapshot: AuditStore | None = None
+        self._job_snapshot: JobStore | None = None
         self.committed = False
 
     def __enter__(self) -> "UnitOfWork":
@@ -300,6 +355,7 @@ class InMemoryUnitOfWork:
         self._audit_snapshot = {
             thread: list(trail) for thread, trail in self._audit_store.items()
         }
+        self._job_snapshot = dict(self._job_store)
         self.committed = False
         return self
 
@@ -308,6 +364,7 @@ class InMemoryUnitOfWork:
             self.rollback()
         self._snapshot = None
         self._audit_snapshot = None
+        self._job_snapshot = None
 
     def commit(self) -> None:
         self.committed = True
@@ -319,16 +376,21 @@ class InMemoryUnitOfWork:
         if self._audit_snapshot is not None:
             self._audit_store.clear()
             self._audit_store.update(self._audit_snapshot)
+        if self._job_snapshot is not None:
+            self._job_store.clear()
+            self._job_store.update(self._job_snapshot)
 
 
 def make_uow_factory(
     store: dict[str, AssessmentRecord],
     audit_store: AuditStore | None = None,
+    job_store: JobStore | None = None,
 ) -> UnitOfWorkFactory:
     shared_audit: AuditStore = {} if audit_store is None else audit_store
+    shared_jobs: JobStore = {} if job_store is None else job_store
 
     def _open() -> InMemoryUnitOfWork:
-        return InMemoryUnitOfWork(store, shared_audit)
+        return InMemoryUnitOfWork(store, shared_audit, shared_jobs)
 
     return _open
 

--- a/tests/unit/application/test_get_audit_trail.py
+++ b/tests/unit/application/test_get_audit_trail.py
@@ -1,4 +1,4 @@
-"""The GetAuditTrail use case [M5-04]."""
+"""The GetAuditTrail use case [M5-04, M5-05]."""
 
 import pytest
 
@@ -6,19 +6,26 @@ from application.audit_trail_entry import AuditTrailEntry
 from application.errors import AssessmentNotFoundError
 from application.use_cases.get_audit_trail import GetAuditTrail
 from tests.unit.application.fakes import (
+    InMemoryAssessmentJobRepository,
     InMemoryAssessmentRepository,
     InMemoryAuditTrailReader,
     make_audit_entry,
+    make_job,
     make_record,
 )
 
 
 def _use_case(
-    *, seeded: bool, trail: list[AuditTrailEntry] | None = None
+    *,
+    seeded_record: bool = False,
+    seeded_job: bool = False,
+    trail: list[AuditTrailEntry] | None = None,
 ) -> GetAuditTrail:
-    store = {"a1": make_record(assessment_id="a1")} if seeded else {}
+    records = {"a1": make_record(assessment_id="a1")} if seeded_record else {}
+    jobs = {"a1": make_job(assessment_id="a1")} if seeded_job else {}
     return GetAuditTrail(
-        assessments=InMemoryAssessmentRepository(store),
+        assessments=InMemoryAssessmentRepository(records),
+        jobs=InMemoryAssessmentJobRepository(jobs),
         audit=InMemoryAuditTrailReader({"a1": trail or []}),
     )
 
@@ -26,17 +33,22 @@ def _use_case(
 @pytest.mark.unit
 def test_unknown_id_raises_not_found() -> None:
     with pytest.raises(AssessmentNotFoundError):
-        _use_case(seeded=False)("a1")
+        _use_case()("a1")
 
 
 @pytest.mark.unit
 def test_awaiting_review_assessment_has_an_empty_trail() -> None:
-    assert _use_case(seeded=True)("a1") == ()
+    assert _use_case(seeded_record=True)("a1") == ()
+
+
+@pytest.mark.unit
+def test_a_still_queued_job_resolves_to_an_empty_trail_not_a_404() -> None:
+    assert _use_case(seeded_job=True)("a1") == ()
 
 
 @pytest.mark.unit
 def test_returns_the_trail_in_sequence_order() -> None:
     trail = [make_audit_entry(sequence=1), make_audit_entry(sequence=0)]
-    result = _use_case(seeded=True, trail=trail)("a1")
+    result = _use_case(seeded_record=True, trail=trail)("a1")
 
     assert [e.sequence for e in result] == [0, 1]

--- a/tests/unit/application/use_cases/test_get_assessment.py
+++ b/tests/unit/application/use_cases/test_get_assessment.py
@@ -1,38 +1,52 @@
-"""The GetAssessment use case [M5-02]."""
+"""The GetAssessment use case [M5-02, M5-05].
+
+Since M5-05 it returns an ``AssessmentReadModel`` spanning the whole lifecycle:
+the record once it exists, otherwise the job's ``pending`` / ``running`` /
+``failed`` state.
+"""
+
+from datetime import UTC, datetime
 
 import pytest
 
-from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.assessment_job import JobFailure, JobStatus
+from application.assessment_record import AssessmentStatus
 from application.errors import AssessmentNotFoundError
 from application.use_cases.get_assessment import GetAssessment
 from domain.human_decision import DecisionOutcome, HumanDecision
 from domain.verdict import Verdict
 from tests.unit.application.fakes import (
     FIXED_NOW,
+    InMemoryAssessmentJobRepository,
     InMemoryAssessmentRepository,
+    make_job,
     make_record,
 )
 
 
+def _use_case(
+    *,
+    records: dict[str, object] | None = None,
+    jobs: dict[str, object] | None = None,
+) -> GetAssessment:
+    return GetAssessment(
+        assessments=InMemoryAssessmentRepository(dict(records or {})),  # type: ignore[arg-type]
+        jobs=InMemoryAssessmentJobRepository(dict(jobs or {})),  # type: ignore[arg-type]
+    )
+
+
 @pytest.mark.unit
-def test_returns_the_stored_record() -> None:
-    store = {"assessment-1": make_record(assessment_id="assessment-1")}
-    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+def test_returns_the_stored_record_as_a_completed_view() -> None:
+    get_assessment = _use_case(
+        records={"assessment-1": make_record(assessment_id="assessment-1")}
+    )
 
-    record = get_assessment("assessment-1")
+    model = get_assessment("assessment-1")
 
-    assert isinstance(record, AssessmentRecord)
-    assert record.assessment_id == "assessment-1"
-
-
-@pytest.mark.unit
-def test_unknown_id_raises_not_found_carrying_the_id() -> None:
-    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository({}))
-
-    with pytest.raises(AssessmentNotFoundError) as excinfo:
-        get_assessment("missing")
-
-    assert excinfo.value.assessment_id == "missing"
+    assert model.status == "awaiting_review"
+    assert model.record is not None
+    assert model.record.assessment_id == "assessment-1"
+    assert model.error is None
 
 
 @pytest.mark.unit
@@ -42,30 +56,83 @@ def test_returns_a_decided_record_with_its_decision() -> None:
         decision=DecisionOutcome.APPROVE,
         decided_at=FIXED_NOW,
     )
-    store = {
-        "assessment-1": make_record(status=AssessmentStatus.DECIDED, decision=decision)
-    }
-    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+    get_assessment = _use_case(
+        records={
+            "assessment-1": make_record(
+                status=AssessmentStatus.DECIDED, decision=decision
+            )
+        }
+    )
 
-    record = get_assessment("assessment-1")
+    model = get_assessment("assessment-1")
 
-    assert record.status is AssessmentStatus.DECIDED
-    assert record.decision is decision
+    assert model.status == "decided"
+    assert model.record is not None and model.record.decision is decision
 
 
 @pytest.mark.unit
 def test_serves_an_abstain_record_without_raising() -> None:
-    store = {
-        "assessment-1": make_record(
-            verdict=Verdict.INSUFFICIENT_INFORMATION,
-            citations=(),
-            confidence=0.2,
-            context_sufficient=False,
-        )
-    }
-    get_assessment = GetAssessment(assessments=InMemoryAssessmentRepository(store))
+    get_assessment = _use_case(
+        records={
+            "assessment-1": make_record(
+                verdict=Verdict.INSUFFICIENT_INFORMATION,
+                citations=(),
+                confidence=0.2,
+                context_sufficient=False,
+            )
+        }
+    )
 
-    record = get_assessment("assessment-1")
+    model = get_assessment("assessment-1")
 
-    assert record.citations == ()
-    assert not record.is_grounded
+    assert model.record is not None and not model.record.is_grounded
+
+
+@pytest.mark.unit
+def test_a_pending_job_reads_as_pending_with_no_record() -> None:
+    get_assessment = _use_case(jobs={"a1": make_job(assessment_id="a1")})
+
+    model = get_assessment("a1")
+
+    assert model.status == "pending"
+    assert model.record is None
+    assert model.error is None
+
+
+@pytest.mark.unit
+def test_a_failed_job_carries_the_preserved_cause() -> None:
+    job = make_job(
+        assessment_id="a1",
+        status=JobStatus.FAILED,
+        attempts=3,
+        failure=JobFailure(
+            kind="permanent",
+            error_type="ValueError",
+            message="claim narrative was rejected",
+            failed_at=datetime(2026, 9, 4, tzinfo=UTC),
+        ),
+    )
+    get_assessment = _use_case(jobs={"a1": job})
+
+    model = get_assessment("a1")
+
+    assert model.status == "failed"
+    assert model.error == "claim narrative was rejected"
+
+
+@pytest.mark.unit
+def test_the_record_wins_once_it_exists_even_if_a_job_row_lingers() -> None:
+    get_assessment = _use_case(
+        records={"a1": make_record(assessment_id="a1")},
+        jobs={"a1": make_job(assessment_id="a1", status=JobStatus.SUCCEEDED)},
+    )
+
+    assert get_assessment("a1").status == "awaiting_review"
+
+
+@pytest.mark.unit
+def test_unknown_id_raises_not_found_carrying_the_id() -> None:
+    with pytest.raises(AssessmentNotFoundError) as excinfo:
+        _use_case()("missing")
+
+    assert excinfo.value.assessment_id == "missing"

--- a/tests/unit/application/use_cases/test_run_assessment.py
+++ b/tests/unit/application/use_cases/test_run_assessment.py
@@ -1,0 +1,151 @@
+"""The RunAssessment use case -- the worker's half of the queue [M5-05]."""
+
+from __future__ import annotations
+
+import pytest
+
+from application.assessment_job import AssessmentJob, JobStatus
+from application.assessment_record import AssessmentRecord, AssessmentStatus
+from application.errors import PermanentAssessmentError, TransientAssessmentError
+from application.use_cases.run_assessment import RunAssessment
+from tests.unit.application.fakes import (
+    FakeClaimAssessmentOrchestrator,
+    FixedClock,
+    abstain_result,
+    make_job,
+    make_orchestrator_result,
+    make_uow_factory,
+)
+
+
+class _RateLimitError(Exception):
+    """Stand-in for a provider 429 -- the classifier keys off this type."""
+
+
+def _build(
+    *,
+    job: AssessmentJob,
+    orchestrator: FakeClaimAssessmentOrchestrator | None = None,
+    max_attempts: int = 3,
+) -> tuple[RunAssessment, dict[str, AssessmentJob], dict[str, AssessmentRecord]]:
+    job_store = {job.assessment_id: job}
+    record_store: dict[str, AssessmentRecord] = {}
+    use_case = RunAssessment(
+        clock=FixedClock(),
+        orchestrator=orchestrator or FakeClaimAssessmentOrchestrator(),
+        uow_factory=make_uow_factory(record_store, None, job_store),
+        is_transient=lambda exc: isinstance(exc, _RateLimitError),
+        max_attempts=max_attempts,
+    )
+    return use_case, job_store, record_store
+
+
+@pytest.mark.unit
+def test_happy_path_writes_the_record_and_succeeds_the_job() -> None:
+    run, jobs, records = _build(job=make_job(assessment_id="a1"))
+
+    run("a1")
+
+    assert jobs["a1"].status is JobStatus.SUCCEEDED
+    assert jobs["a1"].attempts == 1
+    assert jobs["a1"].failure is None
+    record = records["a1"]
+    assert isinstance(record, AssessmentRecord)
+    assert record.status is AssessmentStatus.AWAITING_REVIEW
+
+
+@pytest.mark.unit
+def test_abstain_run_still_succeeds_with_a_zero_citation_record() -> None:
+    orch = FakeClaimAssessmentOrchestrator(
+        start_result=abstain_result(awaiting_review=True)
+    )
+    run, jobs, records = _build(job=make_job(assessment_id="a1"), orchestrator=orch)
+
+    run("a1")
+
+    assert jobs["a1"].status is JobStatus.SUCCEEDED
+    assert records["a1"].citations == ()
+
+
+@pytest.mark.unit
+def test_transient_failure_with_attempts_left_returns_to_pending_and_raises() -> None:
+    orch = FakeClaimAssessmentOrchestrator(raise_on_start=_RateLimitError("429"))
+    run, jobs, records = _build(job=make_job(assessment_id="a1"), orchestrator=orch)
+
+    with pytest.raises(TransientAssessmentError):
+        run("a1")
+
+    job = jobs["a1"]
+    assert job.status is JobStatus.PENDING
+    assert job.attempts == 1
+    assert job.failure is not None
+    assert job.failure.kind == "transient"
+    assert job.failure.error_type == "_RateLimitError"
+    assert records == {}
+
+
+@pytest.mark.unit
+def test_transient_failure_on_the_last_attempt_dead_letters() -> None:
+    orch = FakeClaimAssessmentOrchestrator(raise_on_start=_RateLimitError("429"))
+    run, jobs, _ = _build(
+        job=make_job(assessment_id="a1", attempts=2),
+        orchestrator=orch,
+        max_attempts=3,
+    )
+
+    with pytest.raises(TransientAssessmentError):
+        run("a1")
+
+    assert jobs["a1"].status is JobStatus.FAILED
+    assert jobs["a1"].attempts == 3
+
+
+@pytest.mark.unit
+def test_real_failure_dead_letters_immediately_as_permanent() -> None:
+    orch = FakeClaimAssessmentOrchestrator(raise_on_start=ValueError("bad claim"))
+    run, jobs, _ = _build(job=make_job(assessment_id="a1"), orchestrator=orch)
+
+    with pytest.raises(PermanentAssessmentError):
+        run("a1")
+
+    job = jobs["a1"]
+    assert job.status is JobStatus.FAILED
+    assert job.failure is not None and job.failure.kind == "permanent"
+    assert "bad claim" in job.failure.message
+
+
+@pytest.mark.unit
+def test_a_run_that_does_not_pause_is_a_permanent_failure() -> None:
+    orch = FakeClaimAssessmentOrchestrator(
+        start_result=make_orchestrator_result(awaiting_review=False)
+    )
+    run, jobs, records = _build(job=make_job(assessment_id="a1"), orchestrator=orch)
+
+    with pytest.raises(PermanentAssessmentError, match="did not pause"):
+        run("a1")
+
+    assert jobs["a1"].status is JobStatus.FAILED
+    assert records == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", [JobStatus.SUCCEEDED, JobStatus.FAILED])
+def test_a_redelivered_terminal_job_is_a_no_op(status: JobStatus) -> None:
+    orch = FakeClaimAssessmentOrchestrator(raise_on_start=RuntimeError("must not run"))
+    run, jobs, _ = _build(
+        job=make_job(assessment_id="a1", status=status, attempts=1),
+        orchestrator=orch,
+    )
+
+    run("a1")  # does not raise -- the orchestrator is never called
+
+    assert jobs["a1"].status is status
+    assert orch.started == []
+
+
+@pytest.mark.unit
+def test_an_unknown_job_is_a_permanent_failure() -> None:
+    run, _, _ = _build(job=make_job(assessment_id="a1"))
+
+    with pytest.raises(PermanentAssessmentError, match="no assessment job"):
+        run("ghost")

--- a/tests/unit/application/use_cases/test_submit_claim.py
+++ b/tests/unit/application/use_cases/test_submit_claim.py
@@ -1,20 +1,22 @@
-"""The SubmitClaim use case [M5-02]."""
+"""The SubmitClaim use case [M5-02, M5-05].
+
+Since M5-05, ``SubmitClaim`` does not run the graph -- it persists an
+``AssessmentJob`` in ``PENDING`` and hands the id to the queue. The run itself is
+``RunAssessment``'s (see ``test_run_assessment.py``).
+"""
 
 import pytest
 
-from application.assessment_record import AssessmentRecord, AssessmentStatus
-from application.errors import OrchestratorContractError
+from application.assessment_job import AssessmentJob, JobStatus
+from application.assessment_record import AssessmentRecord
 from application.use_cases.submit_claim import SubmitClaim
-from domain.verdict import Verdict
 from tests.unit.application.fakes import (
     FIXED_NOW,
     SUSEP,
-    FakeClaimAssessmentOrchestrator,
+    FakeAssessmentQueue,
     FixedClock,
     NaiveClock,
     SequentialIds,
-    abstain_result,
-    make_orchestrator_result,
     make_uow_factory,
 )
 
@@ -23,47 +25,46 @@ _NARRATIVE = "Bati o carro em uma colisao na avenida no dia 05/01/2026."
 
 def _build(
     *,
-    orchestrator: FakeClaimAssessmentOrchestrator | None = None,
-    store: dict[str, AssessmentRecord] | None = None,
     clock: object | None = None,
     ids: SequentialIds | None = None,
-) -> tuple[SubmitClaim, dict[str, AssessmentRecord], FakeClaimAssessmentOrchestrator]:
-    resolved_store = store if store is not None else {}
-    resolved_orch = orchestrator or FakeClaimAssessmentOrchestrator()
+) -> tuple[SubmitClaim, dict[str, AssessmentJob], FakeAssessmentQueue]:
+    job_store: dict[str, AssessmentJob] = {}
+    queue = FakeAssessmentQueue()
+    record_store: dict[str, AssessmentRecord] = {}
     use_case = SubmitClaim(
         clock=clock or FixedClock(),  # type: ignore[arg-type]
-        orchestrator=resolved_orch,
-        uow_factory=make_uow_factory(resolved_store),
+        queue=queue,
+        uow_factory=make_uow_factory(record_store, None, job_store),
         new_id=ids or SequentialIds("id"),
     )
-    return use_case, resolved_store, resolved_orch
+    return use_case, job_store, queue
 
 
 @pytest.mark.unit
-def test_happy_path_persists_an_awaiting_review_record() -> None:
-    submit_claim, store, _ = _build()
+def test_happy_path_persists_a_pending_job_and_enqueues_it() -> None:
+    submit_claim, job_store, queue = _build()
 
-    record = submit_claim(raw_text=_NARRATIVE)
+    job = submit_claim(raw_text=_NARRATIVE)
 
-    assert isinstance(record, AssessmentRecord)
-    assert record.status is AssessmentStatus.AWAITING_REVIEW
-    assert record.verdict is Verdict.COMPATIBLE
-    assert store[record.assessment_id] == record
-    assert record.created_at == FIXED_NOW
+    assert isinstance(job, AssessmentJob)
+    assert job.status is JobStatus.PENDING
+    assert job.attempts == 0
+    assert job.raw_text == _NARRATIVE
+    assert job.submitted_at == FIXED_NOW == job.created_at == job.updated_at
+    assert job_store[job.assessment_id] == job
+    assert queue.enqueued == [job.assessment_id]
 
 
 @pytest.mark.unit
 def test_mints_distinct_claim_and_assessment_ids_from_new_id() -> None:
     ids = SequentialIds("id")
-    submit_claim, _, orchestrator = _build(ids=ids)
+    submit_claim, _, _ = _build(ids=ids)
 
-    record = submit_claim(raw_text=_NARRATIVE)
+    job = submit_claim(raw_text=_NARRATIVE)
 
     assert ids.issued == ["id-1", "id-2"]
-    assert record.claim_id == "id-1"
-    assert record.assessment_id == "id-2"
-    assert orchestrator.started[0][0] == "id-2"
-    assert orchestrator.started[0][1].claim_id == "id-1"
+    assert job.claim_id == "id-1"
+    assert job.assessment_id == "id-2"
 
 
 @pytest.mark.unit
@@ -71,80 +72,62 @@ def test_honours_an_explicit_claim_id() -> None:
     ids = SequentialIds("id")
     submit_claim, _, _ = _build(ids=ids)
 
-    record = submit_claim(raw_text=_NARRATIVE, claim_id="claim-external-7")
+    job = submit_claim(raw_text=_NARRATIVE, claim_id="claim-external-7")
 
-    assert record.claim_id == "claim-external-7"
-    assert record.assessment_id == "id-1"
+    assert job.claim_id == "claim-external-7"
+    assert job.assessment_id == "id-1"
     assert ids.issued == ["id-1"]
 
 
 @pytest.mark.unit
-def test_policy_ref_reaches_the_orchestrator_claim() -> None:
-    submit_claim, _, orchestrator = _build()
+def test_policy_ref_is_stored_on_the_job_in_canonical_form() -> None:
+    submit_claim, job_store, _ = _build()
 
-    submit_claim(raw_text=_NARRATIVE, policy_ref=SUSEP)
+    job = submit_claim(raw_text=_NARRATIVE, policy_ref=SUSEP)
 
-    assert orchestrator.started[0][1].policy_ref == SUSEP
-
-
-@pytest.mark.unit
-def test_abstain_outcome_persists_with_no_citations() -> None:
-    orchestrator = FakeClaimAssessmentOrchestrator(
-        start_result=abstain_result(awaiting_review=True)
-    )
-    submit_claim, store, _ = _build(orchestrator=orchestrator)
-
-    record = submit_claim(raw_text=_NARRATIVE)
-
-    assert record.verdict is Verdict.INSUFFICIENT_INFORMATION
-    assert record.citations == ()
-    assert record.status is AssessmentStatus.AWAITING_REVIEW
-    assert store[record.assessment_id].citations == ()
+    assert job.policy_ref == SUSEP.value
+    assert job_store[job.assessment_id].policy_ref == SUSEP.value
 
 
 @pytest.mark.unit
-def test_empty_narrative_is_rejected_and_nothing_is_persisted() -> None:
-    submit_claim, store, orchestrator = _build()
+def test_empty_narrative_is_rejected_and_nothing_is_persisted_or_enqueued() -> None:
+    submit_claim, job_store, queue = _build()
 
     with pytest.raises(ValueError, match="raw_text must not be empty"):
         submit_claim(raw_text="")
 
-    assert store == {}
-    assert orchestrator.started == []
+    assert job_store == {}
+    assert queue.enqueued == []
 
 
 @pytest.mark.unit
 def test_a_naive_clock_is_rejected_before_persisting() -> None:
-    submit_claim, store, orchestrator = _build(clock=NaiveClock())
+    submit_claim, job_store, queue = _build(clock=NaiveClock())
 
     with pytest.raises(ValueError, match="timezone-aware"):
         submit_claim(raw_text=_NARRATIVE)
 
-    assert store == {}
-    assert orchestrator.started == []
+    assert job_store == {}
+    assert queue.enqueued == []
 
 
 @pytest.mark.unit
-def test_orchestrator_failure_leaves_nothing_persisted() -> None:
-    orchestrator = FakeClaimAssessmentOrchestrator(
-        raise_on_start=RuntimeError("graph exploded")
+def test_the_job_is_committed_before_it_is_enqueued() -> None:
+    """A caller polling GET must always find the row the 202 promised."""
+    job_store: dict[str, AssessmentJob] = {}
+    record_store: dict[str, AssessmentRecord] = {}
+    seen: list[bool] = []
+
+    class _RecordingQueue:
+        def enqueue(self, assessment_id: str) -> None:
+            seen.append(assessment_id in job_store)
+
+    submit_claim = SubmitClaim(
+        clock=FixedClock(),
+        queue=_RecordingQueue(),
+        uow_factory=make_uow_factory(record_store, None, job_store),
+        new_id=SequentialIds("id"),
     )
-    submit_claim, store, _ = _build(orchestrator=orchestrator)
+    submit_claim(raw_text=_NARRATIVE)
 
-    with pytest.raises(RuntimeError, match="graph exploded"):
-        submit_claim(raw_text=_NARRATIVE)
-
-    assert store == {}
-
-
-@pytest.mark.unit
-def test_a_run_that_does_not_pause_is_a_contract_error() -> None:
-    orchestrator = FakeClaimAssessmentOrchestrator(
-        start_result=make_orchestrator_result(awaiting_review=False)
-    )
-    submit_claim, store, _ = _build(orchestrator=orchestrator)
-
-    with pytest.raises(OrchestratorContractError, match="did not pause"):
-        submit_claim(raw_text=_NARRATIVE)
-
-    assert store == {}
+    assert seen == [True]

--- a/tests/unit/infrastructure/config/test_settings.py
+++ b/tests/unit/infrastructure/config/test_settings.py
@@ -8,6 +8,7 @@ from infrastructure.config.settings import (
     EmbeddingSettings,
     LlmSettings,
     ObservabilitySettings,
+    QueueSettings,
 )
 from infrastructure.rag.embedding_pipeline import EMBEDDING_BATCH_SIZE
 
@@ -192,6 +193,37 @@ def test_embedding_batch_size_reads_the_env_var(
     monkeypatch.setenv("EMBEDDING_BATCH_SIZE", "16")
 
     assert EmbeddingSettings(_env_file=None).embedding_batch_size == 16
+
+
+@pytest.mark.unit
+def test_queue_settings_defaults() -> None:
+    settings = QueueSettings(_env_file=None)
+
+    assert settings.assessment_worker_concurrency == 2
+    assert settings.assessment_max_retries == 3
+    assert settings.assessment_retry_backoff_seconds == [30, 120, 300]
+    assert settings.assessment_job_timeout_seconds == 1800
+    # one interval per retry (attempts beyond the first)
+    assert settings.rq_retry_intervals == [30, 120]
+
+
+@pytest.mark.unit
+def test_rq_retry_intervals_pads_with_the_last_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASSESSMENT_MAX_RETRIES", "5")
+    monkeypatch.setenv("ASSESSMENT_RETRY_BACKOFF_SECONDS", "[10, 20]")
+
+    assert QueueSettings(_env_file=None).rq_retry_intervals == [10, 20, 20, 20]
+
+
+@pytest.mark.unit
+def test_rq_retry_intervals_is_empty_when_no_retries_are_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASSESSMENT_MAX_RETRIES", "1")
+
+    assert QueueSettings(_env_file=None).rq_retry_intervals == []
 
 
 @pytest.mark.unit

--- a/tests/unit/infrastructure/database/test_assessment_job_mapper.py
+++ b/tests/unit/infrastructure/database/test_assessment_job_mapper.py
@@ -1,0 +1,62 @@
+"""The assessment_job row <-> aggregate mapper [M5-05]."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from application.assessment_job import AssessmentJob, JobFailure, JobStatus
+from infrastructure.database.assessment_job_mapper import job_to_row, row_to_job
+
+_NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+
+
+def _job(**overrides: object) -> AssessmentJob:
+    fields: dict[str, object] = {
+        "assessment_id": "a1",
+        "claim_id": "c1",
+        "raw_text": "Bati o carro.",
+        "policy_ref": "15414.610650/2024-59",
+        "submitted_at": _NOW,
+        "status": JobStatus.PENDING,
+        "attempts": 0,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "failure": None,
+    }
+    fields.update(overrides)
+    return AssessmentJob(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_round_trips_a_pending_job() -> None:
+    job = _job()
+    assert row_to_job(job_to_row(job)) == job
+
+
+@pytest.mark.unit
+def test_round_trips_a_failed_job_with_its_cause() -> None:
+    job = _job(
+        status=JobStatus.FAILED,
+        attempts=3,
+        policy_ref=None,
+        failure=JobFailure(
+            kind="transient",
+            error_type="RateLimitError",
+            message="429 Too Many Requests",
+            failed_at=_NOW,
+        ),
+    )
+    restored = row_to_job(job_to_row(job))
+    assert restored == job
+    assert restored.failure is not None
+    assert restored.failure.failed_at == _NOW
+
+
+@pytest.mark.unit
+def test_a_naive_timestamp_from_the_row_fails_loudly() -> None:
+    row = job_to_row(_job())
+    row.submitted_at = datetime(2026, 9, 4, 12, 0)  # naive
+    with pytest.raises(ValueError, match="timezone-aware"):
+        row_to_job(row)

--- a/tests/unit/infrastructure/database/test_models.py
+++ b/tests/unit/infrastructure/database/test_models.py
@@ -1,7 +1,7 @@
 """Schema-level guarantees for the ORM models.
 
 ``chunk`` -- [M3-02]; ``audit_event`` -- [M4-09]; ``assessment`` /
-``human_decision`` -- [M5-03].
+``human_decision`` -- [M5-03]; ``assessment_job`` -- [M5-05].
 """
 
 import re
@@ -10,12 +10,14 @@ import pytest
 from pgvector.sqlalchemy import HALFVEC
 from sqlalchemy import CheckConstraint, DateTime, Table
 
+from application.assessment_job import JobStatus
 from application.assessment_record import AssessmentStatus
 from domain.chunk import ChunkRule
 from domain.clause_classification import ClauseType, TypeSource
 from domain.human_decision import DecisionOutcome
 from domain.verdict import Verdict
 from infrastructure.database.models import (
+    AssessmentJobRow,
     AssessmentRow,
     AuditEventRow,
     ChunkRow,
@@ -30,6 +32,7 @@ _CHUNK_TABLE = ChunkRow.metadata.tables["chunk"]
 _AUDIT_TABLE = AuditEventRow.metadata.tables["audit_event"]
 _ASSESSMENT_TABLE = AssessmentRow.metadata.tables["assessment"]
 _DECISION_TABLE = HumanDecisionRow.metadata.tables["human_decision"]
+_JOB_TABLE = AssessmentJobRow.metadata.tables["assessment_job"]
 
 _EXPECTED_INDEXES = {
     "ix_chunk_clause_type",
@@ -301,3 +304,44 @@ def test_human_decision_decided_at_is_timezone_aware() -> None:
     column_type = _DECISION_TABLE.c.decided_at.type
     assert isinstance(column_type, DateTime)
     assert column_type.timezone is True
+
+
+# --------------------------------------------------------------------------- #
+# assessment_job -- [M5-05]
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_assessment_job_table_name_and_primary_key() -> None:
+    assert AssessmentJobRow.__tablename__ == "assessment_job"
+    assert [c.name for c in _JOB_TABLE.primary_key.columns] == ["assessment_id"]
+
+
+@pytest.mark.unit
+def test_assessment_job_status_check_matches_the_job_status_enum() -> None:
+    assert _check_constraint_values("ck_assessment_job_status_valid", _JOB_TABLE) == {
+        member.value for member in JobStatus
+    }
+
+
+@pytest.mark.unit
+def test_assessment_job_has_no_foreign_key_to_assessment() -> None:
+    # The job row exists before any assessment does, and a failed run keeps its
+    # job row without ever producing one.
+    assert list(_JOB_TABLE.foreign_keys) == []
+
+
+@pytest.mark.unit
+def test_assessment_job_timestamps_are_timezone_aware() -> None:
+    for name in ("submitted_at", "created_at", "updated_at"):
+        column_type = _JOB_TABLE.c[name].type
+        assert isinstance(column_type, DateTime)
+        assert column_type.timezone is True
+
+
+@pytest.mark.unit
+def test_assessment_job_indexes_status_and_claim_id() -> None:
+    assert {str(index.name) for index in _JOB_TABLE.indexes} == {
+        "ix_assessment_job_status",
+        "ix_assessment_job_claim_id",
+    }

--- a/tests/unit/infrastructure/queue/test_rq_queue.py
+++ b/tests/unit/infrastructure/queue/test_rq_queue.py
@@ -1,0 +1,56 @@
+"""The RqAssessmentQueue adapter -- what it hands to RQ [M5-05]."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from rq import Retry
+
+from infrastructure.queue.rq_queue import RqAssessmentQueue
+
+
+class _FakeRqQueue:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def enqueue(self, f: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append({"f": f, "args": args, "kwargs": kwargs})
+
+
+def _queue(**overrides: Any) -> tuple[RqAssessmentQueue, _FakeRqQueue]:
+    fake = _FakeRqQueue()
+    defaults: dict[str, Any] = {
+        "job_path": "pkg.mod.run",
+        "max_attempts": 3,
+        "retry_intervals": [30, 120],
+        "job_timeout": 1800,
+    }
+    defaults.update(overrides)
+    return RqAssessmentQueue(fake, **defaults), fake  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_enqueue_passes_id_job_id_timeout_and_retry() -> None:
+    queue, fake = _queue()
+
+    queue.enqueue("assess-42")
+
+    (call,) = fake.calls
+    assert call["f"] == "pkg.mod.run"
+    assert call["args"] == ("assess-42",)
+    assert call["kwargs"]["job_id"] == "assess-42"
+    assert call["kwargs"]["job_timeout"] == 1800
+    retry = call["kwargs"]["retry"]
+    assert isinstance(retry, Retry)
+    assert retry.max == 2
+    assert retry.intervals == [30, 120]
+
+
+@pytest.mark.unit
+def test_no_retry_object_when_only_one_attempt_is_allowed() -> None:
+    queue, fake = _queue(max_attempts=1)
+
+    queue.enqueue("assess-1")
+
+    assert fake.calls[0]["kwargs"]["retry"] is None

--- a/tests/unit/infrastructure/queue/test_worker.py
+++ b/tests/unit/infrastructure/queue/test_worker.py
@@ -1,0 +1,44 @@
+"""The worker's transient/permanent retry gate [M5-05]."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from application.errors import PermanentAssessmentError, TransientAssessmentError
+from infrastructure.queue.worker import stop_retry_on_permanent
+
+
+@dataclass
+class _Job:
+    retries_left: int | None = 2
+
+
+@pytest.mark.unit
+def test_a_permanent_failure_has_its_retry_budget_zeroed() -> None:
+    job = _Job(retries_left=2)
+
+    result = stop_retry_on_permanent(
+        job,  # type: ignore[arg-type]
+        PermanentAssessmentError,
+        PermanentAssessmentError("bad claim"),
+        None,
+    )
+
+    assert job.retries_left == 0
+    assert result is True  # RQ still runs its default failure handling -> dead-letter
+
+
+@pytest.mark.unit
+def test_a_transient_failure_keeps_its_retry_budget() -> None:
+    job = _Job(retries_left=2)
+
+    stop_retry_on_permanent(
+        job,  # type: ignore[arg-type]
+        TransientAssessmentError,
+        TransientAssessmentError("429"),
+        None,
+    )
+
+    assert job.retries_left == 2

--- a/tests/unit/infrastructure/test_llm_errors.py
+++ b/tests/unit/infrastructure/test_llm_errors.py
@@ -1,0 +1,64 @@
+"""The transient-vs-real classifier [M5-05]."""
+
+from __future__ import annotations
+
+import httpx2
+import openai
+import pytest
+
+from infrastructure.llm_errors import is_transient_llm_error
+
+_REQUEST = httpx2.Request("POST", "https://example/api")
+
+
+def _api_status_error(status: int) -> openai.APIStatusError:
+    response = httpx2.Response(status, request=_REQUEST)
+    return openai.APIStatusError("boom", response=response, body=None)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "exc",
+    [
+        openai.APITimeoutError(request=_REQUEST),
+        openai.APIConnectionError(message="refused", request=_REQUEST),
+        _api_status_error(429),
+        _api_status_error(503),
+    ],
+)
+def test_transient_faults_are_recognised(exc: BaseException) -> None:
+    assert is_transient_llm_error(exc) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("schema mismatch"),
+        _api_status_error(400),
+        _api_status_error(404),
+        RuntimeError("bug"),
+    ],
+)
+def test_real_errors_are_not_transient(exc: BaseException) -> None:
+    assert is_transient_llm_error(exc) is False
+
+
+@pytest.mark.unit
+def test_a_wrapped_transient_cause_is_found_through_the_chain() -> None:
+    try:
+        try:
+            raise _api_status_error(429)
+        except openai.APIStatusError as inner:
+            raise RuntimeError("node failed") from inner
+    except RuntimeError as outer:
+        assert is_transient_llm_error(outer) is True
+
+
+@pytest.mark.unit
+def test_a_cycle_in_the_cause_chain_terminates() -> None:
+    first = RuntimeError("a")
+    second = RuntimeError("b")
+    first.__cause__ = second
+    second.__cause__ = first
+    assert is_transient_llm_error(first) is False

--- a/tests/unit/presentation/conftest.py
+++ b/tests/unit/presentation/conftest.py
@@ -1,11 +1,12 @@
-"""A ``TestClient`` wired to the in-memory application fakes -- [M5-04].
+"""A ``TestClient`` wired to the in-memory application fakes -- [M5-04, M5-05].
 
 The FastAPI app is built with its production lifespan intact but never entered
 (``TestClient`` runs lifespan only as a context manager), so the composition
-root never touches Postgres, LLMs or the retriever. Every use-case provider is
-overridden to build the interactor against ``tests/unit/application/fakes.py``.
-A test can reassign ``harness.orchestrator`` before a request to change the
-canned graph behaviour.
+root never touches Postgres, Redis, LLMs or the retriever. Every use-case
+provider is overridden to build the interactor against
+``tests/unit/application/fakes.py``. A test can reassign ``harness.orchestrator``
+before a request to change the canned graph behaviour (the resume path), or
+inspect ``harness.queue.enqueued`` to see what ``POST`` scheduled.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from dataclasses import dataclass, field
 import pytest
 from fastapi.testclient import TestClient
 
+from application.assessment_job import AssessmentJob
 from application.assessment_record import AssessmentRecord
 from application.audit_trail_entry import AuditTrailEntry
 from application.use_cases.get_assessment import GetAssessment
@@ -33,8 +35,10 @@ from presentation.dependencies import (
     get_submit_human_decision,
 )
 from tests.unit.application.fakes import (
+    FakeAssessmentQueue,
     FakeClaimAssessmentOrchestrator,
     FixedClock,
+    InMemoryAssessmentJobRepository,
     InMemoryAssessmentRepository,
     InMemoryAuditTrailReader,
     InMemoryClauseRepository,
@@ -50,6 +54,8 @@ class Harness:
     client: TestClient
     store: dict[str, AssessmentRecord]
     audit_store: dict[str, list[AuditTrailEntry]]
+    job_store: dict[str, AssessmentJob]
+    queue: FakeAssessmentQueue
     clauses: dict[str, PolicyClause] = field(default_factory=dict)
     clock: FixedClock = field(default_factory=FixedClock)
     ids: SequentialIds = field(default_factory=lambda: SequentialIds("api"))
@@ -63,23 +69,29 @@ def harness() -> Iterator[Harness]:
     app = create_app()
     store: dict[str, AssessmentRecord] = {}
     audit_store: dict[str, list[AuditTrailEntry]] = {}
+    job_store: dict[str, AssessmentJob] = {}
     h = Harness(
         client=TestClient(app, raise_server_exceptions=False),
         store=store,
         audit_store=audit_store,
+        job_store=job_store,
+        queue=FakeAssessmentQueue(),
     )
 
     def _assessments() -> InMemoryAssessmentRepository:
         return InMemoryAssessmentRepository(store)
 
+    def _jobs() -> InMemoryAssessmentJobRepository:
+        return InMemoryAssessmentJobRepository(job_store)
+
     app.dependency_overrides[get_submit_claim] = lambda: SubmitClaim(
         clock=h.clock,
-        orchestrator=h.orchestrator,
-        uow_factory=make_uow_factory(store, audit_store),
+        queue=h.queue,
+        uow_factory=make_uow_factory(store, audit_store, job_store),
         new_id=h.ids,
     )
     app.dependency_overrides[get_get_assessment] = lambda: GetAssessment(
-        assessments=_assessments()
+        assessments=_assessments(), jobs=_jobs()
     )
     app.dependency_overrides[get_list_assessments] = lambda: ListAssessments(
         assessments=_assessments()
@@ -89,10 +101,11 @@ def harness() -> Iterator[Harness]:
         orchestrator=h.orchestrator,
         assessments=_assessments(),
         clauses=InMemoryClauseRepository(h.clauses.values()),
-        uow_factory=make_uow_factory(store, audit_store),
+        uow_factory=make_uow_factory(store, audit_store, job_store),
     )
     app.dependency_overrides[get_get_audit_trail] = lambda: GetAuditTrail(
         assessments=_assessments(),
+        jobs=_jobs(),
         audit=InMemoryAuditTrailReader(audit_store),
     )
 

--- a/tests/unit/presentation/test_assessments_api.py
+++ b/tests/unit/presentation/test_assessments_api.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 
 import pytest
 
+from application.assessment_job import JobStatus
 from application.assessment_record import AssessmentRecord, AssessmentStatus
 from domain.citation import Citation
 from domain.clause_classification import ClauseType
@@ -22,6 +23,7 @@ from tests.unit.application.fakes import (
     FakeClaimAssessmentOrchestrator,
     make_audit_entry,
     make_citation,
+    make_job,
     make_orchestrator_result,
     make_policy_clause,
     make_record,
@@ -36,7 +38,7 @@ _CANONICAL_SUSEP = "15414.610650/2024-59"
 # --------------------------------------------------------------------------- #
 
 
-def test_submit_claim_returns_202_with_id_and_location(harness: Harness) -> None:
+def test_submit_claim_returns_202_pending_and_enqueues(harness: Harness) -> None:
     response = harness.client.post(
         "/v1/assessments", json={"raw_text": "Bati o carro."}
     )
@@ -44,10 +46,13 @@ def test_submit_claim_returns_202_with_id_and_location(harness: Harness) -> None
     assert response.status_code == 202
     body = response.json()
     assessment_id = body["assessment_id"]
-    assert body["status"] == "awaiting_review"
+    assert body["status"] == "pending"
     assert response.headers["location"] == f"/v1/assessments/{assessment_id}"
-    stored = harness.store[assessment_id]
-    assert stored.status is AssessmentStatus.AWAITING_REVIEW
+    stored = harness.job_store[assessment_id]
+    assert stored.status is JobStatus.PENDING
+    assert harness.queue.enqueued == [assessment_id]
+    # nothing ran -- no record yet
+    assert harness.store == {}
 
 
 def test_submit_claim_empty_narrative_is_422_validation(harness: Harness) -> None:
@@ -66,24 +71,47 @@ def test_submit_claim_bad_policy_ref_is_422(harness: Harness) -> None:
     assert response.json()["error"]["code"] == "invalid_susep_process"
 
 
-def test_submit_claim_threads_policy_ref_into_the_claim(harness: Harness) -> None:
-    harness.client.post(
+def test_submit_claim_stores_policy_ref_on_the_job(harness: Harness) -> None:
+    body = harness.client.post(
         "/v1/assessments", json={"raw_text": "x", "policy_ref": _CANONICAL_SUSEP}
+    ).json()
+
+    job = harness.job_store[body["assessment_id"]]
+    assert job.policy_ref == SusepProcess(_CANONICAL_SUSEP).value
+
+
+def test_get_pending_assessment_reads_as_pending(harness: Harness) -> None:
+    harness.job_store["a1"] = make_job(assessment_id="a1")
+
+    body = harness.client.get("/v1/assessments/a1").json()
+
+    assert body["status"] == "pending"
+    assert body["verdict"] is None
+    assert body["citations"] == []
+    assert body["error"] is None
+
+
+def test_get_failed_assessment_carries_the_cause(harness: Harness) -> None:
+    from datetime import UTC, datetime
+
+    from application.assessment_job import JobFailure
+
+    harness.job_store["a1"] = make_job(
+        assessment_id="a1",
+        status=JobStatus.FAILED,
+        attempts=3,
+        failure=JobFailure(
+            kind="permanent",
+            error_type="ValueError",
+            message="the claim narrative could not be parsed",
+            failed_at=datetime(2026, 9, 4, tzinfo=UTC),
+        ),
     )
 
-    _, claim = harness.orchestrator.started[0]
-    assert claim.policy_ref == SusepProcess(_CANONICAL_SUSEP)
+    body = harness.client.get("/v1/assessments/a1").json()
 
-
-def test_submit_claim_orchestrator_not_pausing_is_502(harness: Harness) -> None:
-    harness.orchestrator = FakeClaimAssessmentOrchestrator(
-        start_result=make_orchestrator_result(awaiting_review=False)
-    )
-
-    response = harness.client.post("/v1/assessments", json={"raw_text": "x"})
-
-    assert response.status_code == 502
-    assert response.json()["error"]["code"] == "orchestrator_contract_error"
+    assert body["status"] == "failed"
+    assert body["error"] == "the claim narrative could not be parsed"
 
 
 # --------------------------------------------------------------------------- #
@@ -394,8 +422,11 @@ def test_error_envelope_shape(harness: Harness, path: str) -> None:
 
 
 def test_unexpected_error_is_logged_500_without_traceback(harness: Harness) -> None:
-    boom = RuntimeError("kaboom")
-    harness.orchestrator = FakeClaimAssessmentOrchestrator(raise_on_start=boom)
+    class _BrokenQueue:
+        def enqueue(self, assessment_id: str) -> None:
+            raise RuntimeError("kaboom")
+
+    harness.queue = _BrokenQueue()  # type: ignore[assignment]
 
     response = harness.client.post("/v1/assessments", json={"raw_text": "x"})
 

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -841,6 +853,8 @@ dependencies = [
     { name = "pypdf" },
     { name = "pytesseract" },
     { name = "python-dotenv" },
+    { name = "redis" },
+    { name = "rq" },
     { name = "snowballstemmer" },
     { name = "sqlalchemy" },
     { name = "tokenizers" },
@@ -882,6 +896,8 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pytesseract", specifier = ">=0.3.13" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "redis", specifier = ">=5.0" },
+    { name = "rq", specifier = ">=2.0" },
     { name = "snowballstemmer", specifier = ">=2.2" },
     { name = "sqlalchemy", specifier = ">=2.0.52" },
     { name = "tokenizers", specifier = ">=0.20" },
@@ -2531,6 +2547,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2753,6 +2778,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
     { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
     { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "rq"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "croniter" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/81/dacb94c8f67606b233cb7836dd67042daf9a61f7b585dcec65113f1e71f7/rq-2.12.0.tar.gz", hash = "sha256:78116d0c860f6285817b52d7d6d0b16a726372073ce8ea1d229732ce74ef9378", size = 760892, upload-time = "2026-08-30T12:05:25.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/c2/995863e88669133a058c2a6a912b62d18a64fa7baaf78eb66aaa4350b48d/rq-2.12.0-py3-none-any.whl", hash = "sha256:97e349a00e9f2a18962102b3dca156cb5ce315d3ef38145e24ba9cabd16a9361", size = 127957, upload-time = "2026-08-30T12:05:23.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`POST /v1/assessments` no longer runs the LangGraph assessment (minutes, many LLM
calls) synchronously in the request handler. It now persists an `AssessmentJob`
in `pending` and enqueues it on a Redis-backed RQ queue; a worker pool
(`make worker`) runs the graph to the human checkpoint. The `202` + `Location`
contract is unchanged; `GET /v1/assessments/{id}` reports a lifecycle status —
`pending` → `running` → `awaiting_review` (or `failed`, with the cause in
`error`) — and fills in the recommendation once ready.

**Queue = RQ** (`rq` + `redis`, both runtime deps). Sync workers, matching the
sync codebase. `ASSESSMENT_WORKER_CONCURRENCY` (default 2) is the configurable
parallelism bound — each worker runs one assessment at a time, so it is also the
count of concurrent graph runs hitting the LLM provider.

**Lifecycle = a separate `AssessmentJob` aggregate + `assessment_job` table.**
`AssessmentRecord`'s invariants (non-empty verdict/prose, the ≥1-citation
projection) can't represent a not-yet-assessed claim, so the queued-run state is
a second aggregate; the read path composes job + record. The worker's success
path writes the `assessment` row and flips the job to `succeeded` in one
transaction.
the job is marked `failed` and the worker's `stop_retry_on_permanent` handler
zeroes the RQ retry budget so it dead-letters immediately. The dead-letter has
two faces, both preserving the cause: the `assessment_job` row (API-visible as
`error`) and RQ's `FailedJobRegistry` (full traceback). The six per-node
`_invoke_with_retry` helpers are **unchanged** — they still absorb a seconds-scale
blip; a sustained rate limit now bubbles to the job and backs off for minutes.

`infrastructure/bootstrap.py::build_core_components` extracts the heavy singletons
(DB engine, chat models, retrieval stack, orchestrator) so the API `lifespan` and
the worker share one composition root.

**Deviations on record** (`docs/ARCHITECTURE.md` §[M5-05]): the list endpoint
stays record-only; a crash between the job commit and the enqueue leaves a stale
`pending` job (a reconciler is left to ops); the checkpointer connection is still
per-call, not pooled; the `api` / `worker` Compose services + Dockerfile remain
[M5-09] (this PR adds only the `redis` service).

## Related issue

[M5-05]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
  - Unit: `test_run_assessment.py` (state machine), `test_llm_errors.py`
    (classifier truth table), `test_rq_queue.py` / `test_worker.py`,
    `test_assessment_job_mapper.py`, `test_models.py` (job CHECK ↔ enum), rewritten
    `test_submit_claim.py` / `test_get_assessment.py` / presentation tests.
  - Integration (real Postgres + real Redis): `test_assessment_queue.py`
    (submission → burst worker → completion, transient retry, dead-letter) and
    `test_assessment_job_repository.py`. `test_assessment_api.py` (M5-04) kept,
    now stubs the queue with an inline runner.
- [x] Docs updated — new `docs/ASYNC_PROCESSING.md`; updated `docs/API.md`,
  `docs/ARCHITECTURE.md`, `docs/DATABASE.md`, `README.md`, `.env.example`.
- [x] Evaluation impact considered — **none.** No M4 graph-node code changes; the
  retry/back-off logic lives entirely at the queue boundary, so the M4 eval
  baselines are untouched.
- [x] `make check` passes locally (lint, format, `mypy --strict`, 1318 unit
  tests); `make test-integration` — 68 passed; `make worker` boots and shuts
  down cleanly.