### PR TITLE
feat(devops): add Docker Compose stack and CI image build (M5-09)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# [M5-09]. Keep the build context to what the image actually needs: app
+# source, scripts, migrations, and the two lockfiles. Everything below is
+# either huge, regenerable, or a secret -- see docs/DEPLOYMENT.md.
+
+.venv/
+.git/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+__pycache__/
+*.pyc
+
+# Data, corpus and eval artifacts. `data/rag/` is the one exception: a small,
+# committed CSV (`lexical_stemming_exceptions.csv`) the lexical retriever
+# reads at startup -- everything else under `data/` is either parsing-only
+# (raw PDFs, OCR/LLM caches -- see Dockerfile's comment on why Tesseract is
+# absent too) or a self-healing on-disk cache (data/cache/embeddings,
+# data/cache/reranker) that starts empty if missing.
+data/cache/
+data/policies/
+data/golden_set/
+data/synthetic_claims/
+data/adversarial_injection/
+data/parsing/
+data/README.md
+build/
+eval/
+dist/
+notebooks/
+docs/clause_tree_checkpoints/
+
+.ai_context/
+.claude/
+.vscode/
+scratch_probe/
+
+# Secrets -- env_file: .env is injected by compose at container *start*,
+# never baked into the image.
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ LOG_LEVEL=
 # local dev lines).
 LOG_FORMAT=json
 
+# Docker Compose application services -- [M5-09]. The `api` container
+# publishes uvicorn on this host port; `worker` has no port (no HTTP surface).
+API_PORT=8000
+
 # Docker Compose reverse proxy
 NGINX_PORT=8080
 PROXY_HEADERS_ENABLED=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,19 @@ jobs:
 
       - name: Apply migrations and run integration tests
         run: make test-integration
