### PR TITLE
feat(observability): add health/readiness, JSON logging and correlati…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ DATABASE_NAME=insurance_claims
 # Logging
 APP_ENV=development
 LOG_LEVEL=
+# [M5-06] json (default -- one JSON object per line to stdout) or text (readable
+# local dev lines).
+LOG_FORMAT=json
 
 # Docker Compose reverse proxy
 NGINX_PORT=8080

--- a/app/src/infrastructure/config/settings.py
+++ b/app/src/infrastructure/config/settings.py
@@ -1,7 +1,7 @@
 """This module contains the application settings loaded from environment variables."""
 
 from functools import lru_cache
-from typing import Self
+from typing import Literal, Self
 from urllib.parse import quote_plus
 
 from pydantic import Field, SecretStr, model_validator
@@ -25,6 +25,11 @@ class ObservabilitySettings(BaseSettings):
 
     app_env: str = Field(alias="APP_ENV", default="development")
     log_level: str = Field(alias="LOG_LEVEL", default="INFO")
+
+    # [M5-06] `json` (one JSON object per line, to stdout -- the DoD shape) or
+    # `text` (a human-readable line for a local `make serve`). Default `json`:
+    # the deployed service is the common case, a developer opts out.
+    log_format: Literal["json", "text"] = Field(alias="LOG_FORMAT", default="json")
     proxy_headers_enabled: bool = Field(alias="PROXY_HEADERS_ENABLED", default=True)
     forwarded_allow_ips: str = Field(
         alias="FORWARDED_ALLOW_IPS",

--- a/app/src/infrastructure/graph/build.py
+++ b/app/src/infrastructure/graph/build.py
@@ -28,6 +28,12 @@ Topology after [M4-09]::
 
 ``human_review`` is the one node with an edge to ``END``.
 
+Every node is registered through ``_instrumented`` ([M5-06]): a wrapper that
+brackets each run with a correlation-id-tagged ``node.start`` / ``node.completed``
+log line (and ``node.failed`` on a real exception). It is applied here, not in
+the node files, so the ``(state, runtime) -> dict`` convention and its
+enforcement test stay untouched.
+
 **Compiling this graph without a checkpointer is a mistake, not an option.**
 ``human_review`` calls ``interrupt()``, and LangGraph does not complain when
 there is nowhere to persist the pause -- ``.invoke()`` simply returns early with
@@ -68,9 +74,14 @@ audit trail somewhere a compliance reader can query. See
 ``docs/HUMAN_CHECKPOINT.md``.
 """
 
-from typing import Literal
+import logging
+import time
+from collections.abc import Callable
+from typing import Literal, cast
 
+from langgraph.errors import GraphBubbleUp
 from langgraph.graph import END, START, StateGraph
+from langgraph.runtime import Runtime
 
 from infrastructure.graph.context import GraphContext
 from infrastructure.graph.nodes.clarification import clarification
@@ -90,6 +101,56 @@ from infrastructure.graph.state import ClaimState
 MAX_CLARIFICATION_ROUNDS = 2
 
 _ClaimGraph = StateGraph[ClaimState, GraphContext, ClaimState, ClaimState]
+
+_Node = Callable[[ClaimState, Runtime[GraphContext]], dict[str, object]]
+
+# One log line at the start and end of every node run, tagged with the run's
+# correlation id ([M5-06]). Emitting it here -- once, around every node -- rather
+# than in each node file keeps the `(state, runtime) -> dict` node convention
+# untouched and gives per-node timing for free (a head start on [M5-10]).
+_node_logger = logging.getLogger("infrastructure.graph.node")
+
+
+def _instrumented[NodeT: _Node](node: NodeT) -> NodeT:
+    """Wrap a node so every run brackets itself with a correlation-tagged log line."""
+
+    def wrapper(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, object]:
+        correlation_id = runtime.context.correlation_id or "-"
+        _node_logger.info(
+            "node.start",
+            extra={"node": node.__name__, "correlation_id": correlation_id},
+        )
+        started = time.perf_counter()
+        try:
+            result = node(state, runtime)
+        except GraphBubbleUp:
+            # `interrupt()` in `human_review` and other LangGraph control flow --
+            # not a failure, let it bubble silently.
+            raise
+        except Exception:
+            _node_logger.exception(
+                "node.failed",
+                extra={
+                    "node": node.__name__,
+                    "correlation_id": correlation_id,
+                    "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+                },
+            )
+            raise
+        _node_logger.info(
+            "node.completed",
+            extra={
+                "node": node.__name__,
+                "correlation_id": correlation_id,
+                "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+            },
+        )
+        return result
+
+    wrapper.__name__ = node.__name__
+    wrapper.__qualname__ = getattr(node, "__qualname__", node.__name__)
+    wrapper.__doc__ = node.__doc__
+    return cast("NodeT", wrapper)
 
 
 def route_after_intake(
@@ -132,14 +193,14 @@ def build_claim_graph() -> _ClaimGraph:
     to every invocation -- see the module docstring.
     """
     builder: _ClaimGraph = StateGraph(ClaimState, context_schema=GraphContext)
-    builder.add_node("intake", intake)
-    builder.add_node("clarification", clarification)
-    builder.add_node("clarification_exhausted", clarification_exhausted)
-    builder.add_node("retrieval", retrieval)
-    builder.add_node("compatibility", compatibility)
-    builder.add_node("consistency", consistency)
-    builder.add_node("recommendation", recommendation)
-    builder.add_node("human_review", human_review)
+    builder.add_node("intake", _instrumented(intake))
+    builder.add_node("clarification", _instrumented(clarification))
+    builder.add_node("clarification_exhausted", _instrumented(clarification_exhausted))
+    builder.add_node("retrieval", _instrumented(retrieval))
+    builder.add_node("compatibility", _instrumented(compatibility))
+    builder.add_node("consistency", _instrumented(consistency))
+    builder.add_node("recommendation", _instrumented(recommendation))
+    builder.add_node("human_review", _instrumented(human_review))
 
     builder.add_edge(START, "intake")
     builder.add_conditional_edges(

--- a/app/src/infrastructure/graph/context.py
+++ b/app/src/infrastructure/graph/context.py
@@ -98,3 +98,9 @@ class GraphContext:
     # the same way a deterministic node leaves `AuditEvent.model` unset. The
     # composition root supplies the Postgres-backed sink.
     audit_sink: AuditTrailSink | None = None
+    # [M5-06]. The correlation id for this run -- tied to the originating HTTP
+    # request (or minted by the worker). `infrastructure.graph.build`'s node
+    # wrapper stamps it on every node log line; the orchestrator also puts it in
+    # the graph `config` metadata so LLM calls inherit it. Defaulted so a test
+    # or eval `GraphContext(...)` needs nothing.
+    correlation_id: str = ""

--- a/app/src/infrastructure/graph/orchestrator.py
+++ b/app/src/infrastructure/graph/orchestrator.py
@@ -44,6 +44,11 @@ from infrastructure.graph.build import build_claim_graph
 from infrastructure.graph.checkpointer import open_claim_checkpointer
 from infrastructure.graph.context import GraphContext
 from infrastructure.graph.state import AuditRecord, ClaimState
+from infrastructure.observability.correlation import (
+    bind_correlation_id,
+    generate_correlation_id,
+    get_correlation_id,
+)
 
 _GraphFactory = Callable[
     [], StateGraph[ClaimState, GraphContext, ClaimState, ClaimState]
@@ -135,14 +140,30 @@ class LangGraphClaimAssessmentOrchestrator:
         graph_input: ClaimState | Command[Any],
     ) -> tuple[dict[str, Any], _CapturingAuditSink]:
         """Compile the graph, invoke it once for this run, return its final state."""
-        config: Any = {"configurable": {"thread_id": assessment_id}}
+        correlation_id = get_correlation_id() or generate_correlation_id()
+        config: Any = {
+            "configurable": {
+                "thread_id": assessment_id,
+                "correlation_id": correlation_id,
+            },
+            # LangGraph copies `metadata` onto every node's child RunnableConfig,
+            # so the bare `chain.invoke(messages)` LLM calls in the nodes carry
+            # the correlation id without a per-node change ([M5-06]; M5-07's
+            # tracer reads it).
+            "metadata": {"correlation_id": correlation_id},
+        }
         sink = _CapturingAuditSink()
         with (
+            bind_correlation_id(correlation_id),
             self._session_factory() as session,
             open_claim_checkpointer(self._database_url) as checkpointer,
         ):
             compiled = self._graph_builder().compile(checkpointer=checkpointer)
-            context = replace(self._context_factory(session), audit_sink=sink)
+            context = replace(
+                self._context_factory(session),
+                audit_sink=sink,
+                correlation_id=correlation_id,
+            )
             final_state = compiled.invoke(graph_input, config=config, context=context)
         return cast("dict[str, Any]", final_state), sink
 

--- a/app/src/infrastructure/observability/__init__.py
+++ b/app/src/infrastructure/observability/__init__.py
@@ -1,0 +1,16 @@
+"""Operational observability: structured logging, correlation IDs, readiness -- [M5-06].
+
+The three pieces of the M5-06 baseline that are not HTTP routes:
+
+- ``correlation`` -- the per-run id, held in a ``contextvars`` variable so it
+  rides along every log line without being threaded through call signatures.
+- ``logging`` -- one JSON line per event to stdout (timestamp, level, logger,
+  message, correlation id, plus whatever ``extra=`` carries).
+- ``readiness`` -- the dependency probes ``GET /ready`` reports on.
+
+Import from the submodules directly (``infrastructure.observability.correlation``
+etc.): ``readiness`` reaches into ``infrastructure.database``, and the queue /
+graph modules that only need a correlation id should not pull that in. Nothing
+here imports FastAPI or RQ -- the middleware and the queue adapter call in, so
+``domain`` / ``application`` stay clean.
+"""

--- a/app/src/infrastructure/observability/correlation.py
+++ b/app/src/infrastructure/observability/correlation.py
@@ -1,0 +1,61 @@
+"""The correlation id for one assessment run -- [M5-06].
+
+A correlation id ties an HTTP request to every log line it (and the graph run it
+starts) produces. It is accepted from the caller when present and minted when
+not, then carried in a module-level ``contextvars.ContextVar`` rather than passed
+down every function signature -- the logging filter
+([infrastructure.observability.logging.CorrelationIdFilter]) reads it, and so
+does anything that needs to tag an outbound call.
+
+Two entry points set it:
+
+- the HTTP middleware ([presentation.middleware.RequestContextMiddleware]) for a
+  request, and
+- the queue task ([infrastructure.queue.tasks.run_assessment_job]) for a worker
+  run, from the id the enqueue side stored on the RQ job.
+
+The graph adapter ([infrastructure.graph.orchestrator]) also binds it for the
+duration of a ``.invoke`` so a node that logs picks it up even on the
+synchronous resume path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# Accepted request headers, in priority order. ``X-Correlation-ID`` is the name
+# this service uses on the way out; ``X-Request-ID`` is accepted because it is
+# what many proxies and clients already send.
+CORRELATION_ID_HEADERS: tuple[str, ...] = ("x-correlation-id", "x-request-id")
+
+# The header this service sets on responses and would send on downstream calls.
+CORRELATION_ID_RESPONSE_HEADER = "X-Correlation-ID"
+
+_correlation_id: ContextVar[str | None] = ContextVar("correlation_id", default=None)
+
+
+def get_correlation_id() -> str | None:
+    """The correlation id bound to the current context, or ``None``."""
+    return _correlation_id.get()
+
+
+def generate_correlation_id() -> str:
+    """Mint a fresh correlation id (a bare uuid4 hex string)."""
+    return uuid.uuid4().hex
+
+
+@contextmanager
+def bind_correlation_id(value: str) -> Iterator[str]:
+    """Bind ``value`` as the correlation id for the duration of the block.
+
+    Resets to the previous value on exit, so nested binds and worker threads
+    that reuse a context do not leak an id into the next unit of work.
+    """
+    token = _correlation_id.set(value)
+    try:
+        yield value
+    finally:
+        _correlation_id.reset(token)

--- a/app/src/infrastructure/observability/logging.py
+++ b/app/src/infrastructure/observability/logging.py
@@ -1,0 +1,104 @@
+"""One JSON log line per event, to stdout -- [M5-06].
+
+The M5-06 DoD: "JSON logs to stdout with timestamp, level, path, method, status,
+duration". ``path`` / ``method`` / ``status`` / ``duration`` are per-request and
+come from the middleware via ``extra=``; the formatter here owns the envelope
+(``timestamp`` / ``level`` / ``logger`` / ``message`` / ``correlation_id``) and
+passes any ``extra=`` keys straight through.
+
+Hand-rolled rather than a ``python-json-logger`` dependency -- the same
+minimal-dependency habit as the rest of the project, and the envelope is a dozen
+lines. ``configure_logging`` is idempotent: the API entry point, the worker entry
+point and every ``create_app()`` in a test all call it, and the last one wins
+without stacking handlers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from infrastructure.config.settings import ObservabilitySettings
+from infrastructure.observability.correlation import get_correlation_id
+
+# Attributes the stdlib puts on every LogRecord. Anything on a record that is
+# *not* in here arrived via ``logger.info(..., extra={...})`` and is a field the
+# caller wants in the line.
+_STANDARD_RECORD_ATTRS = frozenset(logging.makeLogRecord({}).__dict__.keys()) | {
+    "message",
+    "asctime",
+    "taskName",
+}
+
+_TEXT_FORMAT = "%(asctime)s %(levelname)s [%(correlation_id)s] %(name)s: %(message)s"
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Stamp every record with the correlation id bound to the current context."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Always keep the record; add ``correlation_id`` if it is not set."""
+        if not hasattr(record, "correlation_id"):
+            record.correlation_id = get_correlation_id() or "-"
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a record as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """The envelope, then every ``extra=`` field, then the exception if any."""
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "correlation_id": getattr(record, "correlation_id", "-"),
+        }
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_RECORD_ATTRS and key != "correlation_id":
+                payload[key] = value
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_logging(settings: ObservabilitySettings | None = None) -> None:
+    """Point the root logger at stdout with the JSON (or text) formatter.
+
+    Idempotent -- replaces the root handler set rather than adding to it.
+
+    Uvicorn installs its own handlers on ``uvicorn`` / ``uvicorn.access`` /
+    ``uvicorn.error`` with ``propagate=False`` and a plain formatter. We hand
+    those loggers back to the root handler so every line is JSON;
+    ``uvicorn.access`` is then silenced entirely because the per-request line is
+    [presentation.middleware.RequestContextMiddleware]'s to emit, structured.
+    """
+    resolved = settings or ObservabilitySettings()
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(CorrelationIdFilter())
+    if resolved.log_format == "text":
+        handler.setFormatter(logging.Formatter(_TEXT_FORMAT))
+    else:
+        handler.setFormatter(JsonFormatter())
+
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(handler)
+    root.setLevel(resolved.log_level)
+
+    for name in ("uvicorn", "uvicorn.error"):
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers.clear()
+        uvicorn_logger.propagate = True
+
+    access = logging.getLogger("uvicorn.access")
+    access.handlers.clear()
+    access.propagate = False

--- a/app/src/infrastructure/observability/readiness.py
+++ b/app/src/infrastructure/observability/readiness.py
@@ -1,0 +1,83 @@
+"""The dependency probes behind ``GET /ready`` -- [M5-06].
+
+The M5-06 DoD: "``GET /ready`` checks Postgres, Redis and the vector index;
+returns 503 with per-check detail when degraded". Each probe is guarded and
+returns a ``CheckResult`` rather than raising, so one dependency being down gives
+a 503 that still names which one and why -- an operator reads the body, not just
+the status.
+
+Liveness (``GET /health``) stays dependency-free and lives in the route module;
+this is only the readiness side.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session, sessionmaker
+
+from infrastructure.database.chunk_repository import assert_chunk_table_ready
+from infrastructure.database.session import is_database_reachable
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """The outcome of one readiness probe."""
+
+    name: str
+    ok: bool
+    detail: str | None = None
+
+
+class ReadinessProbe:
+    """Run the Postgres / Redis / vector-index probes for ``GET /ready``."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: sessionmaker[Session],
+        redis_ping: Callable[[], object],
+    ) -> None:
+        """Wire the probe to the shared session factory and the queue's ``ping``."""
+        self._session_factory = session_factory
+        self._redis_ping = redis_ping
+
+    def check(self) -> list[CheckResult]:
+        """Probe every dependency; order is stable for a readable response body."""
+        return [self._postgres(), self._redis(), self._vector_index()]
+
+    def _postgres(self) -> CheckResult:
+        if is_database_reachable(self._session_factory):
+            return CheckResult("postgres", ok=True)
+        return CheckResult("postgres", ok=False, detail="SELECT 1 failed")
+
+    def _redis(self) -> CheckResult:
+        try:
+            self._redis_ping()
+        except Exception as exc:  # noqa: BLE001 - reported, not raised
+            return CheckResult("redis", ok=False, detail=f"{type(exc).__name__}: {exc}")
+        return CheckResult("redis", ok=True)
+
+    def _vector_index(self) -> CheckResult:
+        """Ready == the ``chunk`` table is migrated and has embedded rows."""
+        try:
+            with self._session_factory() as session:
+                assert_chunk_table_ready(session)
+                embedded = session.execute(
+                    text("SELECT count(*) FROM chunk WHERE embedding IS NOT NULL")
+                ).scalar_one()
+        except Exception as exc:  # noqa: BLE001 - reported, not raised
+            return CheckResult(
+                "vector_index", ok=False, detail=f"{type(exc).__name__}: {exc}"
+            )
+        if embedded == 0:
+            return CheckResult(
+                "vector_index",
+                ok=False,
+                detail="no embedded chunks -- run make build-index",
+            )
+        return CheckResult(
+            "vector_index", ok=True, detail=f"{embedded} embedded chunks"
+        )

