### PR TITLE
feat(observability): trace every node into a self-hosted Langfuse (M5…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,30 @@ NGINX_PORT=8080
 PROXY_HEADERS_ENABLED=true
 FORWARDED_ALLOW_IPS=127.0.0.1,::1
 
-# Langfuse observability
+# Langfuse tracing -- [M5-07]. On only with both keys + TRACING_ENABLED != false.
+# The keys are seeded into the self-hosted server below, so any non-empty pair
+# works on a fresh volume: `docker compose --profile tracing up -d` creates the
+# project with exactly these. See docs/OBSERVABILITY.md.
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
-LANGFUSE_HOST=https://api.langfuse.com
+LANGFUSE_HOST=http://localhost:3000
+TRACING_ENABLED=true
+
+# Self-hosted langfuse service (compose `tracing` profile). Not read by the
+# application -- compose passes these to the langfuse containers, which reuse
+# this stack's postgres (in a database of their own) and redis.
+# Generate the three secrets with `openssl rand -hex 32`.
+LANGFUSE_PORT=3000
+LANGFUSE_DB_NAME=langfuse
+LANGFUSE_NEXTAUTH_SECRET=
+LANGFUSE_SALT=
+LANGFUSE_ENCRYPTION_KEY=
+LANGFUSE_INIT_ORG_ID=
+LANGFUSE_INIT_PROJECT_ID=
+LANGFUSE_INIT_USER_EMAIL=
+LANGFUSE_INIT_USER_PASSWORD=
+LANGFUSE_CLICKHOUSE_PASSWORD=
+LANGFUSE_MINIO_ROOT_PASSWORD=
 
 # LLM and RAG settings
 LLM_PROVIDER=
@@ -48,6 +68,14 @@ LLM_VISION_ALLOW_FALLBACKS=
 # Vision model pricing, USD per 1M tokens (defaults: 0.30 input / 2.50 output).
 LLM_VISION_INPUT_COST_PER_1M_TOKENS_USD=
 LLM_VISION_OUTPUT_COST_PER_1M_TOKENS_USD=
+
+# Fast / reasoning model pricing, USD per 1M tokens -- [M5-07] registers these
+# with Langfuse so a trace can price a generation. Priced for the *pinned*
+# provider route below; re-pin and these go stale. M5-10 owns the measured cost.
+LLM_FAST_INPUT_COST_PER_1M_TOKENS_USD=
+LLM_FAST_OUTPUT_COST_PER_1M_TOKENS_USD=
+LLM_REASONING_INPUT_COST_PER_1M_TOKENS_USD=
+LLM_REASONING_OUTPUT_COST_PER_1M_TOKENS_USD=
 
 # OpenRouter provider pin for the classification model (default: ["baidu/fp8"], no fallback).
 LLM_CLASSIFICATION_PROVIDER_ORDER=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
           - pytest>=9.1.1
           - pypdf>=6.14.2
           - pillow>=12.3.0
-          - langchain-core>=1.5.5
+          - langchain-core>=1.6.0
           - langchain-openai>=1.5.1
           - langchain-anthropic>=0.3
           - langgraph>=1.2
@@ -36,6 +36,10 @@ repos:
           - rq>=2.0
           - redis>=5.0
           - openai>=3.0
+          # [M5-07]: infrastructure/observability/tracing.py imports the
+          # Langfuse client and its LangChain callback handler.
+          - langfuse>=4.15,<5
+          - langchain>=1.4,<2
   - repo: https://github.com/kynan/nbstripout
     rev: 0.9.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ the retry/back-off policy and the dead-letter path are in
 [`docs/ASYNC_PROCESSING.md`](docs/ASYNC_PROCESSING.md). The `api` / `worker`
 Compose services (and their Dockerfile) are [M5-09].
 
+### Tracing (optional)
+
+A run is a tree of nodes, LLM calls and one retrieval step; when a verdict is
+wrong, the question is which of them was. [M5-07] traces that into a
+self-hosted Langfuse, which rides along in the Compose stack behind a profile:
+
+```bash
+# .env: set the three secrets first -- openssl rand -hex 32 each
+#   LANGFUSE_NEXTAUTH_SECRET, LANGFUSE_SALT, LANGFUSE_ENCRYPTION_KEY
+docker compose --profile tracing up -d    # + langfuse-web, langfuse-worker, clickhouse, minio
+open http://localhost:3000                # sign in with LANGFUSE_INIT_USER_*
+```
+
+The project is seeded on first boot with the `LANGFUSE_PUBLIC_KEY` /
+`LANGFUSE_SECRET_KEY` already in your `.env`, so there is no key-copying step.
+Tracing is off unless both keys are set and `TRACING_ENABLED` is not `false`,
+and plain `docker compose up -d` still starts only postgres + redis — the
+service runs identically with none of this. Reading a trace, and a worked
+example of diagnosing a wrong verdict, are in
+[`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
+
 ### Pre-commit hooks
 
 1. Install the dev dependency (skip if already in the lockfile — run `uv sync` instead):

--- a/app/src/infrastructure/bootstrap.py
+++ b/app/src/infrastructure/bootstrap.py
@@ -22,8 +22,10 @@ from infrastructure.config.llm_client_factory import build_chat_model
 from infrastructure.config.settings import (
     DatabaseSettings,
     LlmSettings,
+    ObservabilitySettings,
     get_database_settings,
     get_llm_settings,
+    get_observability_settings,
 )
 from infrastructure.database import (
     create_engine_from_settings,
@@ -33,6 +35,7 @@ from infrastructure.database import (
 from infrastructure.graph.checkpointer import open_claim_checkpointer
 from infrastructure.graph.context import GraphContext
 from infrastructure.graph.orchestrator import LangGraphClaimAssessmentOrchestrator
+from infrastructure.observability.tracing import RunTracer, build_tracer
 from infrastructure.rag.retriever_factory import (
     build_graph_retriever,
     load_retriever_components,
@@ -47,16 +50,19 @@ class CoreComponents:
     session_factory: sessionmaker[Session]
     orchestrator: LangGraphClaimAssessmentOrchestrator
     uow_factory: UnitOfWorkFactory
+    tracer: RunTracer
 
     def dispose(self) -> None:
-        """Release the connection pool -- call on shutdown."""
+        """Release the connection pool and stop the tracer -- call on shutdown."""
         self.engine.dispose()
+        self.tracer.shutdown()
 
 
 def build_core_components(
     *,
     database_settings: DatabaseSettings | None = None,
     llm_settings: LlmSettings | None = None,
+    observability_settings: ObservabilitySettings | None = None,
     probe_checkpointer: bool = True,
 ) -> CoreComponents:
     """Build the DB engine, the chat models, the retriever and the orchestrator.
@@ -64,9 +70,16 @@ def build_core_components(
     ``probe_checkpointer`` opens the LangGraph Postgres checkpointer once so a
     missing schema fails fast with an actionable "run ``make setup-checkpointer``"
     message rather than on the first job.
+
+    The tracer ([M5-07]) is process-wide like the models: one Langfuse client per
+    API or worker process, or the no-op when tracing is not configured. It is
+    built here rather than per run because the SDK batches and exports on a
+    background thread -- one per assessment would be a thread per assessment.
     """
     db = database_settings or get_database_settings()
     llm = llm_settings or get_llm_settings()
+    observability = observability_settings or get_observability_settings()
+    tracer = build_tracer(observability=observability, llm=llm)
 
     engine = create_engine_from_settings(db)
     session_factory = create_session_factory(engine=engine)
@@ -93,15 +106,19 @@ def build_core_components(
         return GraphContext(
             fast_model=fast_model,
             reasoning_model=reasoning_model,
-            retriever=build_graph_retriever(session, retriever_components),
+            retriever=build_graph_retriever(
+                session, retriever_components, tracer=tracer
+            ),
             llm_settings=llm,
             audit_sink=None,
+            tracer=tracer,
         )
 
     orchestrator = LangGraphClaimAssessmentOrchestrator(
         context_factory=context_factory,
         session_factory=session_factory,
         database_url=db.sqlalchemy_database_url,
+        tracer=tracer,
     )
 
     return CoreComponents(
@@ -109,4 +126,5 @@ def build_core_components(
         session_factory=session_factory,
         orchestrator=orchestrator,
         uow_factory=sqlalchemy_unit_of_work_factory(session_factory),
+        tracer=tracer,
     )

--- a/app/src/infrastructure/config/settings.py
+++ b/app/src/infrastructure/config/settings.py
@@ -40,9 +40,29 @@ class ObservabilitySettings(BaseSettings):
     langfuse_secret_key: SecretStr = Field(
         alias="LANGFUSE_SECRET_KEY", default=SecretStr("")
     )
-    langfuse_host: str = Field(
-        alias="LANGFUSE_HOST", default="https://api.langfuse.com"
-    )
+    # [M5-07] the self-hosted Langfuse from the compose `tracing` profile, not
+    # Langfuse Cloud: this project ships the server it traces to, so the default
+    # is the one `docker compose --profile tracing up -d` brings up.
+    langfuse_host: str = Field(alias="LANGFUSE_HOST", default="http://localhost:3000")
+    # [M5-07] the off switch. Separate from the keys so tracing can be disabled
+    # without deleting credentials -- which is what makes "the service runs
+    # without it" testable rather than merely claimed.
+    tracing_enabled: bool = Field(alias="TRACING_ENABLED", default=True)
+
+    @property
+    def tracing_active(self) -> bool:
+        """Whether tracing should actually run: switched on *and* credentialed.
+
+        [M5-07]'s "optional via configuration" line, in one place. Keys without
+        the flag, or the flag without keys, both mean no tracing -- the tracer
+        degrades to a no-op rather than failing to start, so an unconfigured
+        clone runs the whole flow with tracing simply absent.
+        """
+        return (
+            self.tracing_enabled
+            and bool(self.langfuse_public_key)
+            and bool(self.langfuse_secret_key.get_secret_value())
+        )
 
     @property
     def is_development(self) -> bool:
@@ -222,6 +242,28 @@ class LlmSettings(BaseSettings):
     )
     llm_vision_output_cost_per_1m_tokens_usd: float = Field(
         alias="LLM_VISION_OUTPUT_COST_PER_1M_TOKENS_USD", default=2.50
+    )
+
+    # [M5-07] registers these two pairs with Langfuse as model definitions, so
+    # the trace UI can price a generation for a model served under a name
+    # Langfuse has never seen. **Priced for the pinned OpenRouter route, not for
+    # the model in general** -- the same model costs 3x more on some routes than
+    # others, so re-pin `LLM_*_PROVIDER_ORDER` above and these go stale. Read
+    # from OpenRouter's endpoints API on 2026-09-04: the fast model on
+    # `baidu/fp8` and the reasoning model on `streamlake`, the defaults pinned
+    # above. List prices, not a measurement -- [M5-10] owns the measured cost
+    # per assessment.
+    llm_fast_input_cost_per_1m_tokens_usd: float = Field(
+        alias="LLM_FAST_INPUT_COST_PER_1M_TOKENS_USD", default=0.14
+    )
+    llm_fast_output_cost_per_1m_tokens_usd: float = Field(
+        alias="LLM_FAST_OUTPUT_COST_PER_1M_TOKENS_USD", default=0.28
+    )
+    llm_reasoning_input_cost_per_1m_tokens_usd: float = Field(
+        alias="LLM_REASONING_INPUT_COST_PER_1M_TOKENS_USD", default=1.1154
+    )
+    llm_reasoning_output_cost_per_1m_tokens_usd: float = Field(
+        alias="LLM_REASONING_OUTPUT_COST_PER_1M_TOKENS_USD", default=3.3462
     )
 
     # Pinned per M1-08b: baidu/fp8 is the required OpenRouter route for

--- a/app/src/infrastructure/graph/context.py
+++ b/app/src/infrastructure/graph/context.py
@@ -9,7 +9,8 @@ config -- a node holds no module-level client and takes no constructor. See
 ``docs/ARCHITECTURE.md`` ([M4-01b]).
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
@@ -76,6 +77,67 @@ class AuditTrailSink(Protocol):
         ...
 
 
+class TracePort(Protocol):
+    """Somewhere to open one span of a run, owned by the graph layer -- [M5-07].
+
+    Most of the trace costs a node nothing: the Langfuse callback handler the
+    orchestrator installs on the graph config already opens a span per node and
+    a generation per LLM call. This port exists for the one thing callbacks
+    cannot see -- work a node does *between* those calls, where the interesting
+    numbers are locals. The retrieval node ([M4-04]) is the case that motivates
+    it: its candidates, their scores and the [M3-07] gate's reasoning never
+    appear in an LLM call and mostly never reach state either.
+
+    Deliberately dumb. It deals in plain mappings, not domain objects, so the
+    graph layer grows no tracing vocabulary and a test fake is a handful of
+    lines. It is a context manager rather than a "record this finished span"
+    call because the span's latency should be measured, not reported: the
+    yielded mapping is the span's output, filled in by the body.
+
+        with runtime.context.tracer.span("retrieval", input={...}) as traced:
+            hits = ...
+            traced["n_returned"] = len(hits)
+
+    [infrastructure.observability.tracing.LangfuseTracer] is the
+    implementation; it satisfies this structurally, exactly as ``RetrievalPort``
+    and ``AuditTrailSink`` are satisfied.
+
+    An implementation **must not raise**: a run is not allowed to fail because
+    its observability did.
+    """
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Open a span named ``name``; fill the yielded mapping to set its output."""
+        ...
+
+
+class _NoTracing:
+    """The do-nothing ``TracePort``: what a node gets when tracing is off."""
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Yield a throwaway mapping and record nothing."""
+        return nullcontext({})
+
+
+# A null object rather than the ``| None`` shape ``audit_sink`` uses below. The
+# audit sink is consulted once, at the checkpoint; a tracer wraps work inside a
+# node body, and a null object keeps that body free of `if tracer is not None`
+# noise for a call whose whole point is that it changes nothing.
+NO_TRACING: TracePort = _NoTracing()
+
+
 @dataclass(frozen=True)
 class GraphContext:
     """Run-scoped dependencies for the agent graph -- [M4-01b].
@@ -104,3 +166,8 @@ class GraphContext:
     # the graph `config` metadata so LLM calls inherit it. Defaulted so a test
     # or eval `GraphContext(...)` needs nothing.
     correlation_id: str = ""
+    # [M5-07]. Where a node records a span the callback-handler trace cannot see
+    # -- see ``TracePort``. Defaults to the no-op, so every test, eval script and
+    # unconfigured deployment builds a ``GraphContext`` exactly as before and the
+    # nodes take the same path either way.
+    tracer: TracePort = NO_TRACING

--- a/app/src/infrastructure/graph/nodes/retrieval.py
+++ b/app/src/infrastructure/graph/nodes/retrieval.py
@@ -21,6 +21,15 @@ What it does:
 - assembles the [infrastructure.rag.insufficient_context_gate.GateSignals] and
   runs [evaluate_gate] to set ``context_sufficient``. The router
   ``route_after_retrieval`` in ``build.py`` acts on that flag.
+
+[M5-07] wraps that in one explicit span. Retrieval is the only node the trace's
+callback handler sees as a black box, because it makes no LLM call: what it
+retrieved, at what scores, under which filter, and why the gate decided as it
+did are all locals here, and most of them never reach state. They are the first
+thing you want when a verdict is wrong, so the span records them -- including
+the three ``InsufficientContextResult`` fields (``threshold``,
+``missing_category``, ``closest_clause_ids``) that are computed on every run and
+otherwise thrown away.
 """
 
 from __future__ import annotations
@@ -54,31 +63,69 @@ def retrieval(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, ob
     query = _build_query(entities, fallback=state["raw_claim_text"])
     metadata_filter = _build_filter(entities)
 
-    hits = context.retriever.retrieve(
-        query, k=RETRIEVAL_K, metadata_filter=metadata_filter
-    )
-
-    citations = [
-        Citation(
-            clause_id=hit.clause_id,
-            document_id=hit.document_id,
-            susep_process=hit.susep_process,
-            clause_type=hit.clause_type,
-            relevance_score=max(hit.score, 0.0),
-            excerpt=hit.excerpt,
+    with context.tracer.span(
+        "retrieval",
+        input={
+            "query": query,
+            "k": RETRIEVAL_K,
+            "filter": _filter_payload(metadata_filter),
+        },
+    ) as traced:
+        hits = context.retriever.retrieve(
+            query, k=RETRIEVAL_K, metadata_filter=metadata_filter
         )
-        for hit in hits
-    ]
 
-    signals = GateSignals(
-        top_score=hits[0].score if hits else 0.0,
-        reranked_scores=tuple(hit.score for hit in hits),
-        retrieved_clause_ids=tuple(hit.clause_id for hit in hits),
-        retrieved_clause_types=tuple(hit.clause_type for hit in hits),
-        k_requested=RETRIEVAL_K,
-        n_returned=len(hits),
-    )
-    gate = evaluate_gate(query, signals)
+        citations = [
+            Citation(
+                clause_id=hit.clause_id,
+                document_id=hit.document_id,
+                susep_process=hit.susep_process,
+                clause_type=hit.clause_type,
+                relevance_score=max(hit.score, 0.0),
+                excerpt=hit.excerpt,
+            )
+            for hit in hits
+        ]
+
+        signals = GateSignals(
+            top_score=hits[0].score if hits else 0.0,
+            reranked_scores=tuple(hit.score for hit in hits),
+            retrieved_clause_ids=tuple(hit.clause_id for hit in hits),
+            retrieved_clause_types=tuple(hit.clause_type for hit in hits),
+            k_requested=RETRIEVAL_K,
+            n_returned=len(hits),
+        )
+        gate = evaluate_gate(query, signals)
+
+        traced.update(
+            {
+                "n_returned": len(hits),
+                # Ranked, scored, and named -- the span's reason to exist. Read
+                # top to bottom this is what the assessment nodes will see.
+                "candidates": [
+                    {
+                        "rank": rank,
+                        "clause_id": hit.clause_id,
+                        "document_id": hit.document_id,
+                        "susep_process": hit.susep_process,
+                        "clause_type": hit.clause_type.value,
+                        "score": hit.score,
+                    }
+                    for rank, hit in enumerate(hits, start=1)
+                ],
+                "gate": {
+                    "sufficient": gate.sufficient,
+                    "trigger": gate.trigger.value or None,
+                    "top_score": gate.top_score,
+                    "threshold": gate.threshold,
+                    "missing_category": gate.missing_category.value
+                    if gate.missing_category is not None
+                    else None,
+                    "closest_clause_ids": list(gate.closest_clause_ids),
+                    "explanation": gate.explanation,
+                },
+            }
+        )
 
     audit_event = AuditEvent(
         node="retrieval",
@@ -93,6 +140,16 @@ def retrieval(state: ClaimState, runtime: Runtime[GraphContext]) -> dict[str, ob
         "citations": citations,
         "context_sufficient": gate.sufficient,
         "audit_trail": [audit_event],
+    }
+
+
+def _filter_payload(metadata_filter: RetrievalFilter | None) -> dict[str, str | None]:
+    """The metadata pre-filter as trace-friendly fields, or ``None`` for unfiltered."""
+    if metadata_filter is None:
+        return {"susep_process": None, "product_line": None}
+    return {
+        "susep_process": metadata_filter.susep_process,
+        "product_line": metadata_filter.product_line,
     }
 
 

--- a/app/src/infrastructure/graph/orchestrator.py
+++ b/app/src/infrastructure/graph/orchestrator.py
@@ -20,6 +20,12 @@ Design notes:
   ``_CapturingAuditSink`` so the ``human_review`` node's trail comes back in the
   ``OrchestratorResult`` and ``SubmitHumanDecision`` writes it in the same
   transaction as the settled record (``docs/ARCHITECTURE.md``, the [M5-04] fold).
+- **Tracing hangs off this one method** ([M5-07]). ``_invoke`` is the only place
+  the whole graph run passes through, so installing the Langfuse callback
+  handler on ``config["callbacks"]`` here is what makes every node and every LLM
+  call appear in a trace -- ``build.py`` and the nodes are untouched. It also
+  makes the flush point obvious: one per invocation, covering the worker, the
+  synchronous ``resume`` the API serves, and the eval scripts alike.
 - **The contract checks belong to the use case.** ``start`` not pausing / ``resume``
   not finishing is surfaced by the use case as ``OrchestratorContractError``
   (per the port docstring); this adapter just reports ``awaiting_review`` as it
@@ -49,6 +55,7 @@ from infrastructure.observability.correlation import (
     generate_correlation_id,
     get_correlation_id,
 )
+from infrastructure.observability.tracing import NO_TRACING, RunTracer
 
 _GraphFactory = Callable[
     [], StateGraph[ClaimState, GraphContext, ClaimState, ClaimState]
@@ -92,18 +99,22 @@ class LangGraphClaimAssessmentOrchestrator:
         session_factory: sessionmaker[Session],
         database_url: str | None = None,
         graph_builder: _GraphFactory = build_claim_graph,
+        tracer: RunTracer = NO_TRACING,
     ) -> None:
         """Wire the adapter to its per-run dependencies.
 
         ``context_factory`` builds a ``GraphContext`` on a fresh session (models
         and retriever components are singletons the composition root closes over);
         ``database_url`` is passed to ``open_claim_checkpointer`` -- ``None`` uses
-        the service database the rest of the app reads.
+        the service database the rest of the app reads. ``tracer`` defaults to the
+        no-op ([M5-07]), so a test or an eval script constructs an untraced
+        orchestrator by saying nothing.
         """
         self._context_factory = context_factory
         self._session_factory = session_factory
         self._database_url = database_url
         self._graph_builder = graph_builder
+        self._tracer = tracer
 
     def start(self, *, assessment_id: str, claim: Claim) -> OrchestratorResult:
         """Assess ``claim`` from scratch, up to the human checkpoint."""
@@ -148,13 +159,22 @@ class LangGraphClaimAssessmentOrchestrator:
             },
             # LangGraph copies `metadata` onto every node's child RunnableConfig,
             # so the bare `chain.invoke(messages)` LLM calls in the nodes carry
-            # the correlation id without a per-node change ([M5-06]; M5-07's
-            # tracer reads it).
+            # the correlation id without a per-node change ([M5-06]), and the
+            # [M5-07] callback handler below reads it off the same place.
             "metadata": {"correlation_id": correlation_id},
+            # [M5-07]. Empty when tracing is off, which is exactly what LangGraph
+            # does with no callbacks at all. The nodes pass no `config` to their
+            # own `chain.invoke(messages)`, relying on LangChain's ambient child
+            # config -- which is why the handler has to be attached here, on the
+            # run, and not to the model objects.
+            "callbacks": self._tracer.callbacks(),
         }
         sink = _CapturingAuditSink()
         with (
             bind_correlation_id(correlation_id),
+            self._tracer.assessment_run(
+                assessment_id=assessment_id, correlation_id=correlation_id
+            ),
             self._session_factory() as session,
             open_claim_checkpointer(self._database_url) as checkpointer,
         ):
@@ -163,6 +183,7 @@ class LangGraphClaimAssessmentOrchestrator:
                 self._context_factory(session),
                 audit_sink=sink,
                 correlation_id=correlation_id,
+                tracer=self._tracer,
             )
             final_state = compiled.invoke(graph_input, config=config, context=context)
         return cast("dict[str, Any]", final_state), sink

--- a/app/src/infrastructure/observability/tracing.py
+++ b/app/src/infrastructure/observability/tracing.py
@@ -1,0 +1,471 @@
+"""Langfuse tracing for the assessment graph -- [M5-07].
+
+[M5-06] made a run *loggable*: JSON lines, one correlation id from the HTTP
+request through the queue into every node. Logs answer what happened. They do
+not answer which node was wrong, because the thing you need then is the node's
+input beside its output beside the clauses it was reasoning over, and that is a
+tree, not a sequence of lines.
+
+The whole design is one sentence: **one Langfuse client, installed as a LangChain
+callback handler on the graph config**. LangGraph nodes and the
+``chain.invoke(messages)`` calls inside them are LangChain runnables, so a
+handler on the run's config sees every one of them and produces a span per node
+and a generation per LLM call -- with the prompt, the completion, the model and
+the token usage -- for no change to ``build.py``, to any node, or to the
+``(state, runtime) -> dict`` convention its AST test enforces. Two things the
+callbacks cannot see are added by hand:
+
+- **the retrieval span**, because retrieval makes no LLM call: the node opens it
+  through [infrastructure.graph.context.TracePort], whose default is a no-op;
+- **cost**, because Langfuse prices a generation from a model definition, and it
+  has never heard of an OpenRouter model id. ``register_model_prices`` upserts
+  one definition per model from the configured per-1M-token prices.
+
+Everything here is off unless ``ObservabilitySettings.tracing_active`` -- the
+flag *and* both keys. Off, ``build_tracer`` returns [NullTracer] and no Langfuse
+object is ever constructed. On, every call into the SDK is wrapped: a run must
+not fail because its observability did, so the guards below log and carry on
+rather than raising into a claim assessment.
+
+Import this module directly (``from infrastructure.observability.tracing import
+...``); the package ``__init__`` deliberately re-exports nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator, Mapping, MutableMapping
+from contextlib import (
+    AbstractContextManager,
+    ExitStack,
+    contextmanager,
+    nullcontext,
+    suppress,
+)
+from typing import TYPE_CHECKING, Protocol
+
+from langfuse import Langfuse, propagate_attributes
+from langfuse.api.commons.types.pricing_tier_input import PricingTierInput
+from langfuse.langchain import CallbackHandler
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks.base import BaseCallbackHandler
+    from opentelemetry.sdk.trace.export import SpanExporter
+
+    from infrastructure.config.settings import LlmSettings, ObservabilitySettings
+
+logger = logging.getLogger("infrastructure.observability.tracing")
+
+# The name every assessment trace carries, so the Langfuse trace list is a list
+# of assessments rather than a list of whatever LangGraph called its root run.
+TRACE_NAME = "claim-assessment"
+
+# Langfuse prices a generation per *unit*; the settings are per 1M tokens.
+_TOKENS_PER_PRICE_UNIT = 1_000_000
+
+# The model-definitions endpoint's page size cap.
+_MODEL_PAGE_SIZE = 100
+
+# Stand-in trace id used once, at startup, to learn the shape of a trace URL --
+# see `_resolve_trace_url_template`.
+_TRACE_ID_PLACEHOLDER = "0" * 32
+
+
+class RunTracer(Protocol):
+    """One assessment run's tracing, as the orchestrator and nodes need it.
+
+    Two audiences in one object because they are one decision: ``callbacks`` and
+    ``assessment_run`` are the orchestrator's (install the handler, open the
+    root span, flush), ``span`` is [infrastructure.graph.context.TracePort],
+    which is what a node sees. [NullTracer] and [LangfuseTracer] both satisfy
+    it, and the orchestrator's default is the null one -- so every existing
+    test and eval script builds an untraced orchestrator by doing nothing.
+    """
+
+    def callbacks(self) -> list[BaseCallbackHandler]:
+        """Handlers to put on the graph's ``config["callbacks"]``."""
+        ...
+
+    def assessment_run(
+        self, *, assessment_id: str, correlation_id: str
+    ) -> AbstractContextManager[None]:
+        """Wrap one graph invocation: root span, trace attributes, flush."""
+        ...
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Open a child span; fill the yielded mapping to set its output."""
+        ...
+
+    def shutdown(self) -> None:
+        """Flush and stop the exporter. Called once, on process shutdown."""
+        ...
+
+
+class NullTracer:
+    """Tracing switched off: every method is a no-op that allocates nothing.
+
+    Not an error path. An unconfigured clone, a unit test and a deployment with
+    ``TRACING_ENABLED=false`` all run the identical code path through the graph;
+    the only difference is that these calls do nothing.
+    """
+
+    def callbacks(self) -> list[BaseCallbackHandler]:
+        """No handlers, so LangGraph's config carries no callbacks at all."""
+        return []
+
+    def assessment_run(
+        self, *, assessment_id: str, correlation_id: str
+    ) -> AbstractContextManager[None]:
+        """Run the assessment untraced."""
+        return nullcontext()
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Yield a throwaway mapping and record nothing."""
+        return nullcontext({})
+
+    def shutdown(self) -> None:
+        """Nothing to flush."""
+
+
+class LangfuseTracer:
+    """The real tracer: a Langfuse client plus its LangChain callback handler.
+
+    Holds the client rather than reaching for ``langfuse.get_client()`` so the
+    composition root stays the only place that decides tracing exists, and a
+    test can hand in a client exporting to memory.
+    """
+
+    def __init__(
+        self,
+        client: Langfuse,
+        *,
+        public_key: str,
+        trace_url_template: str | None = None,
+    ) -> None:
+        """Wrap ``client``; ``public_key`` is how a handler finds it again.
+
+        ``trace_url_template`` is resolved once at startup by ``build_tracer``
+        rather than per run, because the SDK's ``get_trace_url`` fetches the
+        project id over HTTP: on the per-assessment path that is a blocking
+        round trip, and a round trip that *fails slowly* whenever Langfuse is
+        down -- the one moment tracing must cost nothing.
+        """
+        self._client = client
+        self._public_key = public_key
+        self._trace_url_template = trace_url_template
+
+    def callbacks(self) -> list[BaseCallbackHandler]:
+        """A handler for this run.
+
+        Built per run rather than once and shared: the handler keeps a map of
+        in-flight LangChain runs, and the API process can assess two claims
+        concurrently. A fresh one costs an object allocation and removes the
+        question entirely.
+        """
+        try:
+            return [CallbackHandler(public_key=self._public_key)]
+        except Exception:  # noqa: BLE001 - tracing never breaks a run
+            logger.warning("tracing.handler_failed", exc_info=True)
+            return []
+
+    @contextmanager
+    def assessment_run(
+        self, *, assessment_id: str, correlation_id: str
+    ) -> Iterator[None]:
+        """Open the root span for one graph invocation and flush on the way out.
+
+        The root span is ours rather than whichever runnable the callback
+        handler happens to see first, which is what makes the trace id knowable
+        *before* the run: it goes straight into a log line, so a correlation id
+        in the logs leads to a trace in one hop. The correlation id also lands on
+        the trace itself, as a tag and in the metadata, so the hop works the
+        other way and in the search box.
+
+        ``session_id`` is the assessment id, so the two halves of a paused
+        assessment -- the run up to the human checkpoint and the run resumed
+        after the decision -- group as one session in the UI.
+        """
+        stack = ExitStack()
+        try:
+            stack.enter_context(
+                propagate_attributes(
+                    session_id=assessment_id,
+                    tags=[correlation_id],
+                    metadata={
+                        "correlation_id": correlation_id,
+                        "assessment_id": assessment_id,
+                    },
+                    trace_name=TRACE_NAME,
+                )
+            )
+            stack.enter_context(
+                self._client.start_as_current_observation(
+                    name=TRACE_NAME,
+                    as_type="span",
+                    input={
+                        "assessment_id": assessment_id,
+                        "correlation_id": correlation_id,
+                    },
+                )
+            )
+            trace_id = self._client.get_current_trace_id()
+            logger.info(
+                "trace.started",
+                extra={
+                    "trace_id": trace_id,
+                    "trace_url": self._trace_url(trace_id),
+                    "assessment_id": assessment_id,
+                },
+            )
+        except Exception:  # noqa: BLE001 - tracing never breaks a run
+            logger.warning("tracing.run_start_failed", exc_info=True)
+
+        try:
+            yield
+        except Exception as exc:
+            # Mark the root span before unwinding, so a failed run is red in the
+            # UI instead of merely short.
+            with suppress(Exception):
+                self._client.update_current_span(
+                    level="ERROR", status_message=f"{type(exc).__name__}: {exc}"
+                )
+            raise
+        finally:
+            with suppress(Exception):
+                stack.close()
+            # Per run, not per process: the worker is long-lived and a trace
+            # nobody can read until the process exits is not an observability
+            # tool. `flush` is a batched HTTP POST, not a per-span round trip.
+            with suppress(Exception):
+                self._client.flush()
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[MutableMapping[str, object]]:
+        """Open a child of the current span; the yielded mapping becomes its output."""
+        output: MutableMapping[str, object] = {}
+        stack = ExitStack()
+        observation = None
+        try:
+            observation = stack.enter_context(
+                self._client.start_as_current_observation(
+                    name=name,
+                    as_type="span",
+                    input=dict(input),
+                    metadata=dict(metadata) if metadata is not None else None,
+                )
+            )
+        except Exception:  # noqa: BLE001 - tracing never breaks a node
+            logger.warning("tracing.span_failed", extra={"span": name}, exc_info=True)
+
+        try:
+            yield output
+        finally:
+            if observation is not None:
+                with suppress(Exception):
+                    observation.update(output=dict(output))
+            with suppress(Exception):
+                stack.close()
+
+    def _trace_url(self, trace_id: str | None) -> str | None:
+        """This run's trace URL, formatted locally from the startup template."""
+        if trace_id is None or self._trace_url_template is None:
+            return None
+        return self._trace_url_template.replace(_TRACE_ID_PLACEHOLDER, trace_id)
+
+    def shutdown(self) -> None:
+        """Flush anything pending and stop the exporter."""
+        with suppress(Exception):
+            self._client.shutdown()
+
+
+NO_TRACING: RunTracer = NullTracer()
+
+
+def build_tracer(
+    *,
+    observability: ObservabilitySettings,
+    llm: LlmSettings,
+    span_exporter: SpanExporter | None = None,
+) -> RunTracer:
+    """Build the tracer this process should use, or the no-op one.
+
+    ``span_exporter`` is the seam the unit tests use: an in-memory exporter
+    gives a real Langfuse client, real spans and no server. Production passes
+    nothing and the SDK exports over OTLP to ``langfuse_host``.
+    """
+    if not observability.tracing_active:
+        logger.info(
+            "tracing.disabled",
+            extra={
+                "tracing_enabled": observability.tracing_enabled,
+                "has_credentials": bool(observability.langfuse_public_key),
+            },
+        )
+        return NO_TRACING
+
+    try:
+        client = Langfuse(
+            public_key=observability.langfuse_public_key,
+            secret_key=observability.langfuse_secret_key.get_secret_value(),
+            base_url=observability.langfuse_host,
+            environment=observability.app_env,
+            span_exporter=span_exporter,
+        )
+    except Exception:  # noqa: BLE001 - an unreachable tracer is not an outage
+        logger.warning("tracing.client_failed", exc_info=True)
+        return NO_TRACING
+
+    register_model_prices(client, llm)
+    logger.info("tracing.enabled", extra={"langfuse_host": observability.langfuse_host})
+    return LangfuseTracer(
+        client,
+        public_key=observability.langfuse_public_key,
+        trace_url_template=_resolve_trace_url_template(client),
+    )
+
+
+def _resolve_trace_url_template(client: Langfuse) -> str | None:
+    """Learn the trace-URL shape once, so every run can format one for free.
+
+    Asked of the SDK with a placeholder id rather than assembled here, so the
+    URL layout stays Langfuse's business and a self-hosted instance behind a
+    path prefix still produces links that work.
+    """
+    try:
+        url = client.get_trace_url(trace_id=_TRACE_ID_PLACEHOLDER)
+    except Exception:  # noqa: BLE001 - a missing link is not a failure
+        logger.warning("tracing.trace_url_failed", exc_info=True)
+        return None
+    return url if url and _TRACE_ID_PLACEHOLDER in url else None
+
+
+def model_price_definitions(llm: LlmSettings) -> list[tuple[str, float, float]]:
+    """``(model name, USD per input token, USD per output token)`` for both models.
+
+    Split out from the upsert so the arithmetic -- the only part that can be
+    wrong without a server to tell you -- is directly testable.
+    """
+    return [
+        (
+            llm.llm_model_fast,
+            llm.llm_fast_input_cost_per_1m_tokens_usd / _TOKENS_PER_PRICE_UNIT,
+            llm.llm_fast_output_cost_per_1m_tokens_usd / _TOKENS_PER_PRICE_UNIT,
+        ),
+        (
+            llm.llm_model_reasoning,
+            llm.llm_reasoning_input_cost_per_1m_tokens_usd / _TOKENS_PER_PRICE_UNIT,
+            llm.llm_reasoning_output_cost_per_1m_tokens_usd / _TOKENS_PER_PRICE_UNIT,
+        ),
+    ]
+
+
+def register_model_prices(client: Langfuse, llm: LlmSettings) -> None:
+    """Teach Langfuse what this project's models cost, so a trace shows a number.
+
+    Langfuse prices a generation by matching the model name the callback handler
+    reported against the model definitions in the project. It ships definitions
+    for the well-known hosted models and knows nothing about an OpenRouter id
+    like ``deepseek/deepseek-v4-flash-0731``, so without this every generation
+    costs 0.00 and the DoD's "cost" is a blank column.
+
+    Runs on every process start, so it has to be idempotent. Upserting on a
+    deterministic id is not enough on its own: the model *name* is unique per
+    project, so once a definition exists under some other id -- Langfuse assigns
+    its own when it creates one -- a second upsert under ours is rejected with
+    "already exists in project". So look the name up first and update whatever
+    id it actually has, which also means a changed price in ``.env`` corrects the
+    definition instead of being quietly ignored.
+
+    Best effort throughout: a project that cannot be reached still traces, it
+    just does not price.
+    """
+    definitions = [
+        definition for definition in model_price_definitions(llm) if definition[0]
+    ]
+    if not definitions:
+        return
+    existing = _existing_model_ids(client, {name for name, _, _ in definitions})
+    for model_name, input_price, output_price in definitions:
+        try:
+            client.api.models.upsert(
+                existing.get(model_name, _model_definition_id(model_name)),
+                model_name=model_name,
+                # Anchored and escaped: the model id contains `/` and `-`, and a
+                # loose pattern would silently price a different model.
+                match_pattern=f"(?i)^{re.escape(model_name)}$",
+                unit="TOKENS",
+                # A pricing tier rather than the flat `input_price`/`output_price`
+                # pair, which the API accepts only one of. The flat pair prices
+                # the `input` and `output` usage keys and nothing else, and a
+                # reasoning model reports its thinking under a third key,
+                # `output_reasoning` -- 3725 of one measured compatibility call's
+                # 4000 completion tokens. Providers bill those at the completion
+                # rate, so pricing only input/output understates a reasoning
+                # call's cost several-fold. See docs/OBSERVABILITY.md.
+                pricing_tiers=[
+                    PricingTierInput(
+                        name="Standard",
+                        is_default=True,
+                        priority=0,
+                        conditions=[],
+                        prices={
+                            "input": input_price,
+                            "output": output_price,
+                            "output_reasoning": output_price,
+                        },
+                    )
+                ],
+            )
+        except Exception:  # noqa: BLE001 - pricing is a nicety, not a dependency
+            logger.warning(
+                "tracing.model_price_failed",
+                extra={"model": model_name},
+                exc_info=True,
+            )
+
+
+def _existing_model_ids(client: Langfuse, wanted: set[str]) -> dict[str, str]:
+    """``model name -> definition id`` for the wanted names already in the project.
+
+    Paged, because a fresh project already holds ~180 built-in definitions and
+    the endpoint returns 50 at a time -- a first-page-only lookup would miss an
+    existing definition and turn every restart into a failed upsert.
+    """
+    found: dict[str, str] = {}
+    page = 1
+    try:
+        while wanted - found.keys():
+            response = client.api.models.list(page=page, limit=_MODEL_PAGE_SIZE)
+            for model in response.data:
+                if model.model_name in wanted:
+                    found[model.model_name] = model.id
+            if page >= response.meta.total_pages:
+                break
+            page += 1
+    except Exception:  # noqa: BLE001 - fall back to creating under our own id
+        logger.warning("tracing.model_list_failed", exc_info=True)
+    return found
+
+
+def _model_definition_id(model_name: str) -> str:
+    """A stable Langfuse model-definition id for ``model_name``."""
+    return "claims-" + re.sub(r"[^a-z0-9]+", "-", model_name.lower()).strip("-")

--- a/app/src/infrastructure/rag/graph_retrieval_adapter.py
+++ b/app/src/infrastructure/rag/graph_retrieval_adapter.py
@@ -22,11 +22,21 @@ Flow, per ``retrieve`` call:
 
 Needs a live [infrastructure.rag.hybrid_retriever.HybridRetriever] (Postgres +
 the ``embed`` group's models); a unit test drives it with fakes.
+
+[M5-07] records steps 1-4 as a ``retrieval.rerank`` span. The retrieval node's
+own span shows the ranking the assessment nodes then reason over; this one shows
+how it was arrived at -- each candidate's hybrid rank beside its cross-encoder
+rank and score, plus anything co-retrieval injected. ``RERANK_CANDIDATE_DEPTH``
+is 10, the same as the node's ``k``, so the reranker re-orders rather than
+prunes: the question this span answers is not "what was dropped" but "did the
+hybrid legs surface the right clause at all, and where did the cross-encoder
+move it" -- two different bugs with two different fixes.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -129,6 +139,43 @@ def build_clause_index(chunks: Sequence[_ChunkRow]) -> dict[str, IndexedClause]:
     return index
 
 
+class SpanRecorder(Protocol):
+    """A ``span`` context manager -- structurally the graph's ``TracePort``.
+
+    Re-declared rather than imported for the same reason ``_FilterableBase``
+    above is: ``infrastructure.rag`` does not depend on
+    ``infrastructure.graph``, and this module is not going to be the first to
+    reverse that.
+    """
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Open a span; fill the yielded mapping to set its output."""
+        ...
+
+
+class _NoSpans:
+    """The no-op recorder this adapter uses unless the composition root traces."""
+
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> AbstractContextManager[MutableMapping[str, object]]:
+        """Yield a throwaway mapping and record nothing."""
+        return nullcontext({})
+
+
+_NO_SPANS: SpanRecorder = _NoSpans()
+
+
 class _FixedRanking:
     """A one-shot base that hands ``ExclusionCoRetrievalRetriever`` a set ranking."""
 
@@ -157,12 +204,14 @@ class GraphRetrievalAdapter:
         candidate_depth: int = RERANK_CANDIDATE_DEPTH,
         co_retrieval: ClauseGraph | None = None,
         reserved_exclusion_slots: int = RESERVED_EXCLUSION_SLOTS,
+        tracer: SpanRecorder | None = None,
     ) -> None:
         """Compose the hybrid retriever, the reranker and the clause index.
 
         ``co_retrieval`` set turns on [M3-06] exclusion co-retrieval over the
         reranked ranking. A candidate missing from ``clause_index`` is scored as
-        the empty string (it sinks) and hydrated as a bare id.
+        the empty string (it sinks) and hydrated as a bare id. ``tracer``
+        defaults to the no-op ([M5-07]).
         """
         self._hybrid = hybrid
         self._reranker = reranker
@@ -170,6 +219,7 @@ class GraphRetrievalAdapter:
         self._candidate_depth = candidate_depth
         self._co_retrieval = co_retrieval
         self._reserved_exclusion_slots = reserved_exclusion_slots
+        self._tracer = tracer if tracer is not None else _NO_SPANS
 
     def retrieve(
         self,
@@ -181,35 +231,66 @@ class GraphRetrievalAdapter:
         """Up to ``k`` clauses (more only when co-retrieval injects), best first."""
         if k <= 0:
             return []
-        candidates = self._hybrid.retrieve(
-            question, k=self._candidate_depth, metadata_filter=metadata_filter
-        )
-        if not candidates:
-            return []
+        with self._tracer.span(
+            "retrieval.rerank",
+            input={"k": k, "candidate_depth": self._candidate_depth},
+        ) as traced:
+            candidates = self._hybrid.retrieve(
+                question, k=self._candidate_depth, metadata_filter=metadata_filter
+            )
+            traced["n_hybrid_candidates"] = len(candidates)
+            if not candidates:
+                return []
 
-        passages = [
-            self._clause_index[cid].embed_text if cid in self._clause_index else ""
-            for cid in candidates
-        ]
-        scores = self._reranker.rerank(question, passages)
-        order = sorted(range(len(candidates)), key=lambda i: scores[i], reverse=True)
-        ranked = [(candidates[i], float(scores[i])) for i in order]
-        top = ranked[:k]
+            passages = [
+                self._clause_index[cid].embed_text if cid in self._clause_index else ""
+                for cid in candidates
+            ]
+            scores = self._reranker.rerank(question, passages)
+            order = sorted(
+                range(len(candidates)), key=lambda i: scores[i], reverse=True
+            )
+            ranked = [(candidates[i], float(scores[i])) for i in order]
+            top = ranked[:k]
 
-        score_by_id = dict(ranked)
-        final_ids = [cid for cid, _ in top]
-        if self._co_retrieval is not None:
-            final_ids = _ExclusionCoRetrieval(
-                _FixedRanking(final_ids),
-                self._co_retrieval,
-                reserved_slots=self._reserved_exclusion_slots,
-            ).retrieve(question, k=k, metadata_filter=metadata_filter)
+            score_by_id = dict(ranked)
+            final_ids = [cid for cid, _ in top]
+            if self._co_retrieval is not None:
+                final_ids = _ExclusionCoRetrieval(
+                    _FixedRanking(final_ids),
+                    self._co_retrieval,
+                    reserved_slots=self._reserved_exclusion_slots,
+                ).retrieve(question, k=k, metadata_filter=metadata_filter)
 
-        return [
-            self._hydrate(cid, score_by_id.get(cid, _INJECTED_CLAUSE_SCORE))
-            for cid in final_ids
-            if cid in self._clause_index
-        ]
+            # Both ranks per candidate: where the hybrid legs put it, and where
+            # the cross-encoder moved it to. A large gap on the clause that
+            # mattered is the whole diagnosis.
+            hybrid_rank = {cid: rank for rank, cid in enumerate(candidates, start=1)}
+            traced.update(
+                {
+                    "candidates": [
+                        {
+                            "clause_id": clause_id,
+                            "hybrid_rank": hybrid_rank[clause_id],
+                            "rerank_rank": rank,
+                            "rerank_score": score,
+                        }
+                        for rank, (clause_id, score) in enumerate(ranked, start=1)
+                    ],
+                    "kept": final_ids,
+                    "co_retrieval_injected": [
+                        clause_id
+                        for clause_id in final_ids
+                        if clause_id not in score_by_id
+                    ],
+                }
+            )
+
+            return [
+                self._hydrate(cid, score_by_id.get(cid, _INJECTED_CLAUSE_SCORE))
+                for cid in final_ids
+                if cid in self._clause_index
+            ]
 
     def _hydrate(self, clause_id: str, score: float) -> RetrievedClause:
         """Build a [RetrievedClause] from the clause index (caller guards presence)."""

--- a/app/src/infrastructure/rag/retriever_factory.py
+++ b/app/src/infrastructure/rag/retriever_factory.py
@@ -41,6 +41,7 @@ from infrastructure.rag.exclusion_co_retrieval import ClauseGraph
 from infrastructure.rag.graph_retrieval_adapter import (
     GraphRetrievalAdapter,
     IndexedClause,
+    SpanRecorder,
     build_clause_index,
 )
 from infrastructure.rag.hybrid_retriever import HybridRetriever
@@ -95,9 +96,19 @@ def retriever_components_from_corpora(
 
 
 def build_graph_retriever(
-    session: Session, components: RetrieverComponents
+    session: Session,
+    components: RetrieverComponents,
+    *,
+    tracer: SpanRecorder | None = None,
 ) -> GraphRetrievalAdapter:
-    """Compose the per-run retrieval adapter over a live Postgres session."""
+    """Compose the per-run retrieval adapter over a live Postgres session.
+
+    ``tracer`` ([M5-07]) is the graph's ``TracePort``, passed through so the
+    adapter can record its ``retrieval.rerank`` span. ``SpanRecorder`` is the
+    same shape re-declared in ``infrastructure.rag`` -- this layer does not
+    import ``infrastructure.graph``. ``None`` (every caller but the composition
+    root) leaves the adapter untraced.
+    """
     dense = DenseRetriever(session, components.embedder)
     hybrid = HybridRetriever(components.lexical, dense)
     return GraphRetrievalAdapter(
@@ -105,6 +116,7 @@ def build_graph_retriever(
         components.reranker,
         components.clause_index,
         co_retrieval=components.clause_graph,
+        tracer=tracer,
     )
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,9 +2,12 @@
 #
 # [M0-08] brought up the database. [M5-05] adds `redis` -- the asynchronous
 # assessment queue (`make worker`) needs it, and so does `make test-integration`.
-# [M5-09] still adds the `api` / `worker` / `langfuse` services (once there is a
-# Dockerfile to run them from). Every block reads its configuration from the same
-# `${...}` variables those services will, so they are appended, not rewritten.
+# [M5-07] adds the self-hosted Langfuse stack behind the `tracing` profile, so
+# `docker compose up -d` is still just postgres + redis and
+# `docker compose --profile tracing up -d` is the traced stack. [M5-09] still
+# adds the `api` / `worker` services (once there is a Dockerfile to run them
+# from). Every block reads its configuration from the same `${...}` variables
+# those services will, so they are appended, not rewritten.
 services:
   postgres:
     # Postgres major and pgvector version are both explicit: the floating
@@ -48,5 +51,152 @@ services:
       timeout: 3s
       retries: 12
 
+  # ---------------------------------------------------------------------------
+  # Tracing -- [M5-07]. `profiles: ["tracing"]` on every service below, so a
+  # plain `docker compose up -d` never starts them: tracing is opt-in at the
+  # infrastructure layer the same way `TRACING_ENABLED` makes it opt-in at the
+  # application layer.
+  #
+  #   docker compose --profile tracing up -d
+  #
+  # Langfuse v4 needs Postgres, ClickHouse, S3-compatible blob storage and Redis.
+  # It shares this stack's postgres (its own database) and redis (its own db
+  # index) rather than duplicating them; ClickHouse and MinIO have no local
+  # counterpart, so they are added, unpublished -- nothing outside the compose
+  # network talks to them.
+  #
+  # Note the variable names: the langfuse containers read `DATABASE_URL`, `SALT`
+  # and `ENCRYPTION_KEY`, and `DATABASE_URL` already means the *application*
+  # database in this project's .env. Every value below is therefore passed
+  # explicitly, and our own knobs stay under the `LANGFUSE_` prefix.
+  # ---------------------------------------------------------------------------
+  clickhouse:
+    # Langfuse's trace store. Pinned to the minor Langfuse tests against, for the
+    # same reason postgres and redis are pinned above.
+    image: clickhouse/clickhouse-server:25.12
+    profiles: ["tracing"]
+    restart: unless-stopped
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      - langfuse_clickhouse_logs:/var/log/clickhouse-server
+    healthcheck:
+      test:
+        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  minio:
+    # Langfuse uploads raw ingestion events to blob storage before the worker
+    # folds them into ClickHouse. The bucket is created by the entrypoint rather
+    # than by a separate init container, as upstream's own compose does.
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    profiles: ["tracing"]
+    restart: unless-stopped
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" /data'
+    environment:
+      MINIO_ROOT_USER: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  langfuse-worker: &langfuse-service
+    image: docker.langfuse.com/langfuse/langfuse-worker:4.28.1
+    profiles: ["tracing"]
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment: &langfuse-env
+      # Its own database on this stack's postgres -- created by
+      # docker/postgres/initdb/02-create-langfuse-database.sql on a fresh volume.
+      DATABASE_URL: postgresql://${DATABASE_USER:-postgres}:${DATABASE_PASSWORD:-postgres}@postgres:5432/${LANGFUSE_DB_NAME:-langfuse}
+      # db index 1: the assessment queue owns db 0, so RQ's keyspace and
+      # Langfuse's BullMQ queues never share a `FLUSHDB`.
+      REDIS_CONNECTION_STRING: redis://redis:6379/1
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD:-clickhouse}
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+      NEXTAUTH_URL: http://localhost:${LANGFUSE_PORT:-3000}
+      SALT: ${LANGFUSE_SALT:?set LANGFUSE_SALT in .env -- openssl rand -hex 32}
+      ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY:?set LANGFUSE_ENCRYPTION_KEY in .env -- openssl rand -hex 32}
+      # This is a local development stack; it phones nobody home.
+      TELEMETRY_ENABLED: "false"
+    healthcheck:
+      # `$$(hostname)`, not localhost: both langfuse servers bind the container's
+      # own network address rather than loopback, so a probe at 127.0.0.1 (or at
+      # `localhost`, which resolves to ::1 here) is refused by a healthy service.
+      # The `$$` is compose escaping -- the shell inside the container expands it.
+      test:
+        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://$$(hostname):3030/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  langfuse-web:
+    <<: *langfuse-service
+    image: docker.langfuse.com/langfuse/langfuse:4.28.1
+    ports:
+      - ${LANGFUSE_PORT:-3000}:3000
+    environment:
+      <<: *langfuse-env
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:?set LANGFUSE_NEXTAUTH_SECRET in .env -- openssl rand -hex 32}
+      # Headless bootstrap: the project is created on first boot with exactly the
+      # keys the application is already configured with, so `up -d` yields a
+      # working tracer with no click-through in the UI.
+      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-insurance-claims}
+      LANGFUSE_INIT_ORG_NAME: Insurance Claims
+      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-claims-assessment}
+      LANGFUSE_INIT_PROJECT_NAME: Claims Assessment
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:?set LANGFUSE_PUBLIC_KEY in .env}
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_SECRET_KEY:?set LANGFUSE_SECRET_KEY in .env}
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-}
+      LANGFUSE_INIT_USER_NAME: Local Analyst
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
+    healthcheck:
+      test:
+        ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://$$(hostname):3000/api/public/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
 volumes:
   postgres_data:
+  langfuse_clickhouse_data:
+  langfuse_clickhouse_logs:
+  langfuse_minio_data:

--- a/docker/postgres/initdb/02-create-langfuse-database.sql
+++ b/docker/postgres/initdb/02-create-langfuse-database.sql
@@ -1,0 +1,14 @@
+-- The self-hosted Langfuse server's own database -- [M5-07].
+--
+-- Langfuse needs a Postgres of its own for users, projects and API keys (its
+-- trace data lives in ClickHouse). It gets a database on this container rather
+-- than a second Postgres: one less service, and the `tracing` profile is a
+-- development/demo convenience, not a production topology.
+--
+-- The name is hardcoded, like the test database above, because `initdb` scripts
+-- run before any compose variable could reach them. Point LANGFUSE_DB_NAME
+-- somewhere else and you own creating it.
+--
+-- Runs only on an empty data volume. On a stack that already has one:
+--   docker compose exec postgres createdb -U postgres langfuse
+CREATE DATABASE langfuse;

--- a/docs/API.md
+++ b/docs/API.md
@@ -186,10 +186,15 @@ response as `X-Correlation-ID`. The middleware emits one access line per request
 The id propagates into the assessment run: the orchestrator binds it for the
 graph invocation and puts it in the graph `config` metadata, so every node run
 logs a correlation-tagged `node.start` / `node.completed` line
-(`infrastructure.graph.node`) and every LLM call carries it (M5-07's tracing
-reads that metadata). On the async path the id rides the RQ job across Redis and
-the worker re-binds it, so a worker's node logs trace back to the `POST` that
-queued the claim.
+(`infrastructure.graph.node`) and every LLM call carries it. On the async path
+the id rides the RQ job across Redis and the worker re-binds it, so a worker's
+node logs trace back to the `POST` that queued the claim.
+
+Since [M5-07] the same id also tags the run's **trace**, and each run logs a
+`trace.started` line carrying `trace_id` and a ready-made `trace_url` — so a log
+line leads to the trace, and a correlation id from a log line finds it in
+Langfuse's search. See [`docs/OBSERVABILITY.md`](OBSERVABILITY.md) for the span
+tree, how to read one, and how to turn tracing off.
 
 ## Errors
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,8 +137,14 @@ and its enforcement test are untouched. The correlation id is
 `GraphContext.correlation_id`, set by `LangGraphClaimAssessmentOrchestrator` from
 the ambient request/worker id; the orchestrator also puts it in the graph
 `config` metadata, which LangGraph copies onto every node's child
-`RunnableConfig` so LLM calls carry it (M5-07's tracing reads that). See
-`docs/API.md` "Structured logging & correlation IDs".
+`RunnableConfig` so LLM calls carry it. See `docs/API.md` "Structured logging &
+correlation IDs".
+
+[M5-07] adds spans beside those log lines, and adds them **without touching this
+wrapper or any node** — the Langfuse callback handler goes on the run's config in
+the orchestrator, where it sees the nodes *and* the LLM calls inside them. See
+"Tracing is one callback handler on the run" below and
+`docs/OBSERVABILITY.md`.
 
 ---
 
@@ -935,3 +941,79 @@ state machine), `test_submit_claim.py` (persist-then-enqueue),
 → burst worker → completion, transient retry, dead-letter). `test_layer_boundaries.py`
 adds `rq` / `redis` to the forbidden roots. CI's `integration` job gains a
 `redis` service.
+
+## Tracing is one callback handler on the run, plus two hand-written spans — [M5-07]
+
+**Decision.** Trace the graph into a self-hosted Langfuse by installing its
+LangChain `CallbackHandler` on the graph's run config in
+`LangGraphClaimAssessmentOrchestrator._invoke`, and add exactly two spans by
+hand for the work no LLM call passes through. `docs/OBSERVABILITY.md` is the
+reader's guide; this section is the why.
+
+**Why the orchestrator and not `build.py`.** [M5-06] already wraps every node in
+`build._instrumented` for its log lines, so wrapping them again for spans is the
+obvious move — and it is the wrong one. LangGraph nodes are runnables, so a
+handler on the *run* already sees every node, and it sees something a node
+wrapper never can: the `chain.invoke(messages)` calls **inside** the nodes,
+with their prompts, completions and token usage. `_invoke` is also the only
+place a whole run passes through, which makes it the only sensible flush point —
+it covers the worker, the synchronous `resume` the API serves, and the eval
+scripts at once. So `build.py`, all eight node modules and the [M4-01b]
+`(state, runtime) -> dict` convention are untouched by this issue.
+
+The handler must go on the run rather than on the model objects, because the
+nodes deliberately pass no `config` to their own `chain.invoke` and rely on
+LangChain's ambient child config; a handler bound to a model would be bypassed.
+
+**Why two spans are still hand-written.** Callbacks see runnables. Retrieval is
+deterministic Python — no LLM call — so to a callback handler the node is a
+black box, and its candidate list, their scores and the [M3-07] gate's reasoning
+are locals that mostly never reach state. Three gate fields (`threshold`,
+`missing_category`, `closest_clause_ids`) are computed on every single run and
+recorded *nowhere*: state keeps the boolean, the audit event keeps the trigger
+name. Since those are the first thing you want when a verdict is wrong, the
+retrieval node opens a span for them, and `GraphRetrievalAdapter` nests a second
+one showing each candidate's hybrid rank against its cross-encoder rank.
+
+**Why the graph layer owns a `TracePort`.** Same reason it owns `RetrievalPort`
+and `AuditTrailSink`: a node depends on a capability, never on an adapter, and
+`infrastructure.observability.tracing.LangfuseTracer` satisfies it structurally.
+`infrastructure.rag` restates the same shape as `SpanRecorder` rather than
+importing it, so the `graph -> rag` dependency direction is not reversed for a
+span. The port deals in plain mappings and is a context manager, so the span's
+latency is measured rather than reported, and a test fake is a handful of lines.
+
+**A null object, not `| None`.** `GraphContext.tracer` defaults to `NO_TRACING`
+rather than to `None` the way `audit_sink` does. The sink is consulted once, at
+the checkpoint, where a branch is cheap and readable; a tracer is called from
+node bodies, and the null object keeps those bodies free of `if tracer is not
+None` noise for a call whose entire point is that it changes nothing. It also
+means an untraced deployment runs the identical code path, not a second one.
+
+**Optional means two things.** At the application layer,
+`ObservabilitySettings.tracing_active` is the `TRACING_ENABLED` flag **and** both
+keys; inactive, no Langfuse client is constructed at all. At the infrastructure
+layer the four langfuse services sit behind a Compose `profiles: ["tracing"]`,
+so plain `docker compose up -d` remains postgres + redis. And tracing never
+raises into a run: every SDK call is guarded, so a broken tracer degrades to no
+tracing, exactly as the compatibility node degrades rather than raising.
+
+**Deviations on record.** (a) `GET /ready` deliberately does *not* check
+Langfuse — readiness means "can serve an assessment", and an optional dependency
+must not be able to take the service out of rotation. (b) Cost is registered as
+list prices for the *pinned provider route*, not measured; re-pinning
+`LLM_*_PROVIDER_ORDER` makes them stale, and [M5-10] owns the measured number.
+(c) The langfuse services share this stack's Postgres (own database) and Redis
+(db index 1 against the queue's db 0) instead of running their own — a
+development-stack choice, stated rather than hidden. (d) The `langchain`
+meta-package became a direct dependency: Langfuse's handler does
+`import langchain` purely to branch on `langchain.__version__` and refuses to
+import without it, though every symbol it uses comes from `langchain_core`.
+
+**Enforcement.** `tests/unit/infrastructure/observability/test_tracing.py` runs
+the **real compiled graph** against a real Langfuse client whose span exporter
+writes to memory, and asserts a span per node, the retrieval span's candidates
+and scores, the correlation id on the trace, and that a deliberately broken
+tracer still runs the body it wraps — no server, no credentials, so it holds in
+CI. `tests/unit/infrastructure/graph/test_retrieval.py` covers the retrieval
+span's payload against a recording fake port.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,370 @@
+# Tracing the assessment graph — [M5-07]
+
+[M5-06] made a run loggable: JSON lines to stdout, one correlation id carried
+from the HTTP request through Redis into every node. That answers *what
+happened*. It does not answer *which node was wrong*, because that question
+needs a node's input beside its output beside the clauses it was reasoning over
+— a tree, not a sequence of lines. M5-07 adds a self-hosted **Langfuse** to the
+Compose stack and traces the graph into it.
+
+```
+POST /v1/assessments (X-Correlation-ID: abc)
+  └─ trace "claim-assessment"          session_id = assessment id, tags = [abc]
+     ├─ intake                         chain  · state in → state delta out
+     │   └─ ChatOpenAI                 GEN    · prompt, completion, tokens, cost
+     ├─ retrieval                      chain
+     │   └─ retrieval                  SPAN   · query, filter, k, candidates+scores, gate
+     │       └─ retrieval.rerank       SPAN   · hybrid rank vs cross-encoder rank
+     ├─ compatibility                  chain
+     │   └─ ChatOpenAI                 GEN    · the reasoning model
+     ├─ consistency                    chain
+     │   └─ ChatOpenAI                 GEN
+     ├─ recommendation                 chain
+     │   └─ ChatOpenAI                 GEN
+     └─ human_review                   chain  · ends on interrupt()
+```
+
+Everything but the two `SPAN` rows is produced by installing one LangChain
+callback handler on the graph's run config. `build.py`, the eight node modules
+and the `(state, runtime) -> dict` convention are untouched by this issue.
+
+## Code
+
+- `app/src/infrastructure/observability/tracing.py` — the whole application
+  side: `build_tracer` (the switch), `NullTracer` (off), `LangfuseTracer`
+  (`callbacks()` / `assessment_run()` / `span()` / `shutdown()`), and
+  `register_model_prices`.
+- `app/src/infrastructure/graph/context.py` — `TracePort`, the capability a node
+  depends on, and `NO_TRACING`, the null object that is `GraphContext.tracer`'s
+  default.
+- `app/src/infrastructure/graph/orchestrator.py` — the one wiring point:
+  `config["callbacks"]`, the root span, the flush.
+- `app/src/infrastructure/graph/nodes/retrieval.py` — the explicit retrieval
+  span.
+- `app/src/infrastructure/rag/graph_retrieval_adapter.py` — the nested
+  `retrieval.rerank` span (`SpanRecorder`, the port restated so `rag` keeps not
+  importing `graph`).
+- `app/src/infrastructure/bootstrap.py` — one client per process, shut down with
+  the engine.
+- `compose.yaml` — the `tracing` profile: `langfuse-web`, `langfuse-worker`,
+  `clickhouse`, `minio`.
+- `docker/postgres/initdb/02-create-langfuse-database.sql` — Langfuse's database
+  on the existing Postgres.
+
+## Bring-up
+
+```bash
+cp .env.example .env                       # then fill the five values listed below
+docker compose --profile tracing up -d     # postgres + redis + the 4 langfuse services
+make migrate && make setup-checkpointer
+make serve                                 # one shell
+make worker                                # another
+```
+
+Open <http://localhost:3000> and sign in with `LANGFUSE_INIT_USER_EMAIL` /
+`LANGFUSE_INIT_USER_PASSWORD`.
+
+**Five `.env` values have no safe default**, and the `tracing` profile refuses to
+start without them — each with an error naming the variable, so you find out at
+`up`, not at the first missing trace:
+
+```bash
+openssl rand -hex 32   # LANGFUSE_NEXTAUTH_SECRET
+openssl rand -hex 32   # LANGFUSE_SALT
+openssl rand -hex 32   # LANGFUSE_ENCRYPTION_KEY
+# plus any non-empty pair, `pk-lf-…` / `sk-lf-…` by convention:
+#   LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
+```
+
+The key pair is **seeded into the server**, not read from it: compose passes it
+as `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` / `_SECRET_KEY`, so on a fresh volume the
+project is created holding exactly the keys the application is already
+configured with. There is no key-copying step and no click-through.
+
+Leaving the pair empty is the supported "no tracing" state, and it is what
+`.env.example` ships: `docker compose up -d` (no profile) then brings up
+postgres and redis exactly as before, and the service runs untraced.
+
+**On an existing Postgres volume**, `initdb` will not re-run, so create the
+database by hand once:
+
+```bash
+docker compose exec postgres createdb -U postgres langfuse
+```
+
+## What is traced, and by whom
+
+**The callback handler does the bulk.** `LangGraph` nodes and the
+`chain.invoke(messages)` calls inside them are LangChain runnables, so a handler
+on the run's config sees all of them. Each node becomes a span carrying the
+state it read and the delta it returned; each LLM call becomes a *generation*
+carrying the prompt, the completion, the model id and `usage_details`.
+
+Attaching it in `orchestrator._invoke` rather than to the model objects is
+deliberate: the nodes pass no `config` to their own `chain.invoke`, relying on
+LangChain's ambient child config, so a handler bound to a model would be
+bypassed while one bound to the run is not.
+
+**Two spans are added by hand**, because no LLM call passes through them:
+
+- **`retrieval`** (the node) — the query built from the entities, the metadata
+  pre-filter, `k`, then every returned clause with its id, document, type and
+  score, and the whole gate result. Three of the gate's fields (`threshold`,
+  `missing_category`, `closest_clause_ids`) are computed on every run and
+  recorded nowhere else: state keeps only the boolean, and the audit event keeps
+  only the trigger name.
+- **`retrieval.rerank`** (the adapter) — each candidate's hybrid rank beside its
+  cross-encoder rank and score, plus anything exclusion co-retrieval injected.
+  `RERANK_CANDIDATE_DEPTH` is 10, the same as the node's `k`, so the reranker
+  reorders rather than prunes; the question this span answers is not "what was
+  dropped" but "did the hybrid legs surface the right clause at all".
+
+**Cost** needs one more thing. Langfuse prices a generation by matching the
+reported model name against the model definitions in the project, and it has
+never heard of an OpenRouter id like `deepseek/deepseek-v4-flash-0731`. So
+`register_model_prices` upserts one definition per model at startup from
+`LLM_{FAST,REASONING}_{INPUT,OUTPUT}_COST_PER_1M_TOKENS_USD`. Without it every
+generation costs `0.00`.
+
+Those prices are **per pinned provider route**, not per model: the same model is
+served at $0.05/1M input on one OpenRouter route and $0.35 on another. Re-pin
+`LLM_FAST_PROVIDER_ORDER` and the price goes stale. They are list prices, not a
+measurement — [M5-10] owns measured cost per assessment.
+
+## Reaching a trace from a log line, and back
+
+Both directions work, which is the point of tagging:
+
+- **log → trace.** Every run logs one `trace.started` line carrying `trace_id`
+  and a ready-made `trace_url`, beside the `correlation_id`. Open the URL.
+- **trace → log.** The trace carries the correlation id twice: as a **tag** and
+  in `metadata.correlation_id`. Paste it into Langfuse's search to find the
+  trace for a correlation id you already have from a log line.
+- `session_id` is the assessment id, so the run up to the human checkpoint and
+  the run resumed after the decision group as one session.
+
+The trace URL is resolved **once, at startup**, not per run: the SDK's
+`get_trace_url()` fetches the project id over HTTP, and a blocking round trip
+per assessment — one that fails slowly exactly when Langfuse is down — is not
+something observability is allowed to cost.
+
+## Turning it off
+
+```bash
+TRACING_ENABLED=false      # or leave LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY empty
+```
+
+`ObservabilitySettings.tracing_active` is the flag **and** both keys.
+Inactive, `build_tracer` returns `NullTracer` and no Langfuse client is
+constructed at all — no exporter thread, no network. The graph runs the
+identical code path; `GraphContext.tracer` is a null object, so nodes do not
+branch on whether tracing is on.
+
+Tracing is also optional at the infrastructure layer: the langfuse services sit
+behind a Compose **profile**, so plain `docker compose up -d` is still exactly
+postgres + redis.
+
+Two consequences worth stating plainly:
+
+- **A tracing failure is never a run failure.** Every call into the SDK is
+  guarded; a broken or unreachable Langfuse logs a warning and the assessment
+  proceeds untraced. `test_a_broken_tracer_does_not_break_the_body_it_wraps`
+  holds this.
+- **`GET /ready` does not check Langfuse.** Readiness means "can serve an
+  assessment", and an assessment does not need a tracer. Adding it would make an
+  optional dependency able to take the service out of rotation.
+
+## Reading a trace
+
+Open the trace and read the span tree top-down; the first place the run went
+wrong is usually visible before any prompt is read.
+
+1. **Did retrieval see the right document?** The `retrieval` span's `filter`
+   shows what constrained the search — a stated SUSEP process, else the product
+   line, else nothing. `candidates[].document_id` shows what came back.
+2. **Did it see the right *clause*?** `candidates[].clause_id` with scores. The
+   right document with the wrong clauses is a different bug from the wrong
+   document, and this is the only place the distinction is visible.
+3. **What did the gate decide, and why?** `gate.sufficient` with `top_score`
+   against `threshold`. A gate that says *sufficient* over clauses that do not
+   answer the question is the setup for a confident wrong verdict.
+4. **What did the reasoning model actually see?** The `compatibility`
+   generation's prompt contains the clause text that was passed in. If step 2
+   showed the right clause missing, this is where you confirm the model reasoned
+   correctly over the wrong evidence.
+5. **Latency and cost** sit on each span and total on the trace.
+
+## Worked example: a confident wrong verdict
+
+Run on 2026-09-04 through `make serve` + `make worker` against the compose
+`tracing` profile, on `compatible-007` from `data/synthetic_claims/claims.jsonl`
+— a claimant who swerved an e-scooter to avoid a pedestrian and hit a parked
+car, filed against SUSEP process `15414.614145/2021-31` (document 18). The
+golden label is **compatible**. The system said **incompatible**, confidence
+0.85, and this run reproduces the M4-10 result exactly
+(`docs/END_TO_END_EVALUATION.md` classifies it `retrieval_miss`).
+
+The trace, `claim-assessment`, 234.6 s wall clock:
+
+| span | type | latency | in | out | cost |
+|---|---|---:|---:|---:|---:|
+| `intake` | chain | 61.26 s | | | |
+| ⟶ `ChatOpenAI` | generation | 61.25 s | 1069 | 4 (+1773 reasoning) | $0.000086 |
+| `retrieval` | chain | 2.39 s | | | |
+| ⟶ `retrieval` | **span** | 2.39 s | | | |
+| ⟶ `retrieval.rerank` | **span** | 2.39 s | | | |
+| `compatibility` | chain | 51.38 s | | | |
+| ⟶ `ChatOpenAI` | generation | 51.36 s | 3022 | 271 (+3725 reasoning) | $0.004303 |
+| `consistency` | chain | 79.32 s | | | |
+| ⟶ `ChatOpenAI` | generation | 79.30 s | 846 | 225 | $0.000108 |
+| `recommendation` | chain | 91.55 s | | | |
+| ⟶ `ChatOpenAI` | generation | 91.54 s | 1387 | 264 | $0.000158 |
+| `human_review` | chain | 0.002 s | | | |
+
+**The cost column is what this run recorded, and it is an undercount** — the run
+predates the `output_reasoning` pricing tier described in Finding 4, so it prices
+`input` and `output` only. Corrected, the compatibility call is ~$0.0168 rather
+than $0.0043 and the run totals ~$0.0176 rather than $0.0047. The latencies and
+token counts are as measured. Route matters too: this run pinned the fast model
+to `deepinfra/fp8` ($0.08/$0.18 per 1M) and the reasoning model to `alibaba`
+($1.122/$3.366), with `LLM_*_COST_PER_1M_TOKENS_USD` set to match — the repo
+defaults price the default pins instead.
+
+Reading it in the order of "Reading a trace" above:
+
+**1. The right document was searched.** The `retrieval` span's input:
+
+```json
+{"query": "RCF-A O segurado, andando de patinete elétrico, desviou para evitar
+           um pedestre e colidiu com um carro estacionado...",
+ "k": 10,
+ "filter": {"susep_process": "15414.614145/2021-31", "product_line": null}}
+```
+
+The stated process filtered the search to document 18 — the [M4-10] filter
+behaving exactly as intended. Every candidate that came back is from document
+18. So this is **not** a wrong-document bug, and one glance at this span rules
+that whole class out.
+
+**2. The right clause was never retrieved.** The span's `candidates`:
+
+| rank | clause | type | score |
+|---:|---|---|---:|
+| 1 | `18:3/3.11` | definition | 0.5074 |
+| 2 | `18:9/12.3` | **exclusion** | 0.4878 |
+| 3 | `18:3/3.39` | definition | 0.4580 |
+| 4–10 | `18:3`, `18:3/3.6`, `3.7`, `3.9`, `3.10`, `3.21`, `3.23` | definition | 0.2681 (all seven identical) |
+
+The claim's reference clause is **`18:11`**, and it is not there. Nine of the ten
+retrieved clauses are *definitions*; the tenth is an *exclusion*. **Not one
+coverage clause was retrieved.** The seven-way tie at exactly 0.2681 is the
+cross-encoder saying it cannot tell those apart at all.
+
+`retrieval.rerank` shows the reranker did not cause this — it moved
+`18:9/12.3` from hybrid rank 3 to rank 2 and `18:3/3.39` from 2 to 3, and
+changed nothing else. The clause was never in the hybrid candidate set to begin
+with, so the fix belongs in retrieval, not reranking.
+
+**3. The gate passed anyway, by 0.047.** The span's `gate`:
+
+```json
+{"sufficient": true, "trigger": null, "top_score": 0.5074, "threshold": 0.46}
+```
+
+This is the finding the trace makes unmissable. The [M3-07] gate is a threshold
+on the top reranked score, and 0.5074 clears 0.46 — on a *definition* clause.
+The gate measures whether the top hit looks relevant, not whether the retrieved
+set can answer the question, and a set of nine definitions plus one exclusion
+cannot. `top_score` beside `threshold` in one object is what turns "the gate
+said sufficient" into "the gate said sufficient by 0.047, on a definition".
+
+**4. The model reasoned correctly over the wrong evidence.** The
+`compatibility` generation's completion:
+
+```json
+{"assertions": [{"clause_ids": ["18:3/3.39"],
+                 "statement": "A cláusula 3.39 define expressamente 'patinetes'
+                               como equipamento de mobilidade individual..."}]}
+```
+
+and the final recommendation cites `18:9/12.3` and `18:3/3.39` — the exclusion
+and the definition that feeds it. Given only an exclusion and definitions, an
+`incompatible` verdict is the *correct* reading of that context. The reasoning
+node is not the bug.
+
+**The diagnosis, in one line:** retrieval returned no coverage clause, the gate
+could not tell that from a good result, and the assessment then faithfully
+applied the only rule it was shown — an exclusion. The fix is in the gate (a
+composition signal beside the score threshold: does the retrieved set contain a
+coverage clause at all?) and in retrieval recall for `18:11`, and **not** in the
+compatibility prompt, which is where a reader without the trace would have
+started, because the wrong output came out of that node.
+
+Two numbers the trace also settles in passing: the parallel branch saved 51.4 s
+of the run's 234.6 s (`compatibility` 51.38 s ran entirely inside `consistency`'s
+79.32 s), and the single reasoning call is **92% of the run's cost** — the other
+three LLM calls together came to $0.00035 against its $0.0043. That ratio is a
+sharper argument for the [M4-07] parallel branch than the wall-clock saving is:
+the expensive call is the one on the critical path either way.
+
+## Findings
+
+1. **The callback handler covers "trace every node" with no graph change.**
+   Every one of the six nodes on the executed path appears as a span with its
+   input, output and latency, and every LLM call as a generation with prompt,
+   completion and token usage — from one line in `orchestrator._invoke`.
+   `build.py`, the node modules and the [M4-01b] node convention are untouched.
+2. **Retrieval needed a hand-written span, and it is the one that pays.** No LLM
+   call passes through the retrieval node, so callbacks see a black box. Every
+   step of the diagnosis above came from the two hand-written spans; the four
+   generations only confirmed the conclusion.
+3. **Three gate fields existed but were unrecorded.** `threshold`,
+   `missing_category` and `closest_clause_ids` are computed on every run and
+   were reaching neither state nor the audit trail. `top_score: 0.5074` against
+   `threshold: 0.46` is the single most useful number in this trace, and before
+   M5-07 it was discarded microseconds after being computed.
+4. **Cost needed model definitions, and reasoning tokens needed a pricing
+   tier.** Langfuse prices from a project model definition and knows no
+   OpenRouter model id, so every generation costs `0.00` without
+   `register_model_prices`. Worse, the obvious flat `input_price`/`output_price`
+   pair prices only the `input` and `output` usage keys — and this reasoning
+   model reported **3725 of ~4000 completion tokens** under `output_reasoning`.
+   Priced flat, the compatibility call reads $0.0043; with `output_reasoning`
+   priced at the completion rate it is ~$0.017, a **4x** understatement. The
+   registration sends a pricing tier for that reason.
+5. **The trace-URL lookup was a hidden per-run HTTP call.** `get_trace_url()`
+   fetches the project id over the network. Called per assessment it would add a
+   blocking round trip to every run — one that fails *slowly* exactly when
+   Langfuse is down. It is resolved once at startup and formatted locally after.
+6. **Idempotent price registration needed a lookup, not just a stable id.**
+   Model *names* are unique per project, so an upsert under our own id is
+   rejected with "already exists in project" whenever a definition was created
+   under a Langfuse-assigned id. Registration lists the project's definitions
+   (paged — a fresh project ships ~180) and updates whatever id the name
+   actually has.
+7. **Langfuse v4 self-hosting is four containers, not one.** `langfuse-web`,
+   `langfuse-worker`, ClickHouse and MinIO, because the v4 SDK exports over
+   OpenTelemetry to a v4 server. It reuses this stack's Postgres and Redis, and
+   the whole set sits behind a Compose profile so the default stack is unchanged.
+8. **The v2 SDK was not an option.** `langfuse<3`'s LangChain integration
+   hard-imports the `langchain` meta-package *and* `langchain.schema.*`, removed
+   in langchain 1.x; the version that has it pins `langchain-core <1`, which this
+   project is past. The v4 handler imports from `langchain_core` — but still
+   does `import langchain` to read `__version__`, which is why the meta-package
+   is now a direct dependency.
+
+## What this leaves for later
+
+- **Measured latency and cost** are [M5-10]. M5-07 makes the numbers visible per
+  node and per run; it does not report a p50/p95 or a cost per assessment, and
+  the prices registered here are list prices for the pinned route.
+- **No integration test needs a Langfuse server.** The span assertions in
+  `tests/unit/infrastructure/observability/test_tracing.py` run the real graph
+  against a real Langfuse client whose exporter writes to memory, so CI proves
+  "every node appears as a span" with no server and no credentials. Keeping the
+  `tracing` profile out of CI is the point of it being a profile.
+- **The langfuse services have no resource limits** and share this stack's
+  Postgres and Redis (its own database, and Redis db index 1 against the queue's
+  db 0). Fine for a development and demo stack, stated rather than hidden.
+- **Sampling is not configured.** Every run is traced. The SDK supports a sample
+  rate; at this project's volume there is nothing to sample.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pypdf>=6.14.2",
     "pytesseract>=0.3.13",
     "pillow>=12.3.0",
-    "langchain-core>=1.5.5",
+    "langchain-core>=1.6.0",
     "langchain-openai>=1.5.1",
     "langgraph>=1.2",
     # [M4-09] the Postgres checkpointer -- a separate distribution from
@@ -36,6 +36,21 @@ dependencies = [
     # readiness checks import the client.
     "rq>=2.0",
     "redis>=5.0",
+    # [M5-07] tracing. The v4 SDK is OpenTelemetry-based and its LangChain
+    # callback handler imports `langchain_core` (falling back to the `langchain`
+    # meta-package only if that fails), so it works on this stack -- the v2 SDK's
+    # handler does not, it hard-imports `langchain.schema.*`, removed in
+    # langchain 1.x. Ships `py.typed`, so `mypy --strict` needs no override. A
+    # plain dependency, not an opt-in group like `embed`: it is pure Python and
+    # small, and tracing is switched off by configuration, not by absence.
+    "langfuse>=4.15,<5",
+    # [M5-07] the `langchain` meta-package is a dependency of the Langfuse
+    # callback handler and nothing else here imports it: the handler does
+    # `import langchain` purely to branch on `langchain.__version__`, then
+    # imports every symbol it actually uses from `langchain_core`. It refuses to
+    # import without it. Thin -- langchain-core, langgraph and pydantic, all
+    # already direct dependencies -- but it does raise the langchain-core floor.
+    "langchain>=1.4,<2",
 ]
 
 [dependency-groups]

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -38,6 +38,10 @@ FORBIDDEN_ROOTS = frozenset(
         # adapter stays in infrastructure.
         "rq",
         "redis",
+        # [M5-07]: tracing. `TracePort` is a port on the graph layer; the
+        # Langfuse client and its OpenTelemetry exporter stay in infrastructure.
+        "langfuse",
+        "opentelemetry",
         "fitz",
         "pyarrow",
         "pytesseract",

--- a/tests/unit/infrastructure/graph/test_retrieval.py
+++ b/tests/unit/infrastructure/graph/test_retrieval.py
@@ -6,6 +6,8 @@ against the golden set is a separate ``eval``-marked measurement
 (``scripts/eval_retrieval_node.py`` / ``tests/eval``).
 """
 
+from collections.abc import Iterator, Mapping, MutableMapping
+from contextlib import contextmanager
 from typing import Any, cast
 
 import pytest
@@ -16,7 +18,12 @@ from langgraph.runtime import Runtime
 from domain.clause_classification import ClauseType
 from infrastructure.config.enums import LlmProvider
 from infrastructure.config.settings import LlmSettings
-from infrastructure.graph.context import GraphContext, RetrievalPort
+from infrastructure.graph.context import (
+    NO_TRACING,
+    GraphContext,
+    RetrievalPort,
+    TracePort,
+)
 from infrastructure.graph.nodes.retrieval import (
     RETRIEVAL_K,
     _build_filter,
@@ -75,13 +82,35 @@ def _llm_settings() -> LlmSettings:
     )
 
 
-def _context(retriever: RetrievalPort) -> GraphContext:
+class _RecordingTracer:
+    """A ``TracePort`` that keeps each span's name, input and finished output."""
+
+    def __init__(self) -> None:
+        self.spans: list[tuple[str, dict[str, object], dict[str, object]]] = []
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        input: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[MutableMapping[str, object]]:
+        output: dict[str, object] = {}
+        yield output
+        self.spans.append((name, dict(input), output))
+
+
+def _context(
+    retriever: RetrievalPort, *, tracer: TracePort = NO_TRACING
+) -> GraphContext:
     unused = cast(BaseChatModel, object())
     return GraphContext(
         fast_model=unused,
         reasoning_model=unused,
         retriever=retriever,
         llm_settings=_llm_settings(),
+        tracer=tracer,
     )
 
 
@@ -90,13 +119,14 @@ def _run(
     *,
     entities: ExtractedEntities | None,
     raw_claim_text: str = "bati o carro no portao ontem",
+    tracer: TracePort = NO_TRACING,
 ) -> dict[str, object]:
     state: dict[str, object] = {"claim_id": "c1", "raw_claim_text": raw_claim_text}
     if entities is not None:
         state["entities"] = entities
     return retrieval(
         cast(ClaimState, state),
-        Runtime(context=_context(cast(RetrievalPort, retriever))),
+        Runtime(context=_context(cast(RetrievalPort, retriever), tracer=tracer)),
     )
 
 
@@ -261,3 +291,78 @@ def test_retrieval_runs_as_a_node_in_a_compiled_state_graph() -> None:
     )
     assert [c.clause_id for c in out["citations"]] == ["doc-1:1.1"]
     assert out["context_sufficient"] is True
+
+
+# --- tracing ([M5-07]) ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_retrieval_records_a_span_with_its_candidates_and_scores() -> None:
+    """The [M5-07] DoD's retrieval span: what was retrieved, ranked and scored.
+
+    Retrieval makes no LLM call, so the trace's callback handler sees the node
+    as a black box; this span is the only place the candidate list appears.
+    """
+    retriever = _RecordingRetriever([_hit("doc-1:1.1", 0.91), _hit("doc-1:2.4", 0.72)])
+    tracer = _RecordingTracer()
+
+    _run(
+        retriever,
+        entities=ExtractedEntities(event_type="colisão", product_line="CASCO"),
+        tracer=tracer,
+    )
+
+    assert [name for name, _, _ in tracer.spans] == ["retrieval"]
+    _, recorded_input, output = tracer.spans[0]
+    assert recorded_input["query"] == "colisão"
+    assert recorded_input["k"] == RETRIEVAL_K
+    assert recorded_input["filter"] == {"susep_process": None, "product_line": "CASCO"}
+    assert output["n_returned"] == 2
+    assert output["candidates"] == [
+        {
+            "rank": 1,
+            "clause_id": "doc-1:1.1",
+            "document_id": "doc-1",
+            "susep_process": "15414.900000/2013-00",
+            "clause_type": "coverage",
+            "score": 0.91,
+        },
+        {
+            "rank": 2,
+            "clause_id": "doc-1:2.4",
+            "document_id": "doc-1",
+            "susep_process": "15414.900000/2013-00",
+            "clause_type": "coverage",
+            "score": 0.72,
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_the_retrieval_span_records_why_the_gate_abstained() -> None:
+    """The gate's reasoning fields, which reach no other record.
+
+    The node's audit event keeps only ``sufficient`` and the trigger name, and
+    state keeps only the flag -- so without the span, the reason a run abstained
+    is not recoverable after the fact.
+    """
+    retriever = _RecordingRetriever([_hit("doc-1:9.9", 0.01)])
+    tracer = _RecordingTracer()
+
+    _run(retriever, entities=ExtractedEntities(event_type="colisão"), tracer=tracer)
+
+    gate = cast(dict[str, Any], tracer.spans[0][2]["gate"])
+    assert gate["sufficient"] is False
+    assert gate["trigger"]
+    assert gate["threshold"] > 0
+    assert gate["explanation"]
+
+
+@pytest.mark.unit
+def test_retrieval_runs_untraced_by_default() -> None:
+    """``NO_TRACING`` is the default, so nothing above has to opt out of tracing."""
+    retriever = _RecordingRetriever([_hit("doc-1:1.1", 0.91)])
+
+    result = _run(retriever, entities=ExtractedEntities(event_type="colisão"))
+
+    assert result["context_sufficient"] is True

--- a/tests/unit/infrastructure/observability/test_tracing.py
+++ b/tests/unit/infrastructure/observability/test_tracing.py
@@ -1,0 +1,387 @@
+"""Tracing: the switch, the no-op, the prices, and the spans a run produces [M5-07].
+
+The centrepiece is ``test_every_node_appears_as_a_span`` and its neighbours,
+which run the **real compiled graph** against a real ``Langfuse`` client whose
+span exporter writes to memory instead of to a server. That is what makes the
+[M5-07] DoD's "trace every node" and "tag traces with the correlation id"
+checkable in CI, with no Langfuse running and no credentials: the assertions are
+on spans the production code path actually emitted, not on a mock's call log.
+
+The graph fakes come from ``test_claim_graph`` rather than being restated here
+-- one fake LLM and one stub retriever for the whole graph, defined where the
+graph itself is tested.
+
+Not covered here: what the [M5-06] correlation id does *outside* the graph
+(``tests/integration/test_observability.py``), and anything that needs a live
+Langfuse -- the compose ``tracing`` profile is deliberately not a CI dependency.
+"""
+
+from dataclasses import replace
+from itertools import cycle
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langfuse import Langfuse
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic import SecretStr
+
+from infrastructure.config.enums import LlmProvider
+from infrastructure.config.settings import LlmSettings, ObservabilitySettings
+from infrastructure.graph.build import build_claim_graph
+from infrastructure.observability.tracing import (
+    TRACE_NAME,
+    LangfuseTracer,
+    NullTracer,
+    build_tracer,
+    model_price_definitions,
+    register_model_prices,
+)
+from tests.unit.infrastructure.graph.test_claim_graph import (
+    _STUB_HIT,
+    APPROVE,
+    _context,
+)
+
+# Loopback, port 1: nothing listens, so any SDK call that would go to a server
+# is refused immediately rather than hanging. The tests below assert that this
+# costs nothing -- an unreachable Langfuse must not be an outage.
+DEAD_HOST = "http://127.0.0.1:1"
+
+
+def _llm_settings(
+    *,
+    fast_input: float = 0.14,
+    fast_output: float = 0.28,
+    reasoning_input: float = 1.1154,
+    reasoning_output: float = 3.3462,
+) -> LlmSettings:
+    return LlmSettings(
+        LLM_PROVIDER=LlmProvider.OPENAI,
+        LLM_API_KEY="test-key",
+        LLM_MODEL_FAST="fake-fast-model",
+        LLM_MODEL_REASONING="fake-reasoning-model",
+        EMBEDDING_MODEL="embed-model",
+        RERANKER_MODEL="rerank-model",
+        LLM_FAST_INPUT_COST_PER_1M_TOKENS_USD=fast_input,
+        LLM_FAST_OUTPUT_COST_PER_1M_TOKENS_USD=fast_output,
+        LLM_REASONING_INPUT_COST_PER_1M_TOKENS_USD=reasoning_input,
+        LLM_REASONING_OUTPUT_COST_PER_1M_TOKENS_USD=reasoning_output,
+        _env_file=None,
+    )
+
+
+def _observability(
+    *,
+    public_key: str = "pk-lf-test",
+    secret_key: str = "sk-lf-test",
+    tracing_enabled: bool = True,
+) -> ObservabilitySettings:
+    return ObservabilitySettings(
+        LANGFUSE_PUBLIC_KEY=public_key,
+        LANGFUSE_SECRET_KEY=SecretStr(secret_key),
+        LANGFUSE_HOST=DEAD_HOST,
+        TRACING_ENABLED=tracing_enabled,
+        _env_file=None,
+    )
+
+
+def _tracer(public_key: str) -> tuple[LangfuseTracer, InMemorySpanExporter, Langfuse]:
+    """A real tracer over a real client that exports to memory.
+
+    ``public_key`` must be unique per test: the SDK keys its client registry on
+    it, and ``CallbackHandler`` looks the client up by that key.
+    """
+    exporter = InMemorySpanExporter()
+    client = Langfuse(
+        public_key=public_key,
+        secret_key="sk-lf-test",
+        base_url=DEAD_HOST,
+        span_exporter=exporter,
+        tracing_enabled=True,
+    )
+    return LangfuseTracer(client, public_key=public_key), exporter, client
+
+
+def _run_traced_graph(
+    tracer: LangfuseTracer,
+    *,
+    correlation_id: str = "corr-1",
+    assessment_id: str = "a-1",
+) -> None:
+    """Run the whole graph, checkpoint and resume included, under ``tracer``."""
+    context = replace(_context([]), tracer=tracer)
+    compiled = build_claim_graph().compile(checkpointer=InMemorySaver())
+    config: Any = {
+        "configurable": {"thread_id": assessment_id},
+        "callbacks": tracer.callbacks(),
+    }
+    with tracer.assessment_run(
+        assessment_id=assessment_id, correlation_id=correlation_id
+    ):
+        out = compiled.invoke(
+            {"claim_id": "c1", "raw_claim_text": "bati o carro"},
+            config=config,
+            context=context,
+        )
+        assert "__interrupt__" in out
+        compiled.invoke(Command(resume=APPROVE), config=config, context=context)
+
+
+def _attributes(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+# ---- the switch --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tracing_is_active_only_when_flagged_and_credentialed() -> None:
+    assert _observability().tracing_active is True
+    assert _observability(tracing_enabled=False).tracing_active is False
+    assert _observability(public_key="").tracing_active is False
+    assert _observability(secret_key="").tracing_active is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "settings",
+    [
+        _observability(tracing_enabled=False),
+        _observability(public_key=""),
+        _observability(secret_key=""),
+    ],
+    ids=["flag-off", "no-public-key", "no-secret-key"],
+)
+def test_build_tracer_returns_the_no_op_when_tracing_is_off(
+    settings: ObservabilitySettings,
+) -> None:
+    tracer = build_tracer(observability=settings, llm=_llm_settings())
+
+    assert isinstance(tracer, NullTracer)
+    # The point of the switch: no client, so no exporter thread and no keys read.
+    assert tracer.callbacks() == []
+
+
+@pytest.mark.unit
+def test_build_tracer_returns_a_langfuse_tracer_when_configured() -> None:
+    tracer = build_tracer(
+        observability=_observability(),
+        llm=_llm_settings(),
+        span_exporter=InMemorySpanExporter(),
+    )
+
+    # Built against an unreachable host: the price registration and trace-URL
+    # lookup both fail, and neither is allowed to stop tracing coming up.
+    assert isinstance(tracer, LangfuseTracer)
+    tracer.shutdown()
+
+
+# ---- the no-op ---------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_the_null_tracer_does_nothing_and_raises_nothing() -> None:
+    tracer = NullTracer()
+
+    assert tracer.callbacks() == []
+    with tracer.assessment_run(assessment_id="a", correlation_id="c"):
+        pass
+    with tracer.span("retrieval", input={"query": "x"}) as traced:
+        traced["n"] = 1
+    tracer.shutdown()
+
+
+@pytest.mark.unit
+def test_a_broken_tracer_does_not_break_the_body_it_wraps() -> None:
+    """The load-bearing guarantee: observability failure is never a run failure."""
+
+    class _ExplodingClient:
+        def __getattr__(self, name: str) -> object:
+            raise RuntimeError(f"langfuse is down ({name})")
+
+    tracer = LangfuseTracer(cast(Langfuse, _ExplodingClient()), public_key="pk")
+
+    ran = []
+    with tracer.assessment_run(assessment_id="a", correlation_id="c"):
+        with tracer.span("retrieval", input={}) as traced:
+            traced["n"] = 1
+            ran.append("body")
+
+    # Both context managers swallowed the failure and ran their body anyway.
+    # (``callbacks()`` is not asserted empty here: the SDK's own handler
+    # constructor does not raise for an unknown key, it warns and no-ops.)
+    assert ran == ["body"]
+
+
+# ---- prices ------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_model_prices_convert_from_per_million_to_per_token() -> None:
+    definitions = model_price_definitions(
+        _llm_settings(
+            fast_input=0.14,
+            fast_output=0.28,
+            reasoning_input=1.1154,
+            reasoning_output=3.3462,
+        )
+    )
+
+    assert [name for name, _, _ in definitions] == [
+        "fake-fast-model",
+        "fake-reasoning-model",
+    ]
+    assert [price for _, price, _ in definitions] == pytest.approx([0.14e-6, 1.1154e-6])
+    assert [price for _, _, price in definitions] == pytest.approx([0.28e-6, 3.3462e-6])
+
+
+@pytest.mark.unit
+def test_registered_prices_cover_reasoning_tokens() -> None:
+    """Reasoning tokens are a third usage key, and they are most of the bill.
+
+    A flat input/output price pair prices only the ``input`` and ``output``
+    keys; a reasoning model reports its thinking under ``output_reasoning``, and
+    a measured compatibility call put 3725 of its ~4000 completion tokens there.
+    Leaving it unpriced understates the run's cost several-fold.
+    """
+    captured: list[dict[str, Any]] = []
+
+    class _FakeModels:
+        def list(self, *, page: int, limit: int) -> Any:
+            return SimpleNamespace(data=[], meta=SimpleNamespace(total_pages=1))
+
+        def upsert(self, model_id: str, **kwargs: Any) -> None:
+            captured.append({"id": model_id, **kwargs})
+
+    client = cast(Langfuse, SimpleNamespace(api=SimpleNamespace(models=_FakeModels())))
+
+    register_model_prices(client, _llm_settings())
+
+    assert [call["model_name"] for call in captured] == [
+        "fake-fast-model",
+        "fake-reasoning-model",
+    ]
+    prices = captured[1]["pricing_tiers"][0].prices
+    assert prices["output_reasoning"] == prices["output"] == pytest.approx(3.3462e-6)
+    assert prices["input"] == pytest.approx(1.1154e-6)
+    # The API rejects flat prices alongside tiers, so only tiers may be sent.
+    assert "input_price" not in captured[1]
+
+
+# ---- the spans a real run produces -------------------------------------
+
+
+@pytest.mark.unit
+def test_every_node_appears_as_a_span() -> None:
+    """[M5-07] DoD: trace every node. Asserted on the real graph's real spans."""
+    tracer, exporter, client = _tracer("pk-lf-nodes")
+    try:
+        _run_traced_graph(tracer)
+    finally:
+        client.flush()
+
+    names = {span.name for span in exporter.get_finished_spans()}
+    assert {
+        "intake",
+        "retrieval",
+        "compatibility",
+        "consistency",
+        "recommendation",
+        "human_review",
+    } <= names
+    client.shutdown()
+
+
+@pytest.mark.unit
+def test_node_spans_carry_their_input_and_output() -> None:
+    tracer, exporter, client = _tracer("pk-lf-io")
+    try:
+        _run_traced_graph(tracer)
+    finally:
+        client.flush()
+
+    recommendation = next(
+        span for span in exporter.get_finished_spans() if span.name == "recommendation"
+    )
+    attributes = _attributes(recommendation)
+    assert "langfuse.observation.input" in attributes
+    assert "recommendation" in str(attributes["langfuse.observation.output"])
+    client.shutdown()
+
+
+@pytest.mark.unit
+def test_the_retrieval_span_carries_the_candidate_list_with_scores() -> None:
+    """[M5-07] DoD: retrieval as a first-class span with candidates and scores."""
+    tracer, exporter, client = _tracer("pk-lf-retrieval")
+    try:
+        _run_traced_graph(tracer)
+    finally:
+        client.flush()
+
+    span = next(s for s in exporter.get_finished_spans() if s.name == "retrieval")
+    attributes = _attributes(span)
+    recorded_input = str(attributes["langfuse.observation.input"])
+    output = str(attributes["langfuse.observation.output"])
+
+    assert '"query": "bati o carro"' in recorded_input
+    assert '"product_line": "CASCO"' in recorded_input
+    assert _STUB_HIT.clause_id in output
+    assert f'"score": {_STUB_HIT.score}' in output
+    # The gate's reasoning, three fields of which reach no other record.
+    assert '"threshold"' in output
+    assert '"sufficient": true' in output
+    client.shutdown()
+
+
+@pytest.mark.unit
+def test_the_trace_is_tagged_with_the_correlation_id() -> None:
+    """[M5-07] DoD: a trace can be reached from a log line."""
+    tracer, exporter, client = _tracer("pk-lf-correlation")
+    try:
+        _run_traced_graph(tracer, correlation_id="corr-m5-07", assessment_id="a-42")
+    finally:
+        client.flush()
+
+    root = next(s for s in exporter.get_finished_spans() if s.name == TRACE_NAME)
+    attributes = _attributes(root)
+
+    assert attributes["langfuse.trace.tags"] == ("corr-m5-07",)
+    assert attributes["langfuse.trace.metadata.correlation_id"] == "corr-m5-07"
+    # Session id groups the run and its post-decision resume as one assessment.
+    assert attributes["session.id"] == "a-42"
+    client.shutdown()
+
+
+@pytest.mark.unit
+def test_an_llm_call_becomes_a_generation_with_token_usage() -> None:
+    """The tokens half of "inputs, outputs, latency, tokens, cost".
+
+    Driven through a real ``BaseChatModel`` rather than the graph's fake, which
+    is a plain runnable and so produces a chain span, not a generation.
+    """
+    tracer, exporter, client = _tracer("pk-lf-usage")
+    reply = AIMessage(
+        content="ok",
+        usage_metadata={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+    )
+    model = GenericFakeChatModel(messages=cycle([reply]))
+
+    model.invoke("oi", config={"callbacks": tracer.callbacks()})
+    client.flush()
+
+    generations = [
+        span
+        for span in exporter.get_finished_spans()
+        if _attributes(span).get("langfuse.observation.type") == "generation"
+    ]
+    assert len(generations) == 1
+    usage = str(_attributes(generations[0])["langfuse.observation.usage_details"])
+    assert '"input": 11' in usage
+    assert '"output": 7' in usage
+    client.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -596,6 +605,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -839,8 +860,10 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
+    { name = "langchain" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
+    { name = "langfuse" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "pgvector" },
@@ -882,8 +905,10 @@ embed = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.19.1" },
     { name = "fastapi", specifier = ">=0.128.0" },
-    { name = "langchain-core", specifier = ">=1.5.5" },
+    { name = "langchain", specifier = ">=1.4,<2" },
+    { name = "langchain-core", specifier = ">=1.6.0" },
     { name = "langchain-openai", specifier = ">=1.5.1" },
+    { name = "langfuse", specifier = ">=4.15,<5" },
     { name = "langgraph", specifier = ">=1.2" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.2" },
     { name = "pgvector", specifier = ">=0.5.0" },
@@ -1159,6 +1184,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/5d/0ef368fdcf5df08a394787196fb7a80f473a9c7b3fc4cd2e3b53a7a5853d/langchain-1.4.0.tar.gz", hash = "sha256:08da122a439f738f4c09a5158cfa3d2c1d8bea2d0bde7fbbf4aeb4d7f7fd9d80", size = 729354, upload-time = "2026-09-03T16:59:32.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/fa/7da07d9977a5e292ef602c1bb911514ff8206e85dc09a66961874345d57a/langchain-1.4.0-py3-none-any.whl", hash = "sha256:af1dc0161d30944a52ec7844d9bf890d0497b12ec0703069f3503b4003cbbac3", size = 161534, upload-time = "2026-09-03T16:59:31.154Z" },
+]
+
+[[package]]
 name = "langchain-anthropic"
 version = "1.5.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.5"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1188,9 +1227,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/c1/c226367fdf92a173c8b520d0b3583a0aaf4c3fe4952010f680e49d88589d/langchain_core-1.5.5.tar.gz", hash = "sha256:c08d78176113867e9a76acc1007d641cd68fa5682e9e0018980d062b4ae0777e", size = 983166, upload-time = "2026-08-14T18:56:24.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/12/aff76ca89c219ebe6f9dd3c5dbc4e3b1cf5450e9fc7037dccad23d45cd7a/langchain_core-1.6.1.tar.gz", hash = "sha256:1b156cb395aac4f009a8a1b38a574c7d948fe2d5f74c96e0d8a5017b4149e04f", size = 1003359, upload-time = "2026-08-27T19:31:14.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/09/9f29e62e99118865d092acda6143a1ba6ce1893e3dcb72388a75b798e37d/langchain_core-1.5.5-py3-none-any.whl", hash = "sha256:537037fd44ead7c1ffb9621011029ad2e347e051519d17f112d7bf7be12f4365", size = 565884, upload-time = "2026-08-14T18:56:23.051Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/f50dd65673c819aa33d3c34df58c115dbb6ec627d19f93e6e401dd0fc8d7/langchain_core-1.6.1-py3-none-any.whl", hash = "sha256:954a84132a5cb0435d27b910e336347b6744ecc18fbeef1e2de7029a0959841a", size = 571478, upload-time = "2026-08-27T19:31:13.34Z" },
 ]
 
 [[package]]
@@ -1218,6 +1257,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/51/ed5569bc2dcc8fe767e3b315207a7511ad23d00d811f02bbf0d6f80bf906/langfuse-4.15.1.tar.gz", hash = "sha256:70cb47529a6ba78383c4f2a197eb3d3ab9d39529c9e6b568d392150c1f40dbb9", size = 432353, upload-time = "2026-08-28T07:55:15.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/f9/7160bafcfe9797575359a9e77f810cf26f57f55a7c5ceda602fd9e353ddf/langfuse-4.15.1-py3-none-any.whl", hash = "sha256:795760693a62895157b6f5d6c80f1ad524fd12380995f06f82fc3a627b88c8d4", size = 789929, upload-time = "2026-08-28T07:55:14.034Z" },
 ]
 
 [[package]]
@@ -1839,6 +1898,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2092,6 +2232,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
 ]
 
 [[package]]
@@ -3648,6 +3803,81 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
     { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
     { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/22/581a0b44349d5babe526c958f365b8126e0fbd8fc2810e80446c47358050/wrapt-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef4e2d6e399ce6eecc80179a6b9ef6544f121288f95fc132bc36c9d9503903af", size = 96374, upload-time = "2026-08-30T04:39:42.335Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95", size = 96178, upload-time = "2026-08-30T04:39:43.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94", size = 227806, upload-time = "2026-08-30T04:39:45.264Z" },
+    { url = "https://files.pythonhosted.org/packages/08/75/c8dfba5e0caf17cd0718a0cbbe76cb85e637a2d65183fb728232419f6fca/wrapt-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39cd68df4dff79f5336f9c745c06259d204bcb42d504040c9c91eac9e2abb39c", size = 229004, upload-time = "2026-08-30T04:39:47.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/05/d4853fbd33e5860b10d5aec690f563547a92a82e61fb8bb2d4ece1ce3570/wrapt-2.4.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2a9f1a2f75bb95257cc5744e255e10a5a86e923f328b40ad3dbf9d8d03430013", size = 208934, upload-time = "2026-08-30T04:39:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/66/23d0e8de9b411fd198af5121627587563657370c8d509fbe5ea8adb3df79/wrapt-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8763ad01e3725b7751a4575f38bbcc19c0aa0822fec91c5c5bd21ce3ce7e1d2b", size = 225709, upload-time = "2026-08-30T04:39:50.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/37/3b357bc90530d510ae59ae7ac48265c482ae899e47637ca4436645688b40/wrapt-2.4.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9125c6dbe8b88c00dd8ef4fc1e55757e8eb4720b6b2b2cc610a45bd32bd28c57", size = 207090, upload-time = "2026-08-30T04:39:51.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0c/d8a5c6dbcc2d221308223bcea4130c6332454a855cb4dbd5dcb2360b13b2/wrapt-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28f5de1526831b8f173889a436e289fe181ede8c66c9feb669d1aca8fd602eaf", size = 216269, upload-time = "2026-08-30T04:39:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/cc9fc8fef1d3d25edaa1c2dc2337b556dc1d0613ddc1c4a6fe9ee08ad705/wrapt-2.4.0-cp312-cp312-win32.whl", hash = "sha256:a9ca1cdb3f7facb4990c7739ea5afbaceeb6728d066feedde03a4cfe83b29b03", size = 91187, upload-time = "2026-08-30T04:39:55.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9", size = 96423, upload-time = "2026-08-30T04:39:56.81Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/e838ac6463a1a1a1817b2f184ee2aa20c54692b80368c5063403c8d2461c/wrapt-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:db1285071ea09a7767fac608e7b5c7b03c09833b06186875a359905fbc659d29", size = 93003, upload-time = "2026-08-30T04:39:58.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/f9de4e11582ff96ad2199eeeceaa17faa27bbdc599243f520070c4f3de07/wrapt-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5c5c4c728cd22a36e4b8bb5df4a7d3bccaa865d27725b36eeb3b6f18fb2e1bc2", size = 96041, upload-time = "2026-08-30T04:39:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ab/1dbf50802bea3b46192fd0dc39bb0eb2e77a064c813b2bbd88d2888ad49f/wrapt-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7de5b8d94417e55c02be50cc226e0ae1209bbc73813bf691dff3979c94438115", size = 96269, upload-time = "2026-08-30T04:40:01.182Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb", size = 225787, upload-time = "2026-08-30T04:40:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f7/d100f6c348b7669f19119cf890dcd4764623e2233af065586d110e0cd99e/wrapt-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e084558fbd112d2e1e34b0f5c71e45a3405bdad51a17150368a959bcf6697964", size = 226649, upload-time = "2026-08-30T04:40:04.647Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/3af8df515d5d7e92306957536f3468c6bdfecbe3659f99dbf09a468c2c4c/wrapt-2.4.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e78c947e18fadfd690c9420c30a96d221feeb93fc8f1cc00509b370ac16c3114", size = 206760, upload-time = "2026-08-30T04:40:06.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/40d355552bd3eb6c5186e26051c19b573d24d7896de42caa7937d6b5ca9f/wrapt-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08d8378c4514ac8dcc0ace76044cf87a873e6a52b5e6109834c8fb9037f4441b", size = 223467, upload-time = "2026-08-30T04:40:07.829Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ab/d198eebdb39f0d7e182e771e590a36673489cd58cebdad8aa273dcf28e04/wrapt-2.4.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:93180c2199784dd6a1075b33f9ed636bd0966821edbece6b3d5379b1c4f0bb7d", size = 205358, upload-time = "2026-08-30T04:40:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0e/974a60672ad507d39a3d8a1c6351ef37fe65b07240d000ceba5d2b83e9e9/wrapt-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d5e5eb76fb87e62752af751d2dcd9d1cd986b12037d2e1363d109ba716029e8", size = 214654, upload-time = "2026-08-30T04:40:10.923Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5a/8b2db70206db0a4246758e0472ce344cb9636217113ef70640fc8d2ce874/wrapt-2.4.0-cp313-cp313-win32.whl", hash = "sha256:49bb5a572469e0e18163a8ec2aa972135a0929899ecbe627665f274506e1b5b4", size = 91171, upload-time = "2026-08-30T04:40:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1e/e782b511c680dbe7369c92e7d981484aacca0cda584da1f28a84cd9a8e1a/wrapt-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:b1737f46b1e4a81eb93500a7f2854319e1c7a86e8863fb050b7b4daadd5a4178", size = 96178, upload-time = "2026-08-30T04:40:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/095ba31123fa5dd482d6183c05200b061314aabbd5442c010aba4b03ff1c/wrapt-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:f1e9e088094f4895f84ab043e7d59401df137d663efbf1e80c82144882960830", size = 92949, upload-time = "2026-08-30T04:40:15.935Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/dd/1f269e4daf0c992f675e1ca2de6b1683b761c6d0aeb6c7b4b412486823ea/wrapt-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:788e473d1a6786d29d577b1e2bd95e214c09cdafde84907c522c31069c9acfac", size = 96386, upload-time = "2026-08-30T04:40:17.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/7ecef06d33c0121c68d66a8a695efe67ebaa57218c1c61c585eca2a6117a/wrapt-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:947bd4b3438167b3638bf5477cb83a068a586ffb6d331ac427f39839c2b93b3c", size = 96532, upload-time = "2026-08-30T04:40:19.116Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e3/8fdc9eba0e6cbbfe8303e1e807d734691309a27970b2ea458d099f1a46b0/wrapt-2.4.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3a69161cae7f0dca44c89c1d14146b4a0508a0c3cad98b3f2db1f4e9016c94ba", size = 228775, upload-time = "2026-08-30T04:40:20.604Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/77/4ac5882abfb29bf9821c5fa5cf9f30241a194e0f47faa2682b9b29765278/wrapt-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0536f5d85ff6a157ebe7e0fe08c5479943742cf1ce59569075a66159efcbc495", size = 229029, upload-time = "2026-08-30T04:40:22.186Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c5/8a3608311a02faf3e5c072da38d06a7c623150fc258e29f18fe377d91703/wrapt-2.4.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f041ed6a4d571010944bd6cfad9072db463e1851877b6d3227467a44af37456", size = 210436, upload-time = "2026-08-30T04:40:23.953Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/e0cbc43f435fd39df25460e9f173e7b96f3dac5c7f66be41c7227166f021/wrapt-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7fed45dbadf5d98a52bfff9624d3cca00affeb9543d493c9632b7a53cdd35c9", size = 226586, upload-time = "2026-08-30T04:40:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6c/7e5f2143228635ec139ef6df733dc477049f7d96a0c49deb23944a73ed6a/wrapt-2.4.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cc2e7c7b6032e11a2b367a9baadaf0c5241feff2d8205260d87f1aa6dbdf84b", size = 208880, upload-time = "2026-08-30T04:40:27.128Z" },
+    { url = "https://files.pythonhosted.org/packages/10/16/1de84402bb7a0916e10739bf6586e031244172b299e87c8cff2a04baf9ff/wrapt-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:72826910a1cf5a081234720fd43011304b899acfee219af49148155b4d795533", size = 216689, upload-time = "2026-08-30T04:40:28.844Z" },
+    { url = "https://files.pythonhosted.org/packages/20/19/cd6bd5050381a541b44be97c4e0994eed60c5f439f4314f95eb5777d6c1a/wrapt-2.4.0-cp314-cp314-win32.whl", hash = "sha256:0eca69c9e93518240abe8801fb9b2726116a6e48172e4564c2651a2e14521747", size = 91581, upload-time = "2026-08-30T04:40:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f8/b642f3184619adde676ad449030bcbeae6cc78ea07a92f0b5fddeec4c4e6/wrapt-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:63b94f401d7ae3a9a3027472fd3a3ff38afd2ed293b2f0b3b84a6d133a9f99a3", size = 96510, upload-time = "2026-08-30T04:40:32.1Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3b/3415a18b91221261eeac85bf8ee23dfb0e2a39d76b9703a797efca177439/wrapt-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:6b3e082d43f592fcd381aee46354a11ce887a813ce5bbcedd9766fd681723c09", size = 93648, upload-time = "2026-08-30T04:40:33.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/90/80cf6a09e9599a11249775928df9bb790b82471e4312b847a861ffb2c2ed/wrapt-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09064c7be688c38c3ff125ce86bc26b69b5d78dd56062c3ddd9c814b2a25f1e1", size = 99615, upload-time = "2026-08-30T04:40:35.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/da/c1d3245abb911a42584f8f7e9781995bdc41345c7affba75cf7e376c85ac/wrapt-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4f8ddff4bbb75916be36da5169b8b9d475b59a1bd24acdb7551bb2c71be9aaac", size = 100031, upload-time = "2026-08-30T04:40:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/84/46/8ec4941d0abbb010df7caf0a34840ca0128177389843b0f5ef2f9ee48ac5/wrapt-2.4.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f8017443595870aa31f46125553a5c55ce95a26a267b96261baee6ba566d83", size = 269389, upload-time = "2026-08-30T04:40:38.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b5/a0ae1b431cc1f49a545d32b8b678a5788c50583ecf0ecb85dc0c7f95b4f6/wrapt-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:328eb2d978ca3a6ae25f8d8fe560bf8f4bc9778b5932e7b142664eef05b92e8f", size = 281081, upload-time = "2026-08-30T04:40:40.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/24/dfaf53dd3bdb0703524a9367b48e2a64ea86433fcc854b5f14be6a8e0e39/wrapt-2.4.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7a057d376d994da6bd1bbf955ecfda699aa7353826f98847f5605e1801abdfd4", size = 249637, upload-time = "2026-08-30T04:40:41.657Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/bdd82044d7503c2bfa78afcc89881f82a1b82b5d2013aabab853d339ce2a/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3367a5212212c9393e0d3ca6ae029b3a8fa40c5896e4a985d43fe8a4b8322f0d", size = 275322, upload-time = "2026-08-30T04:40:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/82/04f4228eb3fb348d660dd1ea7225e53665b1809df2273ff4861d4d33b741/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c4fca1e63af6675af3df7cdfcd5a0c878b5e655c7e48611ced9dc8d62183a11d", size = 247292, upload-time = "2026-08-30T04:40:45.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/67b2968fa9200458446c51b36a435adb6906083428b70fafb4caf92d4dc2/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:694005fdc3002ade0f21641408c588028abde03c85961f3ba7727d8bead3ed6b", size = 264586, upload-time = "2026-08-30T04:40:47.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/0db9ba03e08a7663f52455e95520c723f567bc037bffc6699950fcc456c4/wrapt-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:332d9bad7e9b718974bb2a576504c4956f45b4a0fcd7b3bb7827279167550464", size = 93752, upload-time = "2026-08-30T04:40:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/87/ced171220935c696b157207385fa6be5675558a74655479f071d95a00f1d/wrapt-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d57264c9dfcf37d2bf0b0fbec68d0f6184fc5617267619ada04d03e8b0231f3", size = 99890, upload-time = "2026-08-30T04:40:50.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/af/4a10c9a6d3b7ae41f830978c28d33a59ceb29537bd6875d2abfe78db4b41/wrapt-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f43af38a642c3d6062e9740d8f5cc0feb5dbe0da516702df892147393b8cb14d", size = 96033, upload-time = "2026-08-30T04:40:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/df/3a0b6225ab88bd47090df70391c059a3308057638f8fc0ae32e8ac9d1886/wrapt-2.4.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:430fde1a116df3ceb5c29035de1da6609b70e680d9b8ce3ee624422f3fe0978c", size = 96389, upload-time = "2026-08-30T04:40:53.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6f/803b0d0e14de11781f0e938e6f7d6e29e79652139fe70d7513460357ac78/wrapt-2.4.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7d28f8f35a02d49f75f57fa4e755db4ba33f65841c0de64cd65b253916f5bf06", size = 96557, upload-time = "2026-08-30T04:40:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e8/46571e1218d0494604a7aadc4c898c738c4b179052327ee1e57e278cebd6/wrapt-2.4.0-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efd9a4be6785295e471f71efdf5682bd11d5b822b9665e6e1b4844917cf2f7ac", size = 229230, upload-time = "2026-08-30T04:40:56.703Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2e/0cab15fcaec56096a5734feace3620bc01edc885653be04bd756f84a6784/wrapt-2.4.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75529a2fb569a671cf162f762c1b576f569f571b55ec7f3481258ca842ba507f", size = 229444, upload-time = "2026-08-30T04:40:58.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/a92c049371a2675f98a0381ab2951f984866d1ba4de0e0771d6a31fdaa2b/wrapt-2.4.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66e7512c0d324cc37bba1def2be1fc365cbb685d3aa393a8f6f4d2d00202881d", size = 212482, upload-time = "2026-08-30T04:41:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3b/8b5b57d0ff24edcd3421dbaeb4e94c89be3616824e47708f4e13f25ae3d7/wrapt-2.4.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:5f3bdfc35c83b562fcaebc0f24593045e5ed9f3b633adafd35222718a0ec38fa", size = 227017, upload-time = "2026-08-30T04:41:01.918Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/20/124b40bfd9585848db5a5aa6741d0c8dbf378dd995c6c2d95f090d9cf540/wrapt-2.4.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:d5f45bead708e2c0014be5e98531ce7202916b098a208c7be83c6ceb0a2559fa", size = 210498, upload-time = "2026-08-30T04:41:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/89db9d5a80a9f2af52b24bdfdb5392be80bc0f0fd39fc39d1aab72afd0bd/wrapt-2.4.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:d294576fddac636589e4deccfe782e8f429da10f167c1985c4d51071de3672b7", size = 217046, upload-time = "2026-08-30T04:41:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/0b/021c9d6ce64c639894bffdaa7a895ddd4187abfefb2873ce55e536cd9d56/wrapt-2.4.0-cp315-cp315-win32.whl", hash = "sha256:0191d717dfbb8e519e7bfd4775e5b9bd57e359b3a09ab5db1ea47f6025b4d845", size = 91591, upload-time = "2026-08-30T04:41:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d3/6ebd944041cea0ac4a108a4739510ed2dc891a3f3216e4f7bf0650f5b5a6/wrapt-2.4.0-cp315-cp315-win_amd64.whl", hash = "sha256:e8df31a126a0a247c1aa379e30873839de03912dea09ca360c680f3625d815df", size = 96517, upload-time = "2026-08-30T04:41:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/7c5e52e450f80ba76fd0282dccf7c79cd004ebd8ccabd0903064d3d2c56e/wrapt-2.4.0-cp315-cp315-win_arm64.whl", hash = "sha256:e9e7e94472f0e3f1447caf27e1939eb384d0e87972a35a05f5c2e0968e9c01af", size = 93652, upload-time = "2026-08-30T04:41:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/35/89/f08ff45d7646de29750932805cc3b1e86b6ac3128015b293ed45fa8efe86/wrapt-2.4.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:8828369b7d3e93c547cc8ad931b5a57b4e8d174035c82762fb1091e7d05ac9f5", size = 99610, upload-time = "2026-08-30T04:41:11.933Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c2/f9a3c40901a36c6bb7ecaff8e1e54af78fa7fa0b95a0e54d13d3a24c8a0a/wrapt-2.4.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:413e757dce7a43fcda8bb8441994b1127492ffac6a5803af777d44516df8c6e2", size = 100064, upload-time = "2026-08-30T04:41:13.492Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/e2437f17f2a1ec292056e2fcafe1248269ebc39502f2ffe79424bf86f8a6/wrapt-2.4.0-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:75944792cf6b99262d649d55710bf5901f7013fbb212c7a1d736b97a20517607", size = 269421, upload-time = "2026-08-30T04:41:15.238Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d0/c98d6548dc4c7d12ab9baa192234ca1a57e141afd283252b448faddbd9ef/wrapt-2.4.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:648d1d4f94e8a0a1656675c755f40d2f0ee5fe92c449ab45326f4ecc2738cbe8", size = 281452, upload-time = "2026-08-30T04:41:16.939Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/57/673168e00aa03725148ce621ed201b75df4e787a57acd48fecefd2725600/wrapt-2.4.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a112a1bfdd2621e4344cb0a32dbaab80636b32dac1b055d03fbb2a67d806d1db", size = 250358, upload-time = "2026-08-30T04:41:18.716Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0b/f2e576de5bf53ef5b578470104ea93f33e273a704c825131bc1719fffc42/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0972cd025f4c86fa2d8abd953d9f875779935343af58b4ce019ff89573fc65bd", size = 275654, upload-time = "2026-08-30T04:41:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/9347b2e236346b1ba4cb28b82b205b8a377bb2da9417cb81bbe3d25816d7/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:c246aaed719dcdb62eeb7b8d9306a6237777226ef3baad35919c4ae134c91ce7", size = 248662, upload-time = "2026-08-30T04:41:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/36/3b84d9e1ac8393bf2c94272760a2d361dc394ac30301e6d6dbd6583ade2d/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:1656de3835f760781c9b974bce07d8c04edb9c9ad7ad67264aee69cd68a1db09", size = 264813, upload-time = "2026-08-30T04:41:24.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a2/de7b1de1702667b4a048318e301e26887268c17b07c8b9797cea06b10aee/wrapt-2.4.0-cp315-cp315t-win32.whl", hash = "sha256:d8e6e1e5dc684dfce7c33fc8b67a08ba2af94f3a45cfc70d5c1d6a839d2caf97", size = 93753, upload-time = "2026-08-30T04:41:25.793Z" },
+    { url = "https://files.pythonhosted.org/packages/09/50/4e7ef58c4eb058861ceddc0d1f94a6ed87f62e1cb27783c60b2897ef7e58/wrapt-2.4.0-cp315-cp315t-win_amd64.whl", hash = "sha256:85ed3c67fd39e8d9a36c224758cb6f2f4eb277d07ea677930caa0008c18ec002", size = 99888, upload-time = "2026-08-30T04:41:27.305Z" },
+    { url = "https://files.pythonhosted.org/packages/68/64/d15740c763dd0ddea2338ad42e3bd4a84f8702e16083e7ff61674c504a13/wrapt-2.4.0-cp315-cp315t-win_arm64.whl", hash = "sha256:36b56a4fba13b34ed8ff307557325fff215de0a58b5dbaef2c50e4d8aa39dbd1", size = 96039, upload-time = "2026-08-30T04:41:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds distributed tracing across the assessment graph, into a self-hosted Langfuse
that rides along in the Compose stack behind a `tracing` profile.

The whole design is one line in `orchestrator._invoke`: LangGraph nodes and the
`chain.invoke(messages)` calls inside them are LangChain runnables, so installing
Langfuse's `CallbackHandler` on the run's `config["callbacks"]` yields a span per
node **and** a generation per LLM call — prompt, completion, model, tokens, cost.
`build.py`, the eight node modules and the [M4-01b] `(state, runtime) -> dict`
convention are untouched. Two spans are hand-written because no LLM call passes
through them: `retrieval` (the node, via a new `TracePort` on `GraphContext`
defaulting to a null object) and `retrieval.rerank` (the rag adapter, via a
restated `SpanRecorder` protocol so `rag` still does not import `graph`).

- **Optional twice over.** `ObservabilitySettings.tracing_active` is
  `TRACING_ENABLED` **and** both keys; inactive, no Langfuse client is built at
  all. The four langfuse services sit behind `profiles: ["tracing"]`, so plain
  `docker compose up -d` is still exactly postgres + redis (verified from a clean
  `down`). Tracing never raises into a run — every SDK call is guarded.
- **Correlation id both ways.** The id tags the trace and sits in its metadata;
  each run logs a `trace.started` line with `trace_id` and a ready-made
  `trace_url`. `session_id` is the assessment id, so a run and its post-decision
  resume group as one session.
- **Cost needed model definitions.** Langfuse knows no OpenRouter model id, so
  every generation would cost `0.00`; prices are registered at startup from the
  four new `LLM_*_COST_PER_1M_TOKENS_USD` settings.

Verified live, not only in tests: a real run of `compatible-007` through
`make serve` + `make worker` reproduced the [M4-10] wrong verdict exactly
(`incompatible` 0.85, expected `compatible`), and the trace diagnosed it — the
SUSEP filter found the right document, but not one coverage clause was retrieved
(nine definitions and one exclusion), and the [M3-07] gate passed by 0.047 on a
*definition*. That walkthrough, with measured latencies and token counts, is the
worked example in `docs/OBSERVABILITY.md`.

Three findings the live run produced that unit tests would not have:

1. **`get_trace_url()` does a blocking HTTP call** for the project id. It was on
   the per-assessment path — a round trip that fails *slowly* exactly when
   Langfuse is down. Now resolved once at startup and formatted locally.
2. **Cost was undercounting ~4x.** A flat `input_price`/`output_price` pair
   prices only the `input` and `output` usage keys, and the reasoning model put
   **3725 of ~4000** completion tokens under `output_reasoning`. Fixed with a
   pricing tier that prices reasoning at the completion rate.
3. **Price registration needed a lookup, not just a stable id.** Model *names*
   are unique per project, so an upsert under our own id is rejected whenever a
   definition exists under a Langfuse-assigned one. Registration now pages the
   project's definitions (~180 built-ins) and updates the id the name actually
   has.

Two deviations worth calling out. `GET /ready` deliberately does **not** check
Langfuse — readiness means "can serve an assessment", and an optional dependency
must not be able to take the service out of rotation. And `langfuse<3` was
unusable: its LangChain handler hard-imports `langchain.schema.*`, removed in
langchain 1.x. The v4 handler works on `langchain_core`, but still does
`import langchain` to read `__version__`, so the `langchain` meta-package is now
a direct dependency (thin — core + langgraph + pydantic) and `langchain-core`
moved 1.5.5 → 1.6.1.

Self-hosting Langfuse v4 is four containers (web, worker, clickhouse, minio),
reusing this stack's Postgres (own database) and Redis (db index 1).

## Related issue

[M5-07]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed)
- [x] Docs updated (`README.md`, `docs/`, or other affected doc)
- [x] Evaluation impact considered — does this change affect parsing,
      retrieval, or evaluation numbers? If so, note it here
- [x] `make check` passes locally

**Tests.** `tests/unit/infrastructure/observability/test_tracing.py` runs the
**real compiled graph** against a real Langfuse client whose span exporter writes
to memory — so CI asserts a span per node, the retrieval span's candidates and
scores, the correlation id on the trace, and that a deliberately broken tracer
still runs the body it wraps, with no server and no credentials. Plus the
`tracing_active` gating matrix, the price arithmetic, and the `output_reasoning`
tier. `tests/unit/infrastructure/graph/test_retrieval.py` covers the retrieval
span's payload against a recording fake port; `test_layer_boundaries.py` adds
`langfuse` / `opentelemetry` to the roots forbidden above infrastructure. No new
integration test: keeping a Langfuse server out of CI is the point of the profile.

**Evaluation impact: none.** The tracer defaults to a no-op everywhere except the
composition root, so every eval script and test builds an untraced orchestrator by
saying nothing, and the graph takes the identical code path either way. No
retrieval, parsing or gate behaviour changed. The `langchain-core` 1.5.5 → 1.6.1
bump was checked against the full suite (1357 unit, 70 integration, all green).
The live run reproducing [M4-10]'s `compatible-007` result exactly is a
re-confirmation of those numbers, not a change to them.

**Docs.** New `docs/OBSERVABILITY.md` (bring-up, span tree, how to read a trace,
the worked example, findings); a `## Tracing` section in `docs/ARCHITECTURE.md`;
a tracing subsection in `README.md`; and `docs/API.md`'s [M5-06] section now
cross-links the log→trace hop.