+
+  docker-image:
+    name: Build the Docker image
+    runs-on: ubuntu-latest
+
+    # [M5-09]: proves the image the `api` / `worker` Compose services run from
+    # actually builds -- the DoD's "image built" clause. Not pushed anywhere;
+    # no registry credentials needed. Its own job for the same reason
+    # `integration` is separate from `quality`: a broken image build should
+    # read as a broken image build, not as a lint failure.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t insurance-claims-assessment:ci .

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,95 @@
+name: Evaluation suite
+
+# [M5-09]. The heavy evaluation suite (`tests/eval/*`, `pytest -m eval`) calls
+# real LLM APIs and needs a fully-indexed corpus, so it stays out of `ci.yml`'s
+# per-PR pipeline (see `ci.yml`'s `quality` job -- it never invokes this).
+# `workflow_dispatch` only, deliberately: a `schedule:` trigger would call the
+# configured LLM key unattended on every run. Trigger it by hand from the
+# Actions tab, or `gh workflow run eval.yml`, whenever you want a fresh
+# reading.
+#
+# Needs, configured once under the repo's Settings -> Secrets and variables ->
+# Actions (I cannot set these for you):
+#   Variables (non-sensitive): LLM_PROVIDER, LLM_BASE_URL, LLM_MODEL_FAST,
+#     LLM_MODEL_REASONING
+#   Secrets: LLM_API_KEY
+# Without them this run fails at the eval step -- same as running
+# `make test-eval` locally with no LLM_* in .env.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  eval:
+    name: Heavy evaluation suite (real LLM calls)
+    runs-on: ubuntu-latest
+
+    # Same service-container shape as ci.yml's `integration` job, own database
+    # so a stray failure here never touches that job's fixtures.
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.6-pg17-bookworm
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: insurance_claims_eval
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d insurance_claims_eval"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/insurance_claims_eval
+      REDIS_URL: redis://127.0.0.1:6379/0
+      LLM_PROVIDER: ${{ vars.LLM_PROVIDER }}
+      LLM_BASE_URL: ${{ vars.LLM_BASE_URL }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_MODEL_FAST: ${{ vars.LLM_MODEL_FAST }}
+      LLM_MODEL_REASONING: ${{ vars.LLM_MODEL_REASONING }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Install dependencies (incl. the embed group)
+        run: uv sync --locked --group embed
+
+      # [M5-09]'s demo-mode shortcut: skips the LLM-cost parse stage and, once
+      # the m3-embedding-cache-v1 release exists, the ~41min cold embed too.
+      # Until that release is published this falls through to a real cold
+      # embed inside build-index below -- functionally correct either way.
+      - name: Fetch demo artifacts (parsed corpus + embedding cache)
+        run: make fetch-demo-artifacts
+
+      - name: Apply migrations
+        run: make migrate
+
+      - name: Set up the LangGraph checkpointer
+        run: make setup-checkpointer
+
+      - name: Build the retrieval index
+        run: make build-index
+
+      - name: Run the heavy evaluation suite
+        run: make test-eval

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# [M5-09]. One image for both the `api` and `worker` Compose services -- they
+# share the same composition root (infrastructure.bootstrap.build_core_components)
+# and therefore the same dependency set; `worker` just overrides `command:` to
+# run scripts.run_assessment_worker instead of uvicorn. See docs/DEPLOYMENT.md.
+#
+# Tesseract / the OCR path are deliberately NOT installed here: they belong to
+# the offline parsing pipeline (`make parse`), which never runs inside these
+# containers -- the graph reads an already-populated Postgres, not raw PDFs.
+
+FROM python:3.12-slim AS builder
+
+# build-essential: some of the `embed` group's transitive C-extension deps
+# (torch/transformers) may need to build from source depending on the
+# resolved wheel for the target platform.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned to the same uv release this project is developed with (`uv --version`).
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+# Dependencies first, so an app-code-only change doesn't invalidate this layer.
+# `embed` is the optional group that carries sentence-transformers/transformers
+# (torch) -- required at runtime because the retrieval stack loads the
+# embedder and cross-encoder in-process (docs/EMBEDDINGS.md, docs/RERANKING.md).
+# `--no-default-groups` drops `dev` (ruff/mypy/pytest/...), which the running
+# service never needs.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-install-project --no-default-groups --group embed
+
+COPY app/src ./app/src
+COPY scripts ./scripts
+COPY alembic ./alembic
+COPY alembic.ini ./
+# The one runtime dependency under data/: a small, committed CSV the lexical
+# retriever's stemmer reads at startup (docs/LEXICAL_RETRIEVAL.md). Everything
+# else under data/ is parsing-only or a self-healing cache -- see .dockerignore.
+COPY data/rag ./data/rag
+RUN uv sync --locked --no-default-groups --group embed
+
+FROM python:3.12-slim AS runtime
+
+# curl: the `api` healthcheck. procps (pgrep): the `worker` healthcheck --
+# it has no HTTP surface, so liveness is "the process is running".
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app /app
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONPATH="/app/app/src" \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+# `worker` overrides this in compose.yaml.
+CMD ["uvicorn", "presentation.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Add Makefile targets: install, lint, format, format-check, typecheck, test, test-integration, check.
 
-.PHONY: install lint format format-check typecheck test test-integration test-eval check serve worker migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end eval-prompt-injection eval-prompt-injection-classifier validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
+.PHONY: install lint format format-check typecheck test test-integration test-eval check serve worker migrate migrate-down setup-checkpointer extract-text remove-boilerplate build-clause-tree parse build-chunks check-embedding-input-length load-chunks embed-chunks build-index benchmark-ann-index benchmark-ann-index-real sample-parsing-quality validate-parsing-quality-sample score-parsing-quality escalate-vision-boundaries fetch-corpus-artifacts package-corpus-artifacts fetch-embedding-cache package-embedding-cache fetch-demo-artifacts validate-golden-set draft-golden-questions-casco repair-golden-questions-casco finalize-golden-set-casco draft-golden-questions-adversarial repair-golden-questions-adversarial finalize-golden-set-adversarial draft-synthetic-claims finalize-synthetic-claims validate-synthetic-claims draft-product-claim-mismatch finalize-product-claim-mismatch validate-product-claim-mismatch draft-unanswerable-questions finalize-unanswerable-questions eval-retrieval eval-retrieval-lexical eval-retrieval-dense eval-retrieval-hybrid eval-retrieval-rerank eval-retrieval-co-retrieval eval-retrieval-matrix eval-insufficient-context-gate eval-intake eval-clarification eval-retrieval-node eval-compatibility eval-consistency eval-parallel-assessment eval-recommendation eval-end-to-end eval-prompt-injection eval-prompt-injection-classifier validate-citation-coverage tune-reranking tune-exclusion-co-retrieval review-golden-set-sample
 
 help:
 	@echo "Available targets:"
@@ -35,6 +35,9 @@ help:
 	@echo "  escalate-vision-boundaries - M1-04d: vision-LLM boundary review of suspicious clauses (opt-in, not part of parse)"
 	@echo "  fetch-corpus-artifacts - Download the pre-computed corpus/LLM caches instead of running make parse"
 	@echo "  package-corpus-artifacts - Maintainer-only: build the release tarball fetch-corpus-artifacts downloads"
+	@echo "  fetch-embedding-cache - M5-09: download the pre-computed embedding cache instead of paying the ~41min cold make embed-chunks pass"
+	@echo "  package-embedding-cache - M5-09: maintainer-only: build the release tarball fetch-embedding-cache downloads"
+	@echo "  fetch-demo-artifacts - M5-09: fetch-corpus-artifacts + fetch-embedding-cache in one step -- the demo-mode shortcut, see README's Quickstart"
 	@echo "  validate-golden-set - Validate data/golden_set/*.jsonl against the schema and the parsed corpus"
 	@echo "  draft-golden-questions-casco - M2-02: draft candidate golden questions over the 15 CASCO documents into eval/golden_set_draft_casco.csv for review (overwrites that file; use repair- once rows are finalized)"
 	@echo "  repair-golden-questions-casco - M2-02: re-draft/complete the CASCO draft using the author's review verdicts (requires REVIEW=<csv>)"
@@ -173,6 +176,17 @@ fetch-corpus-artifacts:
 
 package-corpus-artifacts:
 	PYTHONPATH=app/src uv run python scripts/package_corpus_artifacts.py
+
+fetch-embedding-cache:
+	PYTHONPATH=app/src uv run python scripts/fetch_embedding_cache.py
+
+package-embedding-cache:
+	PYTHONPATH=app/src uv run python scripts/package_embedding_cache.py
+
+# M5-09: the demo-mode shortcut -- skips both cost-bearing pipeline stages
+# (LLM parsing, then embedding) in one command. See README's Quickstart.
+fetch-demo-artifacts: fetch-corpus-artifacts fetch-embedding-cache
+	@echo "fetch-demo-artifacts: corpus + LLM caches + embedding cache in place. 'make build-index' is now a cache-hit replay, not a cold run."
 
 validate-golden-set:
 	PYTHONPATH=app/src uv run python scripts/validate_golden_set.py

--- a/README.md
+++ b/README.md
@@ -10,6 +10,56 @@ inconsistent with the conditions of a registered insurance product — it
 cannot say whether a real claim is covered or denied. See
 [`docs/SCOPE.md`](docs/SCOPE.md) for the full statement.
 
+## Quickstart
+
+The literal, followable path from a clean clone to a running assessment,
+entirely through Docker Compose — [M5-09]. Design rationale for the stack
+is in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+
+```bash
+cp .env.example .env
+# fill in LLM_PROVIDER / LLM_BASE_URL / LLM_API_KEY / LLM_MODEL_FAST /
+# LLM_MODEL_REASONING -- the rest of .env.example's defaults already match
+# the Compose services below.
+
+docker compose up -d postgres redis   # infra first -- api/worker need data in place before they can start
+make fetch-corpus-artifacts           # skip the LLM-cost parsing stage (~10MB download)
+make build-index                      # chunk -> Postgres -> embeddings against the running stack
+docker compose up -d --build          # migrate, api, worker -- each healthchecked
+```
+
+`api`/`worker` read `build/chunks.jsonl` (the lexical retriever's BM25 index
+and the exclusion-clause graph, `docs/DEPLOYMENT.md`) at startup, which is
+why `make build-index` runs before the full `up`: starting `api`/`worker`
+before it exists just crash-loops them on a clear "file not found" error.
+The second `docker compose up -d --build` runs `migrate` once (schema +
+checkpointer setup) then starts `api` (`curl localhost:${API_PORT:-8000}/health`
+→ `200`) and `worker`. `make build-index`'s embedding step is a real,
+one-time ~41-minute CPU pass the first time it runs — $0 in API cost, since
+the embedder runs locally, but real wall-clock time (`docs/EMBEDDINGS.md`).
+**Skipping that too:** `make fetch-embedding-cache` (or `make
+fetch-demo-artifacts` in place of `fetch-corpus-artifacts` above, for both
+fetches in one step) downloads a pre-computed embedding cache so the same
+`make build-index` re-fills every vector in seconds instead — once the
+maintainer has published that release (see `docs/DEPLOYMENT.md`'s "What
+this issue ships, and what it deliberately doesn't (yet)"); until then it's
+equivalent to the corpus-only fetch above.
+
+```bash
+curl -s -X POST localhost:${API_PORT:-8000}/v1/assessments \
+  -H 'Content-Type: application/json' \
+  -d '{"raw_text": "Bati o carro na traseira de outro veículo ao tentar estacionar."}'
+# -> 202, {"assessment_id": "<id>", "status": "pending"}
+
+curl -s localhost:${API_PORT:-8000}/v1/assessments/<id>
+# -> status moves pending -> running -> awaiting_review, with the
+# recommendation and its citations once ready
+```
+
+Endpoint shapes, the human-decision step and the audit trail are in
+[`docs/API.md`](docs/API.md). `docker compose --profile tracing up -d` adds
+the self-hosted Langfuse stack alongside the above — see "Tracing" below.
+
 ## Fast start: inspect the parsed corpus without running the pipeline
 
 The full M1 parsing pipeline (OCR, LLM clause classification, the vision-LLM
@@ -54,13 +104,17 @@ cp .env.example .env
 
 ### Database (Postgres + pgvector) and Redis
 
-Postgres is required by the retrieval index, the LangGraph checkpointer and
-the audit trail; Redis backs the asynchronous assessment queue ([M5-05]).
-Bring both up locally, in this order, on a clean clone:
+This is the bare-metal dev loop -- infra in containers, `make serve` /
+`make worker` on the host for hot reload. (For the fully containerized stack,
+including `api` / `worker` themselves, see the Quickstart above; don't run
+both at once against the same ports.) Postgres is required by the retrieval
+index, the LangGraph checkpointer and the audit trail; Redis backs the
+asynchronous assessment queue ([M5-05]). Bring both up locally, in this
+order, on a clean clone:
 
 ```bash
 cp .env.example .env
-docker compose up -d          # postgres + redis
+docker compose up -d postgres redis   # infra only -- not migrate/api/worker
 make migrate
 make setup-checkpointer
 ```
@@ -119,7 +173,9 @@ Score every retrieval configuration on the golden set with
 
 ### Run the assessment API and the worker
 
-Once the schema, the checkpointer and the index are in place:
+Once the schema, the checkpointer and the index are in place (bare-metal dev
+loop -- see the note above; skip this if you're already running the
+containerized `api` / `worker` from the Quickstart):
 
 ```bash
 make serve           # the API: uvicorn presentation.app:app on :8000
@@ -133,8 +189,9 @@ recommendation. `POST /v1/assessments/{id}/decision` submits the human decision
 and resumes the run; `GET /v1/assessments/{id}/audit` returns the audit trail.
 Endpoint shapes and error codes are in [`docs/API.md`](docs/API.md); the queue,
 the retry/back-off policy and the dead-letter path are in
-[`docs/ASYNC_PROCESSING.md`](docs/ASYNC_PROCESSING.md). The `api` / `worker`
-Compose services (and their Dockerfile) are [M5-09].
+[`docs/ASYNC_PROCESSING.md`](docs/ASYNC_PROCESSING.md). `api` and `worker` also
+run as Compose services from the same Dockerfile — see the Quickstart above
+and [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) [M5-09].
 
 ### Tracing (optional)
 
@@ -149,12 +206,15 @@ docker compose --profile tracing up -d    # + langfuse-web, langfuse-worker, cli
 open http://localhost:3000                # sign in with LANGFUSE_INIT_USER_*
 ```
 
-The project is seeded on first boot with the `LANGFUSE_PUBLIC_KEY` /
-`LANGFUSE_SECRET_KEY` already in your `.env`, so there is no key-copying step.
-Tracing is off unless both keys are set and `TRACING_ENABLED` is not `false`,
-and plain `docker compose up -d` still starts only postgres + redis — the
-service runs identically with none of this. Reading a trace, and a worked
-example of diagnosing a wrong verdict, are in
+This also brings up `migrate` / `api` / `worker` alongside the tracing
+services (they have no profile, so any `up` starts them) — if you're running
+the bare-metal `make serve` / `make worker` instead, stop them first to avoid
+a port clash. The project is seeded on first boot with the
+`LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` already in your `.env`, so
+there is no key-copying step. Tracing is off unless both keys are set and
+`TRACING_ENABLED` is not `false`, and the plain `docker compose up -d` from
+the Quickstart runs identically with none of this. Reading a trace, and a
+worked example of diagnosing a wrong verdict, are in
 [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
 
 ### Prompt-injection classifier (optional)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,17 @@
-# Local infrastructure for development and integration tests.
+# Local infrastructure for development, integration tests, and the full
+# containerised assessment stack.
 #
 # [M0-08] brought up the database. [M5-05] adds `redis` -- the asynchronous
 # assessment queue (`make worker`) needs it, and so does `make test-integration`.
-# [M5-07] adds the self-hosted Langfuse stack behind the `tracing` profile, so
-# `docker compose up -d` is still just postgres + redis and
-# `docker compose --profile tracing up -d` is the traced stack. [M5-09] still
-# adds the `api` / `worker` services (once there is a Dockerfile to run them
-# from). Every block reads its configuration from the same `${...}` variables
-# those services will, so they are appended, not rewritten.
+# [M5-07] adds the self-hosted Langfuse stack behind the `tracing` profile:
+# `docker compose --profile tracing up -d` is the traced stack, a plain `up`
+# never starts it. [M5-09] adds `migrate` / `api` / `worker` -- one shared
+# image (the repo's `Dockerfile`), reused via the `&app-build` /
+# `&app-environment` anchors below -- so a plain `docker compose up -d --build`
+# now starts the full assessment stack (postgres, redis, migrate, api,
+# worker); see README's Quickstart for the step order `api`/`worker` need.
+# Every block reads its configuration from the same `${...}` variables those
+# services also read, so they are appended, not rewritten.
 services:
   postgres:
     # Postgres major and pgvector version are both explicit: the floating
@@ -50,6 +54,91 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+
+  # ---------------------------------------------------------------------------
+  # Assessment service -- [M5-09]. `api` and `worker` share one image (this
+  # repo's Dockerfile) and one environment shape; `migrate` uses the same
+  # image to apply Alembic and the LangGraph checkpointer's own setup once,
+  # before either starts -- `build_core_components()` probes the checkpointer
+  # at API startup and errors on a missing schema, so `depends_on: postgres
+  # (healthy)` alone is not enough ordering. All three load `.env` directly
+  # (`env_file`) and override only the keys that mean something different
+  # from inside the compose network than from the host: `postgres`/`redis`
+  # instead of `localhost`, and the in-network Langfuse hostname (inert
+  # unless the `tracing` profile is also up). See docs/DEPLOYMENT.md.
+  # ---------------------------------------------------------------------------
+  migrate:
+    build: &app-build
+      context: .
+      dockerfile: Dockerfile
+    image: insurance-claims-assessment:local
+    env_file: .env
+    environment: &app-environment
+      DATABASE_HOST: postgres
+      REDIS_URL: redis://redis:6379/0
+      LANGFUSE_HOST: http://langfuse-web:3000
+    command: ["sh", "-c", "alembic upgrade head && python -m scripts.setup_checkpointer"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  api:
+    build: *app-build
+    image: insurance-claims-assessment:local
+    env_file: .env
+    environment: *app-environment
+    ports:
+      - ${API_PORT:-8000}:8000
+    volumes: &app-volumes
+      - hf_cache:/root/.cache/huggingface
+      # `retriever_factory.load_retriever_components()` reads
+      # build/parsed_clauses.jsonl and build/chunks.jsonl directly at startup
+      # (the BM25 lexical leg and the exclusion-clause graph are in-process,
+      # not Postgres -- docs/LEXICAL_RETRIEVAL.md). Bind-mounted, not baked
+      # into the image, so a re-`make build-index` on the host is picked up
+      # by a container restart, no image rebuild. See docs/DEPLOYMENT.md.
+      - ./build:/app/build:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    healthcheck:
+      # Liveness, not `/ready`: `/ready` 503s until the vector index is
+      # populated (`make build-index`), which would otherwise leave a
+      # freshly-started demo stack "unhealthy" forever.
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  worker:
+    build: *app-build
+    image: insurance-claims-assessment:local
+    env_file: .env
+    environment: *app-environment
+    command: ["python", "-m", "scripts.run_assessment_worker"]
+    volumes: *app-volumes
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    healthcheck:
+      # No HTTP surface -- liveness is "the worker pool process is running".
+      test: ["CMD-SHELL", "pgrep -f scripts.run_assessment_worker || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
 
   # ---------------------------------------------------------------------------
   # Tracing -- [M5-07]. `profiles: ["tracing"]` on every service below, so a
@@ -197,6 +286,9 @@ services:
 
 volumes:
   postgres_data:
+  # Persists the ~1.2GB embedder/reranker model download (docs/EMBEDDINGS.md,
+  # docs/RERANKING.md) across `api`/`worker` restarts.
+  hf_cache:
   langfuse_clickhouse_data:
   langfuse_clickhouse_logs:
   langfuse_minio_data:

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,8 +267,10 @@ Redis round-trip — submission → worker → completion, transient retry, dead
 - **[M5-06] done** — `GET /ready` with per-check detail, JSON logs to stdout, and
   correlation-id propagation from the request into every node and LLM call. See
   "Structured logging & correlation IDs" above.
-- **[M5-09]** — the Compose `api` / `worker` services, the Dockerfile, the CI
-  image build, and the proxy-header / trusted-host middleware from
-  `ObservabilitySettings`.
+- **[M5-09] done** — the Compose `api` / `worker` services, the Dockerfile,
+  and the CI image build. See [`DEPLOYMENT.md`](DEPLOYMENT.md). The
+  proxy-header / trusted-host middleware from `ObservabilitySettings` stays
+  unwired — it would matter behind a reverse proxy, and this stack publishes
+  `api` directly with none in front.
 - A pooled checkpointer connection (`docs/DATABASE.md` "the M5 shape") — the
   adapter opens one per `start` / `resume` today.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -882,9 +882,8 @@ run-status states (below). [M5-06] **done** — `/ready` with per-check detail, 
 JSON log line per event to stdout, and a correlation id accepted or minted per
 request and propagated into every graph node log line and LLM call (via
 `presentation/middleware.py`, `infrastructure/observability/`, and the `build.py`
-node wrapper); see `docs/API.md`. [M5-09] adds the Compose `api` / `worker`
-services, the Dockerfile and the CI image build, and wires the proxy-header /
-trusted-host middleware from `ObservabilitySettings`.
+node wrapper); see `docs/API.md`. [M5-09] **done** — the Compose `api` / `worker`
+services and the Dockerfile; see below.
 
 ---
 
@@ -929,7 +928,8 @@ tracking per assessment id". (b) `SubmitClaim` commits the job before enqueueing
 it, so a crash in that window leaves a `PENDING` job that is never picked up — a
 reconciler is left to operations. (c) The checkpointer connection is still
 per-call, not pooled (`docs/DATABASE.md` "the M5 shape"). (d) `compose.yaml`
-gains `redis`; the `api` / `worker` services and the Dockerfile are [M5-09].
+gained `redis` here; the `api` / `worker` services and the Dockerfile
+followed in [M5-09] (`docs/DEPLOYMENT.md`).
 
 **Enforcement.** `tests/unit/application/use_cases/test_run_assessment.py` (the
 state machine), `test_submit_claim.py` (persist-then-enqueue),
@@ -1157,3 +1157,73 @@ network, mirrors `test_cross_encoder_reranker.py`);
 fan-out, the compiled graph's structure);
 `tests/eval/test_prompt_injection_classifier.py` (eval-marked, real model,
 skips without `transformers` installed).
+
+---
+
+## One Compose image for `api` and `worker`, with a one-shot `migrate` service ahead of both — [M5-09]
+
+**Decision.** `compose.yaml` gains `migrate`, `api` and `worker`, all built
+from a new root `Dockerfile`. `api` and `worker` are the same image — they
+share `infrastructure.bootstrap.build_core_components`, so they share the
+same dependency set (including the optional `embed` uv group, needed at
+runtime because both the request path and the queue-worker path load the
+embedder and cross-encoder in-process) — `worker` only overrides `command:`.
+`migrate` runs `alembic upgrade head && python -m scripts.setup_checkpointer`
+once (`restart: "no"`) and `api`/`worker` `depends_on` it completing
+(`condition: service_completed_successfully`), because
+`build_core_components()` probes the checkpointer at API startup and raises
+if its schema is missing — plain `depends_on: postgres (healthy)` is not
+enough ordering. Full rationale, the healthcheck choice (`/health`, not
+`/ready` — Compose has no "healthy but degraded"), and the environment-
+override shape: `docs/DEPLOYMENT.md`.
+
+**Why demo mode extends the existing artifact pattern instead of a new one.**
+The DoD asks that a reviewer not pay `make build-index`'s embedding cost (a
+real ~41-minute CPU pass, `docs/EMBEDDINGS.md`) to try the system.
+`scripts/fetch_corpus_artifacts.py`/`package_corpus_artifacts.py` already
+solve the identical shape of problem one stage earlier (skip the LLM-cost
+parsing stage via a pinned GitHub Release tarball + checksum). The new
+`fetch_embedding_cache.py`/`package_embedding_cache.py` are the same script
+shape, one stage later, bundling `data/cache/embeddings/cache.jsonl` — the
+existing content-addressed cache `CachingEmbedder` already reads before
+loading the model. No new mechanism, no Postgres dump, no vector-index file
+format — the same "download the expensive artifact instead of computing it"
+idea the corpus already established.
+
+**Deviations on record.** (a) The `m3-embedding-cache-v1` release itself is
+not published as part of this change — the fetch/package scripts and Makefile
+targets (`fetch-embedding-cache`, `package-embedding-cache`,
+`fetch-demo-artifacts`) exist and work, but actually paying the ~41-minute
+embedding pass once and running `gh release create` is left as a deliberate
+manual step; until it exists, `make build-index` still works, it just falls
+through to a real cold embed. (b) `PROXY_HEADERS_ENABLED`/
+`FORWARDED_ALLOW_IPS` (`ObservabilitySettings`, already defined since
+[M5-06]) stay unwired — they'd matter behind a reverse proxy, and this
+Compose stack publishes `api` directly with none in front; earlier notes in
+this document and in `docs/API.md`/`docs/ASYNC_PROCESSING.md`/
+`docs/DATABASE.md` anticipating that wiring as part of this issue are
+superseded by this entry. (c) The heavy evaluation suite's on-demand/
+scheduled trigger (`.github/workflows/eval.yml`) is `workflow_dispatch` only
+— no `schedule:` cron, so it never calls the configured LLM key unattended;
+the DoD's "on demand **or** a schedule" is satisfied by the "on demand" half.
+(d) The retrieval stack turned out not to be a pure Postgres client: its
+lexical/BM25 leg and exclusion-clause graph load `build/chunks.jsonl` and
+`build/parsed_clauses.jsonl` off the local filesystem
+(`docs/LEXICAL_RETRIEVAL.md`), and the lexical analyzer needs the committed
+`data/rag/lexical_stemming_exceptions.csv`. Neither was anticipated by the
+original "the graph reads Postgres" framing this entry started with — found
+by actually running `docker compose up -d --build` end-to-end (`api`/
+`worker` crash-looped on both, in turn) rather than by static review. Fixed
+with a read-only bind mount of `./build` (a regenerated artifact — no reason
+to bake a snapshot into the image) and a normal `COPY data/rag` in the
+Dockerfile (committed source, unlike `build/`'s gitignored output). Full
+account: `docs/DEPLOYMENT.md`.
+
+**Enforcement.** `docker build .` and `ci.yml`'s new `docker-image` job (the
+DoD's "image built" clause — `integration` already covered "integration
+tests against Postgres" and "migrations applied", from [M5-05]/[M5-01]-era
+work, before this issue started). `docker compose config` validates every
+YAML anchor resolves. No automated test drives the full containerised stack
+end-to-end (that needs Docker-in-CI plus real LLM credentials); README's
+Quickstart is written to be run and checked by hand against a clean clone,
+which is what this issue's own DoD asks for.

--- a/docs/ASYNC_PROCESSING.md
+++ b/docs/ASYNC_PROCESSING.md
@@ -109,8 +109,9 @@ past them to the job, which backs off for minutes — which is what
   re-enqueues stale `PENDING` jobs is left to operations.
 - **A connection pool for the checkpointer** ("the M5 shape", `docs/DATABASE.md`)
   is still deferred — each `RunAssessment` opens its own.
-- **`api` / `worker` Compose services + the Dockerfile + the CI image** are
-  [M5-09]. M5-05 adds only the `redis` service to `compose.yaml`.
+- **`api` / `worker` Compose services + the Dockerfile + the CI image build**
+  were added in [M5-09] (`docs/DEPLOYMENT.md`); M5-05 added only the `redis`
+  service to `compose.yaml`.
 
 ## Results
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -28,7 +28,8 @@ make setup-checkpointer
 for a reason — see "The checkpointer owns its own schema" below.
 
 `compose.yaml` holds `postgres` and — since [M5-05] — `redis` (the async
-assessment queue). [M5-09] adds `api`, `worker` and `langfuse` to the same file;
+assessment queue), `langfuse` (since [M5-07], behind the `tracing` profile),
+and — since [M5-09] — `migrate` / `api` / `worker` (`docs/DEPLOYMENT.md`);
 every block is written so they are appended rather than requiring a rewrite.
 
 Roll a migration back with `make migrate-down` (one step). Both targets read

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,204 @@
+# Deployment: the Docker Compose stack
+
+How the `api` / `worker` / `migrate` Compose services are built and wired —
+[M5-09]. Step-by-step run instructions live in README's Quickstart; this
+document is the "why", the same split `docs/ASYNC_PROCESSING.md` and
+`docs/OBSERVABILITY.md` use for their own services.
+
+## One image, two containers
+
+`api` and `worker` are built from the same `Dockerfile` and share the same
+composition root (`infrastructure.bootstrap.build_core_components` — the same
+one `presentation/app.py`'s lifespan and `scripts/run_assessment_worker.py`
+both call). They need the same dependency set: the `embed` uv group
+(`sentence-transformers` / `transformers`, which pull in `torch`) is required
+at runtime because the retrieval stack loads the embedder and cross-encoder
+in-process on both the request path and the queue-worker path
+(`docs/EMBEDDINGS.md`, `docs/RERANKING.md`) — there is no "thin" variant of
+either process. `worker` overrides `command:` to run
+`python -m scripts.run_assessment_worker` instead of uvicorn; everything else
+about the image is identical.
+
+Tesseract and the OCR/PDF-parsing dependencies (`pytesseract`, `pymupdf`)
+install as Python packages (they're in `pyproject.toml`'s base dependencies)
+but the Tesseract *binary* is deliberately not installed in the image: OCR
+only runs inside `make parse`, which reads raw PDFs from
+`data/policies/raw/` and never runs inside these containers.
+`.dockerignore` excludes `eval/`, `data/policies/`, `data/cache/`, and the
+dev/VCS caches from the build context for the same reason — none of it is
+needed at runtime.
+
+**The retrieval stack is not purely a Postgres client, though.**
+`retriever_factory.load_retriever_components()` builds the BM25 lexical leg
+and the exclusion-clause graph in-process, straight from
+`build/chunks.jsonl` and `build/parsed_clauses.jsonl`
+(`docs/LEXICAL_RETRIEVAL.md`, `docs/EXCLUSION_CO_RETRIEVAL.md`) — only the
+dense leg queries Postgres. Both files are gitignored, regenerated
+artifacts, so rather than bake a snapshot into the image, `api` and `worker`
+bind-mount the host's `./build` directory read-only. This also means a
+re-`make build-index` on the host (a new corpus, a re-chunk) is picked up by
+a container restart, not an image rebuild. One further runtime dependency
+lives under `data/`: `data/rag/lexical_stemming_exceptions.csv`, a small,
+committed CSV the lexical analyzer's stemmer reads — copied into the image
+directly (it's static source, unlike `build/`'s regenerated artifacts), so
+`.dockerignore` excludes the rest of `data/` but not `data/rag/`.
+`data/cache/embeddings/` and `data/cache/reranker/` are *not* needed at
+startup — both caches degrade gracefully to empty when their file is
+missing.
+
+**This drives the Quickstart's step order.** `load_retriever_components()`
+raises at startup if `build/chunks.jsonl` is missing — by design, the same
+fail-fast-with-a-fix shape as the checkpointer probe below — so `api` /
+`worker` crash-loop until at least `make build-chunks` (fast: pure local
+computation over an already-parsed corpus, no DB, no LLM) has run on the
+host. That's why the Quickstart brings up `postgres`/`redis` alone first,
+runs `make build-index` against them (which both creates `build/chunks.jsonl`
+and loads/embeds the `chunk` table), and only then starts `api`/`worker` —
+starting the whole stack in one `up -d --build` before any of that exists
+would leave `api`/`worker` crash-looping on a missing file, not merely
+degraded.
+
+## Why a one-shot `migrate` service
+
+`build_core_components()` probes the LangGraph checkpointer at API startup
+and raises an actionable error if its schema is missing — by design, so a
+missing `make setup-checkpointer` reads as a startup failure with a fix, not
+a mysterious 500 on the first request (see `presentation/app.py`'s module
+docstring). That means `api` / `worker` cannot simply
+`depends_on: postgres: condition: service_healthy` — the schema has to exist
+first. Compose's `condition: service_completed_successfully` is exactly the
+primitive for a one-off init step, so `migrate` runs
+`alembic upgrade head && python -m scripts.setup_checkpointer` once
+(`restart: "no"`) and `api` / `worker` both depend on it completing before
+they start. All three services share one image and one environment shape via
+the `&app-build` / `&app-environment` YAML anchors, the same reuse pattern
+`compose.yaml` already uses for `langfuse-worker` / `langfuse-web`
+(`&langfuse-service` / `&langfuse-env`).
+
+## Environment: `.env` plus three network-address overrides
+
+`api` / `worker` / `migrate` all use `env_file: .env` rather than
+re-declaring every `LLM_*` / `EMBEDDING_*` / `ASSESSMENT_*` key in
+`compose.yaml` (the way `postgres` does, for example) — the app's own
+`Settings` classes already read the exact variable names `.env` uses, so
+there is nothing to rename. The one wrinkle: three values mean something
+different from *inside* the compose network than from the host, because a
+container reaches `postgres` / `redis` / `langfuse-web` by service name, not
+by `localhost` or a published port. `compose.yaml`'s `environment:` block
+overrides exactly those three keys (`DATABASE_HOST`, `REDIS_URL`,
+`LANGFUSE_HOST`) on top of whatever `.env` sets for host-side tools
+(`make migrate`, `make build-index`, pytest) to use. `LANGFUSE_HOST` is inert
+unless the `tracing` profile is also started and `TRACING_ENABLED=true`.
+
+One caveat this override doesn't cover: if `.env` sets `DATABASE_URL`
+directly (its default is empty — `DATABASE_HOST` and friends are the
+documented local path), `DatabaseSettings` prefers the full URL and the
+`DATABASE_HOST: postgres` override has no effect. That combination — a
+custom `DATABASE_URL` together with the bundled Compose `postgres` — isn't a
+configuration this stack is meant to support; anyone pointing at an external
+database should also point `api` / `worker` there directly.
+
+## Healthchecks
+
+`api`'s healthcheck curls `GET /health` (liveness — "the process is up"),
+deliberately not `GET /ready` (readiness — Postgres/Redis/vector-index,
+[M5-06]). Compose has no notion of "healthy but degraded": a demo stack with
+an empty `chunk` table would leave `/ready` returning 503 indefinitely, and
+Compose would report `api` as permanently unhealthy even though the process
+is fine and the API is answering requests. `/ready` stays available for
+external monitoring and for the reader diagnosing "why is my assessment
+coming back `insufficient_information`" — it's just not what gates the
+container's own health state.
+
+`worker` has no HTTP surface, so its healthcheck is a plain
+`pgrep -f scripts.run_assessment_worker` — "the worker pool process exists".
+`procps` (for `pgrep`) and `curl` (for the `api` check) are the only two
+packages the runtime image adds over `python:3.12-slim`.
+
+## The `hf_cache` volume
+
+`api` and `worker` both mount a named `hf_cache` volume at
+`/root/.cache/huggingface`. The embedder and reranker's combined weights are
+about 1.2GB (`docs/EMBEDDINGS.md`) and download on first use; without a
+persistent volume, every `docker compose restart` (or a `down`/`up` without
+`-v`) would re-download them. This is the same "download once, cache
+forever" shape `data/cache/embeddings/` already gives the host-side
+`make embed-chunks` path — just a Docker volume instead of a bind mount,
+since the container's HF cache and the host's embedding cache are different
+things (model weights vs. computed vectors).
+
+## Demo mode: skipping the embedding cost, not inventing a new mechanism
+
+`make build-index`'s `embed-chunks` step is a real cold ~41-minute CPU pass
+over the full corpus the first time it runs (`docs/EMBEDDINGS.md`'s "Corpus
+embedding cost") — $0 in API charges (the embedder runs in-process, not
+behind an API), but a real wait. `scripts/fetch_corpus_artifacts.py` already
+solves the identical problem one pipeline stage earlier — a GitHub Release
+tarball + checksum that lets a reviewer skip the LLM-cost parsing stage
+entirely. `scripts/fetch_embedding_cache.py` / `package_embedding_cache.py`
+are the exact same shape of script, one release tag later
+(`m3-embedding-cache-v1`), bundling `data/cache/embeddings/cache.jsonl` — the
+content-addressed cache `CachingEmbedder` already reads before ever loading
+the model. With that cache in place, `embed-chunks` re-fills every vector
+from disk in ~2.6 seconds instead of running the model at all. `make
+fetch-demo-artifacts` runs both fetches (corpus + embedding cache) in one
+step; README's Quickstart uses it.
+
+**What this issue ships, and what it deliberately doesn't (yet).** The
+fetch/package scripts and Makefile targets exist and are ready to use; the
+`m3-embedding-cache-v1` release itself is not published as part of this
+change — publishing it means actually paying the ~41-minute embedding pass
+once and running `gh release create` under a real GitHub identity, which
+stays a deliberate manual step for whoever maintains the repo, not something
+this change does on its own initiative. Until that release exists,
+`fetch-embedding-cache` (and therefore `fetch-demo-artifacts`) fails with a
+clear "has this release been published?" error, and `make build-index` still
+works correctly — it just falls through to the real cold embed.
+
+## Known limitation: shares a Redis queue name with the integration tests
+
+`tests/integration/test_assessment_queue.py` and the Compose `worker` both
+enqueue onto the same RQ queue name (`"assessments"`) and, by default,
+`TEST_REDIS_URL`/`REDIS_URL` point at the same `redis://localhost:6379/0` —
+so a live `worker` container racing to claim a test's fake job (which it
+cannot run — the fake job path lives under `tests/`, not in the image) makes
+`make test-integration` fail with jobs stuck at `pending` instead of
+reaching `failed`/`succeeded`. Confirmed live: `docker compose stop worker`
+before running the suite, three tests that failed under a running worker
+passed clean. `make test-integration`'s own fixtures use a separate
+`insurance_claims_test` *database*, but not a separate Redis *db index* —
+stop the Compose `worker` (`docker compose stop worker`) before running it,
+or point `TEST_REDIS_URL` at a different db index.
+
+## Known limitation: image size
+
+The built `api`/`worker` image is large (~9GB, measured 2026-09-05) — almost
+entirely `torch`'s default CUDA wheels, pulled in transitively by
+`sentence-transformers` even though the retrieval stack only ever runs on
+CPU (`docs/EMBEDDINGS.md`: "CPU is the conservative headline since a
+reproducer is not assumed to have a GPU"). This is not new to the Docker
+image — `uv sync --group embed` already resolves the same CUDA wheels for
+every host-side `make embed-chunks` / `eval-*` run; the image just makes an
+existing project-wide dependency footprint visible in a new place. Trimming
+it means pointing `torch` at PyPI's CPU-only wheel index
+(`[tool.uv.sources]` in `pyproject.toml`, then re-locking `uv.lock`), which
+changes dependency resolution for the whole project, not just the image —
+left as a follow-up rather than folded into this issue.
+
+## Enforcement
+
+`docker build .` (also `ci.yml`'s `docker-image` job) proves the image
+builds. `docker compose config` proves `compose.yaml` stays valid YAML with
+every anchor resolving. There is no automated test that exercises the full
+containerised stack end-to-end (that would need Docker-in-CI plus real LLM
+credentials); this issue's own DoD asks for a hand-checked run against a
+clean clone instead, which is how the two gaps above (`build/chunks.jsonl`,
+`data/rag/lexical_stemming_exceptions.csv`) surfaced: both are read directly
+off the local filesystem by code that predates this issue, so nothing in a
+Postgres-only mental model of the retrieval stack would have caught them.
+The live run that found them also completed one, for real: `docker compose
+up -d --build` against a Postgres already holding the full 4,540-chunk
+embedded corpus, `POST /v1/assessments` on a CASCO collision narrative, and
+`GET /v1/assessments/{id}` returning `awaiting_review` with a `compatible`
+verdict, four real citations and `is_grounded: true` — the graph's own
+happy path, not a synthetic check of the plumbing around it.

--- a/scripts/fetch_embedding_cache.py
+++ b/scripts/fetch_embedding_cache.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Fetch the pre-computed embedding cache from GitHub Releases -- [M5-09].
+
+`make embed-chunks` costs real wall-clock time even though it has no dollar
+price: embedding the full 4,540-chunk corpus cold takes ~41 minutes of CPU
+(`docs/EMBEDDINGS.md`'s "Corpus embedding cost"), because the pinned model
+(`Alibaba-NLP/gte-multilingual-base`) runs in-process, not behind an API.
+Anyone who only wants to try the assessment flow should not have to pay that
+wait.
+
+This is the exact sibling of `fetch_corpus_artifacts.py`, one stage later in
+the pipeline: that script skips the LLM-cost parsing stage; this one skips
+the compute-cost embedding stage. It downloads a single release asset -- a
+tarball of `data/cache/embeddings/cache.jsonl`, the content-addressed
+embedding cache `infrastructure.rag.embedding_cache.CachingEmbedder` reads
+and writes -- verifies its checksum, and extracts it on top of the existing
+(gitignored) directory structure. It never touches anything already
+committed to git, and it needs no `.env`/LLM credentials (embedding is
+local, not an LLM call) -- this is a plain download.
+
+With the cache in place, `make build-index`'s `embed-chunks` step becomes a
+cache-hit replay (~2.6s, measured in `docs/EMBEDDINGS.md`) instead of a cold
+41-minute run: every chunk's `sha256(fingerprint · text)` key is already
+present, so `embed_missing_chunks` never loads the model.
+
+Run via `make fetch-embedding-cache`, or `make fetch-demo-artifacts` for both
+this and `fetch_corpus_artifacts.py` in one step. See
+`scripts/package_embedding_cache.py` for the maintainer-side counterpart that
+produces the release asset.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_REPO = "wrlxavier/insurance-claims-multiagent-rag"
+
+# Pinned, not "latest" -- see fetch_corpus_artifacts.py's identical rationale.
+# Bump this when publishing a new version via `make package-embedding-cache`
+# plus a new GitHub Release.
+ARTIFACTS_RELEASE_TAG = "m3-embedding-cache-v1"
+
+ARCHIVE_ASSET_NAME = "embedding-cache.tar.gz"
+CHECKSUM_ASSET_NAME = "embedding-cache.sha256"
+
+RELEASE_BASE_URL = (
+    f"https://github.com/{GITHUB_REPO}/releases/download/{ARTIFACTS_RELEASE_TAG}"
+)
+
+DOWNLOAD_TIMEOUT_SECONDS = 60
+EXTRACT_ROOT = Path(".")
+
+
+def download_file(url: str, dest: Path) -> None:
+    """Download `url` to `dest`, creating parent directories as needed."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(  # noqa: S310 -- fixed https:// GitHub Releases URL
+            url, timeout=DOWNLOAD_TIMEOUT_SECONDS
+        ) as response:
+            dest.write_bytes(response.read())
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"Failed to download {url} ({exc.code} {exc.reason}). "
+            f"Has release `{ARTIFACTS_RELEASE_TAG}` been published on "
+            f"github.com/{GITHUB_REPO}/releases?"
+        ) from exc
+
+
+def read_expected_checksum(checksum_path: Path) -> str:
+    """Parse a `sha256sum`-format file (`<hex digest>  <filename>`)."""
+    content = checksum_path.read_text(encoding="utf-8").strip()
+    digest, _, _name = content.partition(" ")
+    if len(digest) != 64:
+        raise ValueError(f"Malformed checksum file {checksum_path}: {content!r}")
+    return digest
+
+
+def verify_checksum(archive_path: Path, expected_sha256: str) -> None:
+    """Raise ValueError if `archive_path`'s SHA-256 does not match `expected_sha256`."""
+    actual = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if actual != expected_sha256:
+        raise ValueError(
+            f"Checksum mismatch for {archive_path}: expected {expected_sha256}, "
+            f"got {actual}. The download may be corrupted or incomplete -- try again."
+        )
+
+
+def extract_archive(archive_path: Path, dest_dir: Path) -> list[str]:
+    """Extract `archive_path` into `dest_dir`. Returns the extracted member names."""
+    with tarfile.open(archive_path, "r:gz") as archive:
+        archive.extractall(dest_dir, filter="data")
+        return archive.getnames()
+
+
+def main() -> None:
+    """Download, verify and extract the pinned embedding-cache release."""
+    archive_url = f"{RELEASE_BASE_URL}/{ARCHIVE_ASSET_NAME}"
+    checksum_url = f"{RELEASE_BASE_URL}/{CHECKSUM_ASSET_NAME}"
+
+    with tempfile.TemporaryDirectory(prefix="embedding-cache-") as tmp:
+        tmp_dir = Path(tmp)
+        archive_path = tmp_dir / ARCHIVE_ASSET_NAME
+        checksum_path = tmp_dir / CHECKSUM_ASSET_NAME
+
+        print(f"Downloading {checksum_url} ...")
+        download_file(checksum_url, checksum_path)
+        expected_sha256 = read_expected_checksum(checksum_path)
+
+        print(f"Downloading {archive_url} ...")
+        download_file(archive_url, archive_path)
+
+        print("Verifying checksum ...")
+        verify_checksum(archive_path, expected_sha256)
+
+        print(f"Extracting into {EXTRACT_ROOT.resolve()} ...")
+        members = extract_archive(archive_path, EXTRACT_ROOT)
+
+    print(f"Fetched {ARTIFACTS_RELEASE_TAG}: wrote {len(members)} files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package_embedding_cache.py
+++ b/scripts/package_embedding_cache.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Package the embedding cache for a GitHub Release -- [M5-09].
+
+Maintainer-only. The exact sibling of `package_corpus_artifacts.py`: bundles
+`data/cache/embeddings/cache.jsonl` (produced by `make embed-chunks` against
+a fully-loaded `chunk` table -- see `docs/EMBEDDINGS.md`) into a single
+tarball plus a SHA-256 checksum file under `dist/` (already gitignored),
+ready to attach to a GitHub Release.
+
+After running this:
+
+1. Publish both files, e.g. `gh release create <tag>
+   dist/embedding-cache.tar.gz dist/embedding-cache.sha256 --title "<title>"
+   --notes "<notes>"` (or the GitHub web UI).
+2. Bump `ARTIFACTS_RELEASE_TAG` in `scripts/fetch_embedding_cache.py` to
+   `<tag>` and commit.
+
+Run via `make package-embedding-cache`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tarfile
+from pathlib import Path
+
+OUTPUT_DIR = Path("dist")
+ARCHIVE_PATH = OUTPUT_DIR / "embedding-cache.tar.gz"
+CHECKSUM_PATH = OUTPUT_DIR / "embedding-cache.sha256"
+
+# Kept in sync with fetch_embedding_cache.py's module docstring -- what one
+# script packs, the other must unpack.
+SOURCE_PATHS = (Path("data/cache/embeddings/cache.jsonl"),)
+
+
+def build_archive(source_paths: tuple[Path, ...], archive_path: Path) -> None:
+    """Tar+gzip every path in `source_paths`, preserving their relative layout."""
+    missing = [path for path in source_paths if not path.exists()]
+    if missing:
+        joined_missing = ", ".join(str(path) for path in missing)
+        raise FileNotFoundError(
+            f"Missing source path(s): {joined_missing}. Run `make build-index` "
+            "(or at least `make embed-chunks` against a fully-loaded chunk "
+            "table) first."
+        )
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "w:gz") as archive:
+        for path in source_paths:
+            archive.add(path, arcname=str(path))
+
+
+def write_checksum(archive_path: Path, checksum_path: Path) -> None:
+    """Write a `sha256sum`-format checksum file for `archive_path`."""
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    checksum_path.write_text(f"{digest}  {archive_path.name}\n", encoding="utf-8")
+
+
+def main() -> None:
+    """Build the release tarball and its checksum under dist/."""
+    build_archive(SOURCE_PATHS, ARCHIVE_PATH)
+    write_checksum(ARCHIVE_PATH, CHECKSUM_PATH)
+    size_mb = ARCHIVE_PATH.stat().st_size / 1_000_000
+    print(f"Wrote {ARCHIVE_PATH} ({size_mb:.1f}MB) and {CHECKSUM_PATH}.")
+    print(
+        "Publish both to a GitHub Release, e.g.:\n"
+        f"  gh release create <tag> {ARCHIVE_PATH} {CHECKSUM_PATH} "
+        '--title "<title>" --notes "<notes>"\n'
+        "then bump ARTIFACTS_RELEASE_TAG in scripts/fetch_embedding_cache.py."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes the M5-09 gap: no Dockerfile existed and `compose.yaml` had no `api`/`worker` services (CI's integration-test job and the heavy-eval exclusion were already done by earlier M5 work).

- New root `Dockerfile` — one multi-stage image shared by `api` and `worker` (same composition root, same `embed` dependency group).
- `compose.yaml` gains `migrate` (one-shot Alembic + LangGraph checkpointer setup, gates `api`/`worker` via `service_completed_successfully`), `api`, `worker`, and an `hf_cache` volume — reusing the file's existing anchor/healthcheck conventions.
- `ci.yml` gains a `docker-image` job (`docker build .`, not pushed) — the DoD's remaining "image built" clause; integration tests + migrations were already covered.
- New `.github/workflows/eval.yml`: `workflow_dispatch`-only trigger for the heavy eval suite (deliberately no `schedule:`, to avoid unattended LLM spend against a repo secret).
- Demo mode: `scripts/fetch_embedding_cache.py` / `package_embedding_cache.py` + `make fetch-demo-artifacts`, mirroring the existing `fetch_corpus_artifacts.py` pattern one pipeline stage later. Mechanism only — the `m3-embedding-cache-v1` release itself is not published by this PR (that's a real ~41-minute embedding run + a `gh release create`, left as a deliberate maintainer step).
- README gains a literal `## Quickstart`; new `docs/DEPLOYMENT.md`; a `[M5-09]` entry in `docs/ARCHITECTURE.md`'s decision log; stale `[M5-09]` forward-references in `docs/API.md`/`ASYNC_PROCESSING.md`/`DATABASE.md` corrected (including dropping the proxy-header/trusted-host middleware wiring some of them anticipated — not in the actual DoD, and cosmetic without a reverse proxy in front of `api`).

**Found only by actually running the stack, not by static review:** the retrieval stack isn't a pure Postgres client — its BM25/lexical leg and exclusion-clause graph load `build/*.jsonl` off the local filesystem, and the lexical analyzer needs a committed CSV under `data/rag/`. Both were missing from the first Dockerfile/`.dockerignore` pass and crash-looped `api`/`worker`. Fixed with a read-only bind mount for `build/` and a `COPY` for `data/rag/`; documented in `docs/DEPLOYMENT.md` and `docs/ARCHITECTURE.md`.

Verified live end-to-end: `docker compose up -d --build` against a Postgres already holding the full embedded corpus (from earlier milestone work, no new compute cost), a real `POST /v1/assessments` through to `awaiting_review` with a grounded `compatible` verdict and real citations, using the OpenRouter models configured in `.env`.

## Related issue

[M5-09]

## Checklist

- [ ] Tests added/updated for the change (or explained why not needed) — no new automated tests; this is infra/deploy tooling, verified by hand per the issue's own DoD ("README quickstart verified end to end"): live `docker build`, `docker compose up -d --build`, and a real assessment submitted through the running stack (see PR description above).
- [x] Docs updated (`README.md`, `docs/`, or other affected doc) — `README.md`, new `docs/DEPLOYMENT.md`, `docs/ARCHITECTURE.md`, `docs/API.md`, `docs/ASYNC_PROCESSING.md`, `docs/DATABASE.md`.
- [x] Evaluation impact considered — none: infra-only change, no code path affecting parsing, retrieval, or evaluation numbers.
- [x] `make check` passes locally — 1397 unit tests pass; `make test-integration` also passes (70/70) with the Compose `worker` stopped (see `docs/DEPLOYMENT.md`'s note on the shared Redis queue name).