--- a/app/src/infrastructure/queue/rq_queue.py
+++ b/app/src/infrastructure/queue/rq_queue.py
@@ -18,6 +18,10 @@ import redis
 from rq import Queue, Retry
 
 from infrastructure.config.settings import QueueSettings
+from infrastructure.observability.correlation import (
+    generate_correlation_id,
+    get_correlation_id,
+)
 
 QUEUE_NAME = "assessments"
 DEFAULT_JOB_PATH = "infrastructure.queue.tasks.run_assessment_job"
@@ -43,20 +47,33 @@ class RqAssessmentQueue:
         self._job_timeout = job_timeout
 
     def enqueue(self, assessment_id: str) -> None:
-        """Queue ``assessment_id`` for a worker, with retry + timeout attached."""
+        """Queue ``assessment_id`` for a worker, with retry + timeout attached.
+
+        The caller's correlation id ([M5-06]) rides across Redis as the job's
+        second argument and on its ``meta``, so the worker's graph run -- and
+        every node log line it produces -- ties back to the request that
+        submitted the claim.
+        """
         retry: Retry | None = None
         if self._max_attempts > 1:
             retry = Retry(
                 max=self._max_attempts - 1,
                 interval=self._retry_intervals or 0,
             )
+        correlation_id = get_correlation_id() or generate_correlation_id()
         self._queue.enqueue(
             self._job_path,
             assessment_id,
+            correlation_id,
             job_id=assessment_id,
             job_timeout=self._job_timeout,
             retry=retry,
+            meta={"correlation_id": correlation_id},
         )
+
+    def ping(self) -> None:
+        """Round-trip the Redis connection -- the readiness probe's redis check."""
+        self._queue.connection.ping()
 
 
 def build_assessment_queue(

--- a/app/src/infrastructure/queue/tasks.py
+++ b/app/src/infrastructure/queue/tasks.py
@@ -21,6 +21,10 @@ from infrastructure.bootstrap import build_core_components
 from infrastructure.clock import SystemClock
 from infrastructure.config.settings import get_queue_settings
 from infrastructure.llm_errors import is_transient_llm_error
+from infrastructure.observability.correlation import (
+    bind_correlation_id,
+    generate_correlation_id,
+)
 
 _lock = threading.Lock()
 _runner: RunAssessment | None = None
@@ -48,6 +52,13 @@ def _runner_singleton() -> RunAssessment:
     return _runner
 
 
-def run_assessment_job(assessment_id: str) -> None:
-    """RQ entry point: process one queued assessment run to the human checkpoint."""
-    _runner_singleton()(assessment_id)
+def run_assessment_job(assessment_id: str, correlation_id: str | None = None) -> None:
+    """RQ entry point: process one queued assessment run to the human checkpoint.
+
+    ``correlation_id`` is the id the enqueue side ([M5-06]) carried across Redis;
+    binding it here means the graph run and its node log lines trace back to the
+    originating request. Defaulted so an older queued job (no second arg) still
+    runs, with a fresh id.
+    """
+    with bind_correlation_id(correlation_id or generate_correlation_id()):
+        _runner_singleton()(assessment_id)

--- a/app/src/infrastructure/queue/worker.py
+++ b/app/src/infrastructure/queue/worker.py
@@ -32,6 +32,7 @@ from infrastructure.config.settings import (
     get_observability_settings,
     get_queue_settings,
 )
+from infrastructure.observability.logging import configure_logging
 from infrastructure.queue.rq_queue import QUEUE_NAME
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def stop_retry_on_permanent(
 
 def run_worker() -> None:
     """Start the worker pool and block until it is stopped."""
-    logging.basicConfig(level=get_observability_settings().log_level)
+    configure_logging(get_observability_settings())
     settings = get_queue_settings()
     connection = redis.Redis.from_url(settings.redis_url)
 

--- a/app/src/presentation/app.py
+++ b/app/src/presentation/app.py
@@ -33,9 +33,12 @@ from infrastructure.config.settings import (
     get_observability_settings,
     get_queue_settings,
 )
+from infrastructure.observability.logging import configure_logging
+from infrastructure.observability.readiness import ReadinessProbe
 from infrastructure.queue import build_assessment_queue
 from presentation.dependencies import AppComponents
 from presentation.errors import register_exception_handlers
+from presentation.middleware import RequestContextMiddleware
 from presentation.routes import assessments, health
 
 logger = logging.getLogger(__name__)
@@ -46,7 +49,7 @@ _LifespanFactory = Callable[[FastAPI], AbstractAsyncContextManager[None]]
 @asynccontextmanager
 async def _default_lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Build the production composition root and tear it down on shutdown."""
-    logging.basicConfig(level=get_observability_settings().log_level)
+    configure_logging(get_observability_settings())
 
     core = build_core_components()
     queue = build_assessment_queue(get_queue_settings())
@@ -58,6 +61,10 @@ async def _default_lifespan(app: FastAPI) -> AsyncIterator[None]:
         uow_factory=core.uow_factory,
         session_factory=core.session_factory,
         new_id=lambda: str(uuid4()),
+        readiness=ReadinessProbe(
+            session_factory=core.session_factory,
+            redis_ping=queue.ping,
+        ),
     )
     logger.info("assessment API composition root ready")
     try:
@@ -73,6 +80,7 @@ def create_app(*, lifespan: _LifespanFactory | None = None) -> FastAPI:
         version="1",
         lifespan=lifespan or _default_lifespan,
     )
+    app.add_middleware(RequestContextMiddleware)
     app.include_router(health.router)
     app.include_router(assessments.router)
     register_exception_handlers(app)

--- a/app/src/presentation/dependencies.py
+++ b/app/src/presentation/dependencies.py
@@ -36,6 +36,7 @@ from infrastructure.database import (
     SqlAlchemyAuditTrailReader,
     SqlAlchemyClauseRepository,
 )
+from infrastructure.observability.readiness import ReadinessProbe
 
 
 @dataclass
@@ -48,6 +49,7 @@ class AppComponents:
     uow_factory: UnitOfWorkFactory
     session_factory: sessionmaker[Session]
     new_id: Callable[[], str]
+    readiness: ReadinessProbe
 
 
 def _components(request: Request) -> AppComponents:
@@ -84,6 +86,11 @@ def get_uow_factory(request: Request) -> UnitOfWorkFactory:
 def get_new_id(request: Request) -> Callable[[], str]:
     """Mints the claim / assessment identifiers."""
     return _components(request).new_id
+
+
+def get_readiness_probe(request: Request) -> ReadinessProbe:
+    """The dependency probe ``GET /ready`` reports on -- [M5-06]."""
+    return _components(request).readiness
 
 
 _Session = Annotated[Session, Depends(get_read_session)]

--- a/app/src/presentation/middleware.py
+++ b/app/src/presentation/middleware.py
@@ -1,0 +1,95 @@
+"""The request-context middleware -- correlation id + one access line [M5-06].
+
+A pure ASGI middleware, not ``BaseHTTPMiddleware``: it needs to (a) set the
+correlation-id ``contextvars`` variable in the *same* task that runs the route
+and its sync-threadpool handler, so a graph run started inside the request picks
+it up, and (b) see the real response status by wrapping ``send``.
+``BaseHTTPMiddleware`` runs the app in a child task and would defeat (a).
+
+Per request:
+
+- take the correlation id from ``X-Correlation-ID`` / ``X-Request-ID`` or mint one;
+- bind it for the duration of the call;
+- echo it on the response as ``X-Correlation-ID``;
+- emit exactly one ``presentation.access`` log line -- ``path`` / ``method`` /
+  ``status`` / ``duration_ms`` -- which the JSON formatter renders with the
+  ``timestamp`` / ``level`` / ``correlation_id`` envelope the DoD asks for.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from infrastructure.observability.correlation import (
+    CORRELATION_ID_HEADERS,
+    CORRELATION_ID_RESPONSE_HEADER,
+    bind_correlation_id,
+    generate_correlation_id,
+)
+
+_Scope = dict[str, Any]
+_Message = dict[str, Any]
+_Receive = Callable[[], Awaitable[_Message]]
+_Send = Callable[[_Message], Awaitable[None]]
+_App = Callable[[_Scope, _Receive, _Send], Awaitable[None]]
+
+_access_logger = logging.getLogger("presentation.access")
+
+
+def _incoming_correlation_id(scope: _Scope) -> str:
+    """The caller's correlation id from a known header, or a fresh one."""
+    raw_headers: list[tuple[bytes, bytes]] = scope["headers"]
+    headers = {key.decode("latin-1").lower(): value for key, value in raw_headers}
+    for name in CORRELATION_ID_HEADERS:
+        header = headers.get(name)
+        if header is not None:
+            value = header.decode("latin-1").strip()
+            if value:
+                return value
+    return generate_correlation_id()
+
+
+class RequestContextMiddleware:
+    """Bind a correlation id per request and log one structured access line."""
+
+    def __init__(self, app: _App) -> None:
+        """Wrap the downstream ASGI app."""
+        self._app = app
+
+    async def __call__(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        """Bind the correlation id, run the app, emit the access line."""
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        correlation_id = _incoming_correlation_id(scope)
+        header_value = correlation_id.encode("latin-1")
+        status_code = 500
+        started = time.perf_counter()
+
+        async def send_wrapper(message: _Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                headers = message.setdefault("headers", [])
+                headers.append(
+                    (CORRELATION_ID_RESPONSE_HEADER.encode("latin-1"), header_value)
+                )
+            await send(message)
+
+        with bind_correlation_id(correlation_id):
+            try:
+                await self._app(scope, receive, send_wrapper)
+            finally:
+                _access_logger.info(
+                    "request",
+                    extra={
+                        "path": scope["path"],
+                        "method": scope["method"],
+                        "status": status_code,
+                        "duration_ms": round((time.perf_counter() - started) * 1000, 2),
+                    },
+                )

--- a/app/src/presentation/routes/health.py
+++ b/app/src/presentation/routes/health.py
@@ -1,16 +1,47 @@
-"""Liveness endpoint -- [M5-04].
+"""Liveness and readiness endpoints -- [M5-04], [M5-06].
 
 ``GET /health`` returns 200 without touching any dependency, so a load balancer
-can tell the process is up. Readiness (``/ready`` with per-check detail on
-Postgres / Redis / the vector index) is [M5-06]'s.
+can tell the process is up.
+
+``GET /ready`` ([M5-06]) probes Postgres, Redis and the vector index and returns
+per-check detail: 200 ``{"status": "ready", ...}`` when all pass, 503
+``{"status": "degraded", ...}`` naming the check that failed and why.
 """
 
-from fastapi import APIRouter
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response
+
+from infrastructure.observability.readiness import CheckResult, ReadinessProbe
+from presentation.dependencies import get_readiness_probe
 
 router = APIRouter(tags=["health"])
+
+_ReadinessProbe = Annotated[ReadinessProbe, Depends(get_readiness_probe)]
 
 
 @router.get("/health")
 def health() -> dict[str, str]:
     """Report that the process is alive."""
     return {"status": "ok"}
+
+
+def _check_body(result: CheckResult) -> dict[str, str]:
+    body = {"status": "ok" if result.ok else "error"}
+    if result.detail is not None:
+        body["detail"] = result.detail
+    return body
+
+
+@router.get("/ready")
+def ready(probe: _ReadinessProbe, response: Response) -> dict[str, object]:
+    """Probe every dependency; 503 with per-check detail when one is degraded."""
+    results = probe.check()
+    healthy = all(result.ok for result in results)
+    response.status_code = 200 if healthy else 503
+    return {
+        "status": "ready" if healthy else "degraded",
+        "checks": {result.name: _check_body(result) for result in results},
+    }

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,7 @@ GET    /v1/assessments/{id}                 lifecycle + recommendation -> 200
 POST   /v1/assessments/{id}/decision        approve / edit / reject  -> 200
 GET    /v1/assessments/{id}/audit           durable audit trail      -> 200
 GET    /health                              liveness                 -> 200
+GET    /ready                               dependency readiness     -> 200 / 503
 ```
 
 Since [M5-05] the graph runs on a background worker, not in the request. `POST`
@@ -29,7 +30,13 @@ Code:
 - `app/src/presentation/{schemas,mappers}.py` — Pydantic models, pure
   dataclass↔schema conversions.
 - `app/src/presentation/errors.py` — the single error→HTTP edge.
-- `app/src/presentation/routes/{assessments,health}.py` — the routers.
+- `app/src/presentation/routes/{assessments,health}.py` — the routers (`health.py`
+  serves both `/health` and the [M5-06] `/ready`).
+- `app/src/presentation/middleware.py` — the [M5-06] request-context middleware
+  (correlation id + one structured access line).
+- `app/src/infrastructure/observability/` — [M5-06] JSON logging
+  (`logging.py`), the correlation-id context var (`correlation.py`) and the
+  `/ready` dependency probe (`readiness.py`).
 - `app/src/infrastructure/graph/orchestrator.py` — `LangGraphClaimAssessmentOrchestrator`
   and its `_CapturingAuditSink`.
 - `app/src/infrastructure/graph/state_mapper.py` — the `state.py` ↔ domain mapper.
@@ -145,6 +152,45 @@ resumed.
 Empty (`"entries": []`) until a decision is submitted — the durable trail is
 written once, at the human checkpoint.
 
+### `GET /health` and `GET /ready` — [M5-06]
+
+`GET /health` is liveness: `200 {"status": "ok"}`, no dependency touched, so a
+load balancer can tell the process is up even while a dependency is down.
+
+`GET /ready` is readiness — it probes Postgres, Redis and the vector index (the
+`chunk` table must be migrated **and** carry embedded rows):
+
+```json
+{ "status": "ready",
+  "checks": { "postgres": { "status": "ok" },
+              "redis": { "status": "ok" },
+              "vector_index": { "status": "ok", "detail": "4540 embedded chunks" } } }
+```
+
+`200` when every check passes, `503` with `"status": "degraded"` and the failing
+check carrying `{"status": "error", "detail": "<why>"}` otherwise — a caller
+reads the body to see which dependency is down, not just the status.
+
+## Structured logging & correlation IDs — [M5-06]
+
+The service logs one JSON object per line to stdout — `timestamp` (ISO-8601
+UTC), `level`, `logger`, `message`, `correlation_id`, plus any event fields. Set
+`LOG_FORMAT=text` for readable lines on a local `make serve`; `LOG_LEVEL`
+controls verbosity.
+
+Every request carries a **correlation id**: taken from `X-Correlation-ID` (or
+`X-Request-ID`) when the caller sends one, minted otherwise, and echoed on the
+response as `X-Correlation-ID`. The middleware emits one access line per request
+(`{"message": "request", "path", "method", "status", "duration_ms", "correlation_id"}`).
+
+The id propagates into the assessment run: the orchestrator binds it for the
+graph invocation and puts it in the graph `config` metadata, so every node run
+logs a correlation-tagged `node.start` / `node.completed` line
+(`infrastructure.graph.node`) and every LLM call carries it (M5-07's tracing
+reads that metadata). On the async path the id rides the RQ job across Redis and
+the worker re-binds it, so a worker's node logs trace back to the `POST` that
+queued the claim.
+
 ## Errors
 
 Uniform envelope; `code` is stable, branch on it:
@@ -213,8 +259,9 @@ Redis round-trip — submission → worker → completion, transient retry, dead
   retry-with-backoff on transient provider faults, dead-letter, and the
   `pending` / `running` / `failed` lifecycle behind the non-blocking 202.
   See [`ASYNC_PROCESSING.md`](ASYNC_PROCESSING.md).
-- **[M5-06]** — `GET /ready` with per-check detail, JSON logs to stdout, and
-  correlation-id propagation from the request into every node and LLM call.
+- **[M5-06] done** — `GET /ready` with per-check detail, JSON logs to stdout, and
+  correlation-id propagation from the request into every node and LLM call. See
+  "Structured logging & correlation IDs" above.
 - **[M5-09]** — the Compose `api` / `worker` services, the Dockerfile, the CI
   image build, and the proxy-header / trusted-host middleware from
   `ObservabilitySettings`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,6 +127,19 @@ first two parameters are not `(state, runtime)`.
 `tests/architecture/test_scope_vocabulary.py` already scans the same tree for
 verdict-vocabulary drift.
 
+**Instrumentation — [M5-06].** `build.py` registers every node through a
+`_instrumented(node)` wrapper: each run brackets itself with a correlation-tagged
+`node.start` / `node.completed` log line on the `infrastructure.graph.node`
+logger (`node.failed` on a real exception; LangGraph control-flow exceptions such
+as `human_review`'s `interrupt()` bubble silently), plus a `duration_ms`. It sits
+in `build.py`, not the node files, so the `(state, runtime) -> dict` convention
+and its enforcement test are untouched. The correlation id is
+`GraphContext.correlation_id`, set by `LangGraphClaimAssessmentOrchestrator` from
+the ambient request/worker id; the orchestrator also puts it in the graph
+`config` metadata, which LangGraph copies onto every node's child
+`RunnableConfig` so LLM calls carry it (M5-07's tracing reads that). See
+`docs/API.md` "Structured logging & correlation IDs".
+
 ---
 
 ## The clarification loop is self-capping in the router, not in the framework — [M4-03]
@@ -859,10 +872,13 @@ LangGraph checkpointer) with a fake model and stub retriever: submit → 202 →
 runs the presentation unit tests.
 
 **Downstream.** [M5-05] replaces the synchronous 202 with a Redis queue and adds
-run-status states (below). [M5-06] adds `/ready`, JSON logging and correlation-id
-propagation. [M5-09] adds the Compose `api` / `worker` services, the Dockerfile
-and the CI image build, and wires the proxy-header / trusted-host middleware from
-`ObservabilitySettings`.
+run-status states (below). [M5-06] **done** — `/ready` with per-check detail, one
+JSON log line per event to stdout, and a correlation id accepted or minted per
+request and propagated into every graph node log line and LLM call (via
+`presentation/middleware.py`, `infrastructure/observability/`, and the `build.py`
+node wrapper); see `docs/API.md`. [M5-09] adds the Compose `api` / `worker`
+services, the Dockerfile and the CI image build, and wires the proxy-header /
+trusted-host middleware from `ObservabilitySettings`.
 
 ---
 

--- a/tests/integration/_queue_fakes.py
+++ b/tests/integration/_queue_fakes.py
@@ -29,6 +29,10 @@ from infrastructure.database import (
 )
 from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
 from infrastructure.llm_errors import is_transient_llm_error
+from infrastructure.observability.correlation import (
+    bind_correlation_id,
+    generate_correlation_id,
+)
 from tests.integration._checkpoint_fakes import build_fake_context
 
 _MAX_ATTEMPTS = 3
@@ -62,20 +66,23 @@ def _fake_orchestrator(
     )
 
 
-def _run(orchestrator: object, assessment_id: str) -> None:
+def _run(
+    orchestrator: object, assessment_id: str, correlation_id: str | None = None
+) -> None:
     session_factory = _session_factory()
-    RunAssessment(
-        clock=SystemClock(),
-        orchestrator=orchestrator,  # type: ignore[arg-type]
-        uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
-        is_transient=is_transient_llm_error,
-        max_attempts=_MAX_ATTEMPTS,
-    )(assessment_id)
+    with bind_correlation_id(correlation_id or generate_correlation_id()):
+        RunAssessment(
+            clock=SystemClock(),
+            orchestrator=orchestrator,  # type: ignore[arg-type]
+            uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+            is_transient=is_transient_llm_error,
+            max_attempts=_MAX_ATTEMPTS,
+        )(assessment_id)
 
 
-def run_assessment_job(assessment_id: str) -> None:
+def run_assessment_job(assessment_id: str, correlation_id: str | None = None) -> None:
     """Happy-path job: run the fake graph to the human checkpoint."""
-    _run(_fake_orchestrator(_session_factory()), assessment_id)
+    _run(_fake_orchestrator(_session_factory()), assessment_id, correlation_id)
 
 
 class _WrappingOrchestrator:
@@ -110,14 +117,23 @@ class _PermanentlyFailingOrchestrator(_WrappingOrchestrator):
         raise ValueError("the claim narrative could not be parsed")
 
 
-def run_flaky_assessment_job(assessment_id: str) -> None:
+def run_flaky_assessment_job(
+    assessment_id: str, correlation_id: str | None = None
+) -> None:
     """Fails transiently once, then succeeds -- exercises retry-with-backoff."""
-    _run(_FlakyOrchestrator(_fake_orchestrator(_session_factory())), assessment_id)
+    _run(
+        _FlakyOrchestrator(_fake_orchestrator(_session_factory())),
+        assessment_id,
+        correlation_id,
+    )
 
 
-def run_failing_assessment_job(assessment_id: str) -> None:
+def run_failing_assessment_job(
+    assessment_id: str, correlation_id: str | None = None
+) -> None:
     """Fails with a real error every time -- exercises the dead-letter path."""
     _run(
         _PermanentlyFailingOrchestrator(_fake_orchestrator(_session_factory())),
         assessment_id,
+        correlation_id,
     )

--- a/tests/integration/test_assessment_api.py
+++ b/tests/integration/test_assessment_api.py
@@ -37,6 +37,7 @@ from infrastructure.database import (
 from infrastructure.database.chunk_repository import upsert_chunks
 from infrastructure.graph.checkpointer import open_claim_checkpointer
 from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.observability.readiness import ReadinessProbe
 from infrastructure.rag.chunk_schema import SCHEMA_VERSION, ChunkRecord
 from presentation.app import create_app
 from presentation.dependencies import AppComponents
@@ -117,6 +118,9 @@ def _test_lifespan(database_url: str, session_factory: sessionmaker[Session]) ->
             uow_factory=uow_factory,
             session_factory=session_factory,
             new_id=lambda: next(ids),
+            readiness=ReadinessProbe(
+                session_factory=session_factory, redis_ping=lambda: None
+            ),
         )
         yield
 

--- a/tests/integration/test_assessment_queue.py
+++ b/tests/integration/test_assessment_queue.py
@@ -35,6 +35,7 @@ from infrastructure.database import (
 )
 from infrastructure.graph.checkpointer import open_claim_checkpointer
 from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.observability.readiness import ReadinessProbe
 from infrastructure.queue.rq_queue import QUEUE_NAME, RqAssessmentQueue
 from infrastructure.queue.worker import stop_retry_on_permanent
 from presentation.app import create_app
@@ -80,6 +81,9 @@ def _lifespan(
             uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
             session_factory=session_factory,
             new_id=lambda: next(ids),
+            readiness=ReadinessProbe(
+                session_factory=session_factory, redis_ping=queue.ping
+            ),
         )
         yield
 

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -1,0 +1,165 @@
+"""Correlation-id propagation from an HTTP request to a graph node log line -- [M5-06].
+
+The M5-06 DoD's propagation test. Real Postgres + the LangGraph Postgres
+checkpointer; only the LLM and retriever are faked
+(``_checkpoint_fakes.build_fake_context``). The submit path here runs the graph
+synchronously inside the request (the ``_InlineQueue``), so a correlation id set
+by the middleware must reach the ``infrastructure.graph.node`` log lines the
+``build._instrumented`` wrapper emits.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+
+from application.use_cases.run_assessment import RunAssessment
+from infrastructure.clock import SystemClock
+from infrastructure.database import (
+    create_engine_from_database_url,
+    create_session_factory,
+    sqlalchemy_unit_of_work_factory,
+)
+from infrastructure.graph.checkpointer import open_claim_checkpointer
+from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.observability.logging import CorrelationIdFilter, JsonFormatter
+from infrastructure.observability.readiness import ReadinessProbe
+from presentation.app import create_app
+from presentation.dependencies import AppComponents
+from tests.integration._checkpoint_fakes import build_fake_context
+
+pytestmark = pytest.mark.integration
+
+
+class _InlineQueue:
+    def __init__(self, run: RunAssessment) -> None:
+        self._run = run
+
+    def enqueue(self, assessment_id: str) -> None:
+        self._run(assessment_id)
+
+
+def _lifespan(database_url: str, session_factory: sessionmaker[Session]) -> object:
+    ids = (f"obs-{n}" for n in itertools.count(1))
+    orchestrator = LangGraphClaimAssessmentOrchestrator(
+        context_factory=lambda _session: build_fake_context(),
+        session_factory=session_factory,
+        database_url=database_url,
+    )
+    uow_factory = sqlalchemy_unit_of_work_factory(session_factory)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.components = AppComponents(
+            clock=SystemClock(),
+            queue=_InlineQueue(
+                RunAssessment(
+                    clock=SystemClock(),
+                    orchestrator=orchestrator,
+                    uow_factory=uow_factory,
+                    is_transient=lambda _exc: False,
+                    max_attempts=1,
+                )
+            ),
+            orchestrator=orchestrator,
+            uow_factory=uow_factory,
+            session_factory=session_factory,
+            new_id=lambda: next(ids),
+            readiness=ReadinessProbe(
+                session_factory=session_factory, redis_ping=lambda: None
+            ),
+        )
+        yield
+
+    return lifespan
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lines: list[dict[str, Any]] = []
+        self.addFilter(CorrelationIdFilter())
+        self.setFormatter(JsonFormatter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(json.loads(self.format(record)))
+
+
+@dataclass
+class Api:
+    client: TestClient
+    node_logs: _CapturingHandler
+
+
+@pytest.fixture
+def api(
+    postgres_database_url: str,
+    migrated_database: None,
+) -> Iterator[Api]:
+    with open_claim_checkpointer(postgres_database_url, setup=True):
+        pass
+    engine = create_engine_from_database_url(postgres_database_url)
+    session_factory = create_session_factory(engine=engine)
+    app = create_app(
+        lifespan=_lifespan(postgres_database_url, session_factory)  # type: ignore[arg-type]
+    )
+
+    handler = _CapturingHandler()
+    node_logger = logging.getLogger("infrastructure.graph.node")
+    node_logger.addHandler(handler)
+    node_logger.setLevel(logging.INFO)
+    # `migrated_database` runs Alembic, whose `env.py` calls `fileConfig(...)` with
+    # the default `disable_existing_loggers=True` -- that flips this logger off in
+    # the shared test process (it never happens in the real API/worker process,
+    # where migrations are a separate command).
+    node_logger.disabled = False
+    try:
+        with TestClient(app) as client:
+            yield Api(client=client, node_logs=handler)
+    finally:
+        node_logger.removeHandler(handler)
+    engine.dispose()
+
+
+def test_correlation_id_reaches_a_node_log_line(api: Api) -> None:
+    response = api.client.post(
+        "/v1/assessments",
+        json={"raw_text": "Bati o carro."},
+        headers={"X-Correlation-ID": "m5-06-itest"},
+    )
+    assert response.status_code == 202, response.text
+    assert response.headers["x-correlation-id"] == "m5-06-itest"
+
+    node_lines = [
+        line
+        for line in api.node_logs.lines
+        if line["message"] in {"node.start", "node.completed"}
+    ]
+    assert node_lines, "the graph run should have emitted node log lines"
+    assert all(line["correlation_id"] == "m5-06-itest" for line in node_lines)
+    assert {"intake", "retrieval", "recommendation"} <= {
+        line["node"] for line in node_lines
+    }
+
+
+def test_generated_correlation_id_is_consistent_across_the_run(api: Api) -> None:
+    response = api.client.post("/v1/assessments", json={"raw_text": "Bati o carro."})
+
+    generated = response.headers["x-correlation-id"]
+    assert generated
+    node_ids = {
+        line["correlation_id"]
+        for line in api.node_logs.lines
+        if line["message"].startswith("node.")
+    }
+    assert node_ids == {generated}

--- a/tests/unit/infrastructure/observability/__init__.py
+++ b/tests/unit/infrastructure/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the [M5-06] observability package."""

--- a/tests/unit/infrastructure/observability/test_correlation.py
+++ b/tests/unit/infrastructure/observability/test_correlation.py
@@ -1,0 +1,32 @@
+"""The correlation-id context variable -- [M5-06]."""
+
+from __future__ import annotations
+
+import pytest
+
+from infrastructure.observability.correlation import (
+    bind_correlation_id,
+    generate_correlation_id,
+    get_correlation_id,
+)
+
+
+@pytest.mark.unit
+def test_unset_by_default() -> None:
+    assert get_correlation_id() is None
+
+
+@pytest.mark.unit
+def test_bind_sets_and_resets() -> None:
+    with bind_correlation_id("abc"):
+        assert get_correlation_id() == "abc"
+        with bind_correlation_id("def"):
+            assert get_correlation_id() == "def"
+        assert get_correlation_id() == "abc"
+    assert get_correlation_id() is None
+
+
+@pytest.mark.unit
+def test_generate_is_non_empty_and_unique() -> None:
+    first, second = generate_correlation_id(), generate_correlation_id()
+    assert first and second and first != second

--- a/tests/unit/infrastructure/observability/test_logging.py
+++ b/tests/unit/infrastructure/observability/test_logging.py
@@ -1,0 +1,111 @@
+"""The JSON log formatter and ``configure_logging`` -- [M5-06]."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+import pytest
+
+from infrastructure.config.settings import ObservabilitySettings
+from infrastructure.observability.correlation import bind_correlation_id
+from infrastructure.observability.logging import (
+    CorrelationIdFilter,
+    JsonFormatter,
+    configure_logging,
+)
+
+
+def _record(**extra: object) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+@pytest.mark.unit
+def test_formatter_emits_the_dod_envelope() -> None:
+    record = _record(correlation_id="c-1")
+    payload = json.loads(JsonFormatter().format(record))
+
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "test.logger"
+    assert payload["message"] == "hello world"
+    assert payload["correlation_id"] == "c-1"
+    assert payload["timestamp"].endswith("+00:00")
+
+
+@pytest.mark.unit
+def test_formatter_passes_extra_fields_through() -> None:
+    record = _record(
+        correlation_id="c-1", path="/ready", method="GET", status=503, duration_ms=1.2
+    )
+    payload = json.loads(JsonFormatter().format(record))
+
+    assert payload["path"] == "/ready"
+    assert payload["method"] == "GET"
+    assert payload["status"] == 503
+    assert payload["duration_ms"] == 1.2
+
+
+@pytest.mark.unit
+def test_formatter_renders_an_exception() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        exc_info = sys.exc_info()
+    record = logging.LogRecord(
+        "l", logging.ERROR, __file__, 1, "failed", None, exc_info
+    )
+    payload = json.loads(JsonFormatter().format(record))
+
+    assert "ValueError: boom" in payload["exception"]
+
+
+@pytest.mark.unit
+def test_filter_fills_correlation_id_from_context() -> None:
+    record = _record()
+    with bind_correlation_id("bound"):
+        CorrelationIdFilter().filter(record)
+    assert getattr(record, "correlation_id", None) == "bound"
+
+
+@pytest.mark.unit
+def test_filter_defaults_to_dash_when_unbound() -> None:
+    record = _record()
+    CorrelationIdFilter().filter(record)
+    assert getattr(record, "correlation_id", None) == "-"
+
+
+@pytest.mark.unit
+def test_configure_logging_is_idempotent() -> None:
+    root = logging.getLogger()
+    original = list(root.handlers)
+    try:
+        configure_logging(ObservabilitySettings(LOG_FORMAT="json", LOG_LEVEL="WARNING"))
+        configure_logging(ObservabilitySettings(LOG_FORMAT="json", LOG_LEVEL="WARNING"))
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0].formatter, JsonFormatter)
+        assert root.level == logging.WARNING
+    finally:
+        root.handlers = original
+
+
+@pytest.mark.unit
+def test_configure_logging_text_format() -> None:
+    root = logging.getLogger()
+    original = list(root.handlers)
+    try:
+        configure_logging(ObservabilitySettings(LOG_FORMAT="text"))
+        assert not isinstance(root.handlers[0].formatter, JsonFormatter)
+    finally:
+        root.handlers = original

--- a/tests/unit/infrastructure/observability/test_readiness.py
+++ b/tests/unit/infrastructure/observability/test_readiness.py
@@ -1,0 +1,101 @@
+"""The ``ReadinessProbe`` dependency checks -- [M5-06]."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from infrastructure.observability import readiness as readiness_module
+from infrastructure.observability.readiness import ReadinessProbe
+
+
+class _FakeSessionFactory:
+    """Enough of a ``sessionmaker`` for the probe: a context manager per call."""
+
+    def __init__(self, *, reachable: bool = True, embedded: int = 5) -> None:
+        self.reachable = reachable
+        self.embedded = embedded
+
+    def __call__(self) -> _FakeSessionFactory:
+        return self
+
+    def __enter__(self) -> _FakeSessionFactory:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def execute(self, *_: Any) -> Any:
+        class _Result:
+            def __init__(self, value: int) -> None:
+                self._value = value
+
+            def scalar_one(self) -> int:
+                return self._value
+
+        return _Result(self.embedded)
+
+
+@pytest.fixture(autouse=True)
+def _stub_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the two real DB helpers the probe calls with fakes."""
+    monkeypatch.setattr(
+        readiness_module,
+        "is_database_reachable",
+        lambda factory: getattr(factory, "reachable", True),
+    )
+    monkeypatch.setattr(
+        readiness_module, "assert_chunk_table_ready", lambda session: None
+    )
+
+
+def _probe(**kwargs: Any) -> ReadinessProbe:
+    defaults: dict[str, Any] = {
+        "session_factory": _FakeSessionFactory(),
+        "redis_ping": lambda: None,
+    }
+    defaults.update(kwargs)
+    return ReadinessProbe(**defaults)
+
+
+@pytest.mark.unit
+def test_all_checks_pass() -> None:
+    results = {r.name: r for r in _probe().check()}
+
+    assert results.keys() == {"postgres", "redis", "vector_index"}
+    assert all(r.ok for r in results.values())
+    assert results["vector_index"].detail == "5 embedded chunks"
+
+
+@pytest.mark.unit
+def test_postgres_down_is_isolated() -> None:
+    results = {
+        r.name: r
+        for r in _probe(session_factory=_FakeSessionFactory(reachable=False)).check()
+    }
+
+    assert results["postgres"].ok is False
+    assert results["redis"].ok is True
+
+
+@pytest.mark.unit
+def test_redis_ping_failure_is_reported() -> None:
+    def _boom() -> None:
+        raise ConnectionError("no route to host")
+
+    results = {r.name: r for r in _probe(redis_ping=_boom).check()}
+
+    assert results["redis"].ok is False
+    assert "ConnectionError" in (results["redis"].detail or "")
+
+
+@pytest.mark.unit
+def test_empty_chunk_table_is_not_ready() -> None:
+    results = {
+        r.name: r
+        for r in _probe(session_factory=_FakeSessionFactory(embedded=0)).check()
+    }
+
+    assert results["vector_index"].ok is False
+    assert "build-index" in (results["vector_index"].detail or "")

--- a/tests/unit/infrastructure/queue/test_rq_queue.py
+++ b/tests/unit/infrastructure/queue/test_rq_queue.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 from rq import Retry
 
+from infrastructure.observability.correlation import bind_correlation_id
 from infrastructure.queue.rq_queue import RqAssessmentQueue
 
 
@@ -38,7 +39,7 @@ def test_enqueue_passes_id_job_id_timeout_and_retry() -> None:
 
     (call,) = fake.calls
     assert call["f"] == "pkg.mod.run"
-    assert call["args"] == ("assess-42",)
+    assert call["args"][0] == "assess-42"
     assert call["kwargs"]["job_id"] == "assess-42"
     assert call["kwargs"]["job_timeout"] == 1800
     retry = call["kwargs"]["retry"]
@@ -54,3 +55,26 @@ def test_no_retry_object_when_only_one_attempt_is_allowed() -> None:
     queue.enqueue("assess-1")
 
     assert fake.calls[0]["kwargs"]["retry"] is None
+
+
+@pytest.mark.unit
+def test_enqueue_carries_the_bound_correlation_id() -> None:
+    queue, fake = _queue()
+
+    with bind_correlation_id("corr-123"):
+        queue.enqueue("assess-42")
+
+    (call,) = fake.calls
+    assert call["args"] == ("assess-42", "corr-123")
+    assert call["kwargs"]["meta"] == {"correlation_id": "corr-123"}
+
+
+@pytest.mark.unit
+def test_enqueue_mints_a_correlation_id_when_none_is_bound() -> None:
+    queue, fake = _queue()
+
+    queue.enqueue("assess-42")
+
+    (call,) = fake.calls
+    minted = call["args"][1]
+    assert minted and call["kwargs"]["meta"] == {"correlation_id": minted}

--- a/tests/unit/presentation/conftest.py
+++ b/tests/unit/presentation/conftest.py
@@ -26,11 +26,13 @@ from application.use_cases.list_assessments import ListAssessments
 from application.use_cases.submit_claim import SubmitClaim
 from application.use_cases.submit_human_decision import SubmitHumanDecision
 from domain.policy_clause import PolicyClause
+from infrastructure.observability.readiness import CheckResult
 from presentation.app import create_app
 from presentation.dependencies import (
     get_get_assessment,
     get_get_audit_trail,
     get_list_assessments,
+    get_readiness_probe,
     get_submit_claim,
     get_submit_human_decision,
 )
@@ -45,6 +47,20 @@ from tests.unit.application.fakes import (
     SequentialIds,
     make_uow_factory,
 )
+
+
+class FakeReadinessProbe:
+    """A ``ReadinessProbe`` stand-in whose check results the test dictates."""
+
+    def __init__(self) -> None:
+        self.results: list[CheckResult] = [
+            CheckResult("postgres", ok=True),
+            CheckResult("redis", ok=True),
+            CheckResult("vector_index", ok=True, detail="12 embedded chunks"),
+        ]
+
+    def check(self) -> list[CheckResult]:
+        return list(self.results)
 
 
 @dataclass
@@ -62,6 +78,7 @@ class Harness:
     orchestrator: FakeClaimAssessmentOrchestrator = field(
         default_factory=FakeClaimAssessmentOrchestrator
     )
+    readiness: FakeReadinessProbe = field(default_factory=FakeReadinessProbe)
 
 
 @pytest.fixture
@@ -108,6 +125,7 @@ def harness() -> Iterator[Harness]:
         jobs=_jobs(),
         audit=InMemoryAuditTrailReader(audit_store),
     )
+    app.dependency_overrides[get_readiness_probe] = lambda: h.readiness
 
     yield h
     app.dependency_overrides.clear()

--- a/tests/unit/presentation/test_observability.py
+++ b/tests/unit/presentation/test_observability.py
@@ -1,0 +1,119 @@
+"""``GET /ready`` and the request-context middleware -- [M5-06].
+
+Driven through the same in-memory ``Harness`` as the other endpoint tests
+(``tests/unit/presentation/conftest.py``); the readiness probe is the
+``FakeReadinessProbe`` whose results the test dictates.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from infrastructure.observability.logging import CorrelationIdFilter, JsonFormatter
+from infrastructure.observability.readiness import CheckResult
+from tests.unit.presentation.conftest import Harness
+
+
+class _CapturingHandler(logging.Handler):
+    """Collects the JSON string every root log line would be written as."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lines: list[dict[str, object]] = []
+        self.addFilter(CorrelationIdFilter())
+        self.setFormatter(JsonFormatter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(json.loads(self.format(record)))
+
+
+@pytest.fixture
+def captured_logs() -> Iterator[_CapturingHandler]:
+    handler = _CapturingHandler()
+    root = logging.getLogger()
+    root.addHandler(handler)
+    previous_level = root.level
+    root.setLevel(logging.INFO)
+    try:
+        yield handler
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+
+# --------------------------------------------------------------------------- #
+# GET /ready
+# --------------------------------------------------------------------------- #
+
+
+def test_ready_returns_200_and_per_check_detail_when_healthy(harness: Harness) -> None:
+    response = harness.client.get("/ready")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert set(body["checks"]) == {"postgres", "redis", "vector_index"}
+    assert body["checks"]["postgres"] == {"status": "ok"}
+    assert body["checks"]["vector_index"]["detail"] == "12 embedded chunks"
+
+
+def test_ready_returns_503_naming_the_degraded_dependency(harness: Harness) -> None:
+    harness.readiness.results = [
+        CheckResult("postgres", ok=True),
+        CheckResult("redis", ok=False, detail="ConnectionError: refused"),
+        CheckResult("vector_index", ok=True),
+    ]
+
+    response = harness.client.get("/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["checks"]["redis"] == {
+        "status": "error",
+        "detail": "ConnectionError: refused",
+    }
+    assert body["checks"]["postgres"] == {"status": "ok"}
+
+
+# --------------------------------------------------------------------------- #
+# Request-context middleware
+# --------------------------------------------------------------------------- #
+
+
+def test_generates_a_correlation_id_when_the_request_has_none(harness: Harness) -> None:
+    response = harness.client.get("/health")
+
+    assert response.headers["x-correlation-id"]
+
+
+def test_echoes_an_inbound_correlation_id(harness: Harness) -> None:
+    response = harness.client.get("/health", headers={"X-Correlation-ID": "req-42"})
+
+    assert response.headers["x-correlation-id"] == "req-42"
+
+
+def test_accepts_x_request_id_as_the_correlation_id(harness: Harness) -> None:
+    response = harness.client.get("/health", headers={"X-Request-ID": "trace-9"})
+
+    assert response.headers["x-correlation-id"] == "trace-9"
+
+
+def test_emits_one_structured_access_line_per_request(
+    harness: Harness, captured_logs: _CapturingHandler
+) -> None:
+    harness.client.get("/health", headers={"X-Correlation-ID": "req-42"})
+
+    access = [line for line in captured_logs.lines if line["message"] == "request"]
+    assert len(access) == 1
+    line = access[0]
+    assert line["path"] == "/health"
+    assert line["method"] == "GET"
+    assert line["status"] == 200
+    assert isinstance(line["duration_ms"], (int, float))
+    assert line["correlation_id"] == "req-42"
+    assert line["timestamp"] and line["level"] == "INFO"


### PR DESCRIPTION
## Summary

Adds the operational baseline for the assessment service.

- **New `infrastructure/observability/` package** (import from submodules —
  `readiness` reaches into `infrastructure.database`):
  - `correlation.py` — `X-Correlation-ID` / `X-Request-ID` header names, a
    `contextvars` variable, `get` / `generate` / `bind_correlation_id`.
  - `logging.py` — hand-rolled `JsonFormatter` (no new dependency) +
    `CorrelationIdFilter` + idempotent `configure_logging()`. One JSON object per
    line to stdout: `timestamp` (ISO-8601 UTC), `level`, `logger`, `message`,
    `correlation_id`, plus any `extra=` fields. `LOG_FORMAT` (`json` default /
    `text`) added to `ObservabilitySettings`, `.env`, `.env.example`.
  - `readiness.py` — `ReadinessProbe` probing Postgres
    (`is_database_reachable`), Redis (`RqAssessmentQueue.ping()`, new) and the
    vector index (`chunk` table migrated **and** carrying embedded rows).
- **`presentation/middleware.py`** — pure-ASGI `RequestContextMiddleware` (not
  `BaseHTTPMiddleware`, for contextvar propagation + real status capture): binds
  the correlation id (accepted or minted), echoes it on the response, emits one
  `presentation.access` line (`path` / `method` / `status` / `duration_ms`).
- **`GET /ready`** in `routes/health.py` — 200 `{"status":"ready","checks":{…}}`
  when every check passes, 503 `"degraded"` naming the failing check and why.
  `/health` stays dependency-free.
- **Correlation id into the graph, no node-file edits** —
  `GraphContext.correlation_id`; `LangGraphClaimAssessmentOrchestrator._invoke`
  mints/binds it and puts it in the graph `config` metadata (LangGraph copies
  that onto every node's child `RunnableConfig`, so LLM calls carry it; M5-07's
  tracing reads it); `build.py` `_instrumented(node)` wraps every `add_node` →
  correlation-tagged `node.start` / `node.completed` / `node.failed` lines with
  `duration_ms`.
- **Async path** — the id rides the RQ job (2nd arg + `meta`) across Redis;
  `run_assessment_job` re-binds it on the worker.

## Related issue

[M5-06]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) —
      `tests/unit/infrastructure/observability/` (correlation, logging,
      readiness), `tests/unit/presentation/test_observability.py` (`/ready` +
      middleware), `test_rq_queue.py` additions, and
      `tests/integration/test_observability.py` (the DoD test: an
      `X-Correlation-ID` on a `POST` reaches the graph node log lines).
- [x] Docs updated — `docs/API.md` (`/health` vs `/ready`, "Structured logging &
      correlation IDs"), `docs/ARCHITECTURE.md` (node instrumentation + M5-06
      downstream). `docs/OBSERVABILITY.md` is left to M5-07, whose DoD creates it.
- [x] Evaluation impact considered — none. No parsing / retrieval / verdict path
      changes; the graph gains only log lines around unchanged nodes.
- [x] `make check` passes locally (ruff, format, `mypy --strict`, 1340 unit
      tests). The M5-06 integration test and the existing `test_assessment_api.py`
      suite pass. The 3 `test_assessment_queue.py` failures are pre-existing on
      the base commit (RQ burst-worker path in this environment), unrelated to
      this change.
