### PR TITLE
docs(release): rewrite README as an evaluation-first portfolio entry …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  package-corpus-artifacts - Maintainer-only: build the release tarball fetch-corpus-artifacts downloads"
 	@echo "  fetch-embedding-cache - M5-09: download the pre-computed embedding cache instead of paying the ~41min cold make embed-chunks pass"
 	@echo "  package-embedding-cache - M5-09: maintainer-only: build the release tarball fetch-embedding-cache downloads"
-	@echo "  fetch-demo-artifacts - M5-09: fetch-corpus-artifacts + fetch-embedding-cache in one step -- the demo-mode shortcut, see README's Quickstart"
+	@echo "  fetch-demo-artifacts - M5-09: fetch-corpus-artifacts + fetch-embedding-cache in one step -- the demo-mode shortcut, see docs/GETTING_STARTED.md"
 	@echo "  validate-golden-set - Validate data/golden_set/*.jsonl against the schema and the parsed corpus"
 	@echo "  draft-golden-questions-casco - M2-02: draft candidate golden questions over the 15 CASCO documents into eval/golden_set_draft_casco.csv for review (overwrites that file; use repair- once rows are finalized)"
 	@echo "  repair-golden-questions-casco - M2-02: re-draft/complete the CASCO draft using the author's review verdicts (requires REVIEW=<csv>)"
@@ -185,7 +185,7 @@ package-embedding-cache:
 	PYTHONPATH=app/src uv run python scripts/package_embedding_cache.py
 
 # M5-09: the demo-mode shortcut -- skips both cost-bearing pipeline stages
-# (LLM parsing, then embedding) in one command. See README's Quickstart.
+# (LLM parsing, then embedding) in one command. See docs/GETTING_STARTED.md.
 fetch-demo-artifacts: fetch-corpus-artifacts fetch-embedding-cache
 	@echo "fetch-demo-artifacts: corpus + LLM caches + embedding cache in place. 'make build-index' is now a cache-hit replay, not a cold run."
 

--- a/README.md
+++ b/README.md
@@ -1,287 +1,182 @@
 # insurance-claims-multiagent-rag
-Multi-agent assistant that checks insurance claims against real Brazilian policy conditions (SUSEP). LangGraph conditional graph with parallel agents, hybrid RAG with reranking, human-in-the-loop checkpoint and full audit trail. FastAPI + Clean Architecture. Retrieval and end-to-end quality measured on a hand-curated golden set.
 
-The MIT license covers the source code in this repository only.
-Documents under `data/policies/raw/` are published by their respective
-insurers and remain their property — see NOTICE.md.
+A multi-agent assistant that checks a described insurance event against the
+filed conditions of a registered Brazilian motor-insurance product (SUSEP): a
+LangGraph conditional graph with a clarification loop and parallel assessment
+agents, hybrid RAG with cross-encoder reranking and domain-rule exclusion
+co-retrieval, a mandatory human checkpoint, and a durable audit trail. FastAPI
+over a Clean Architecture core. Every quality claim below is measured against a
+hand-curated golden set and committed to `docs/`.
 
-This system can say whether a described event is consistent or
-inconsistent with the conditions of a registered insurance product — it
-cannot say whether a real claim is covered or denied. See
-[`docs/SCOPE.md`](docs/SCOPE.md) for the full statement.
+> **Setup, how to run it, and API usage** live in
+> [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) — per-OS prerequisites,
+> `.env` configuration, Docker/container management, and a full worked API
+> session. This README is the project overview and its results.
+
+The MIT license covers the source code in this repository only. Documents under
+`data/policies/raw/` are published by their respective insurers and remain their
+property — see [NOTICE.md](NOTICE.md).
+
+## The problem, and the scope constraint
+
+The corpus is 30 sets of *condições gerais* — the general and special conditions
+of SUSEP-registered motor-insurance products across five product lines. Those
+are **product templates filed with the regulator, not individual contracts**:
+they carry no contracted coverage, insured amount, deductible, premium or policy
+period. Given a described event and a registered product's filed conditions,
+this system says whether the event is **consistent, inconsistent, or
+insufficiently determined** against those conditions — it cannot, and does not,
+say whether a real claim would be covered or denied. The full statement is
+[`docs/SCOPE.md`](docs/SCOPE.md).
+
+## Results
+
+Every number is quoted from a committed report; follow the link for the method,
+the pre-registered prediction and the findings.
+
+| Stage | Metric | Result | Basis |
+| --- | --- | --- | --- |
+| Clause parsing | boundary / type accuracy | **98.0% / 92.0%** | 50-clause stratified sample, LLM-judged — [`PARSING.md`](docs/PARSING.md) |
+| Retrieval | Recall@10 | **92.3%** | golden-set-v1, 117 scorable questions — [`RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md) |
+| Retrieval | MRR | **0.806** | same |
+| Retrieval | exclusion-clause recall | **100% (27/27)** | with exclusion co-retrieval; 92.6% without — [`EXCLUSION_CO_RETRIEVAL.md`](docs/EXCLUSION_CO_RETRIEVAL.md) |
+| Retrieval | foreign-document rate | **0.0%** | metadata pre-filter — [`HYBRID_RETRIEVAL.md`](docs/HYBRID_RETRIEVAL.md) |
+| End-to-end | verdict accuracy (3-class) | **56.9%** | 51 synthetic claims, one run; graph completion 100% — [`END_TO_END_EVALUATION.md`](docs/END_TO_END_EVALUATION.md) |
+| End-to-end | faithfulness (LLM judge) | **93.8%** | 128 assertions, cross-family judge — [`END_TO_END_EVALUATION.md`](docs/END_TO_END_EVALUATION.md) |
+| Latency | p50 / p95, end to end | **83 s / 250 s** | 46 assessments, one sample — [`PERFORMANCE.md`](docs/PERFORMANCE.md) |
+| Cost | mean / p95 per assessment | **$0.013 / $0.037** | same run; one-off corpus index build ~$4–6 |
+
+- **Parsing.** Figures are under the corrected boundary criterion; the
+  conservative reading is 96.0% boundary (one disputed sample excluded), and the
+  same corpus measures 84.0% / 86.0% under the original un-clarified criterion.
+  See [`PARSING.md`](docs/PARSING.md).
+- **End-to-end.** 56.9% is a single non-deterministic run over a small,
+  single-author synthetic set. The system's characteristic error is
+  over-abstention, not a wrong verdict — `incompatible` precision is 92.3% at
+  50.0% recall. The value of this measurement is the failure catalogue behind
+  it, which found and fixed a retrieval pre-filter defect (35.3% → 56.9% in the
+  same pass). The compatibility node in isolation scores 88.1% on the 42
+  verdict-labelled golden questions — [`COMPATIBILITY_ASSESSMENT.md`](docs/COMPATIBILITY_ASSESSMENT.md).
+- **Latency and cost.** One sample, n = 46. About 72% of latency and 84% of cost
+  is a single reasoning-model call, so both move with the model and the provider
+  route — [`PERFORMANCE.md`](docs/PERFORMANCE.md).
+
+The retrieval numbers are strong and reproducible byte-for-byte
+(`make eval-retrieval-matrix`). The end-to-end number is an early, honest,
+small-sample measurement — reported with its `n` and its caveats rather than
+rounded up.
+
+## Architecture
+
+A Clean Architecture core (domain → application → infrastructure/presentation)
+with **LangGraph confined to the infrastructure layer** — the domain and
+application layers import no framework symbol, enforced by a test. The pipeline
+splits deterministic work from model work deliberately: the metadata pre-filter,
+the exclusion co-retrieval, the insufficient-context gate, the consistency
+arithmetic checks and every confidence ceiling are plain Python; the LLM is used
+only where judgement is unavoidable, and every compatibility assertion must cite
+a retrieved clause or it is rejected and retried. The two assessment nodes run
+as fixed parallel branches. Nothing reaches a final state without a person
+approving, editing or rejecting the recommendation at the checkpoint.
+
+```mermaid
+flowchart TD
+  START([claim narrative]) --> intake
+  intake -->|missing info| clarification
+  clarification --> intake
+  intake -->|"clarification cap (2) reached"| clarification_exhausted
+  intake -->|complete| retrieval
+  clarification_exhausted --> recommendation
+  retrieval -->|context sufficient| compatibility
+  retrieval -->|context sufficient| consistency
+  retrieval -->|insufficient context| recommendation
+  compatibility --> recommendation
+  consistency --> recommendation
+  recommendation --> human_review
+  human_review -->|"interrupt() — approve / edit / reject"| DONE([settled + audit trail])
+```
+
+`compatibility` and `consistency` run in one parallel superstep (alongside an
+optional advisory prompt-injection scan, off by default); `recommendation`
+consolidates but never re-decides; `human_review` is unconditional. Design
+rationale, the deterministic/LLM boundary and a decision log are in
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ## Quickstart
 
-The literal, followable path from a clean clone to a running assessment,
-entirely through Docker Compose — [M5-09]. Design rationale for the stack
-is in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+The full path — per-OS notes, `.env` details, container management and a worked
+API session — is [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md). The short
+version, from a clean clone, entirely through Docker Compose:
 
 ```bash
 cp .env.example .env
-# fill in LLM_PROVIDER / LLM_BASE_URL / LLM_API_KEY / LLM_MODEL_FAST /
-# LLM_MODEL_REASONING -- the rest of .env.example's defaults already match
-# the Compose services below.
+# fill LLM_PROVIDER / LLM_BASE_URL / LLM_API_KEY / LLM_MODEL_FAST /
+# LLM_MODEL_REASONING (and the matching provider pins) — the rest of
+# .env.example's defaults already match the Compose services.
 
-docker compose up -d postgres redis   # infra first -- api/worker need data in place before they can start
-make fetch-corpus-artifacts           # skip the LLM-cost parsing stage (~10MB download)
-make build-index                      # chunk -> Postgres -> embeddings against the running stack
-docker compose up -d --build          # migrate, api, worker -- each healthchecked
+docker compose up -d postgres redis   # infra first
+make fetch-corpus-artifacts           # pre-processed corpus (~10 MB) — skips the LLM parse
+make build-index                      # chunks -> Postgres -> embeddings
+docker compose up -d --build          # migrate (once), then api + worker
 ```
 
-`api`/`worker` read `build/chunks.jsonl` (the lexical retriever's BM25 index
-and the exclusion-clause graph, `docs/DEPLOYMENT.md`) at startup, which is
-why `make build-index` runs before the full `up`: starting `api`/`worker`
-before it exists just crash-loops them on a clear "file not found" error.
-The second `docker compose up -d --build` runs `migrate` once (schema +
-checkpointer setup) then starts `api` (`curl localhost:${API_PORT:-8000}/health`
-→ `200`) and `worker`. `make build-index`'s embedding step is a real,
-one-time ~41-minute CPU pass the first time it runs — $0 in API cost, since
-the embedder runs locally, but real wall-clock time (`docs/EMBEDDINGS.md`).
-**Skipping that too:** `make fetch-embedding-cache` (or `make
-fetch-demo-artifacts` in place of `fetch-corpus-artifacts` above, for both
-fetches in one step) downloads a pre-computed embedding cache so the same
-`make build-index` re-fills every vector in seconds instead — once the
-maintainer has published that release (see `docs/DEPLOYMENT.md`'s "What
-this issue ships, and what it deliberately doesn't (yet)"); until then it's
-equivalent to the corpus-only fetch above.
+`make build-index`'s embedding step is a one-time ~41-minute local CPU pass
+($0 in API cost). `make fetch-demo-artifacts` in place of `fetch-corpus-artifacts`
+downloads a pre-computed cache so it replays in seconds instead — once the
+maintainer has published that release ([`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md)).
 
 ```bash
-curl -s -X POST localhost:${API_PORT:-8000}/v1/assessments \
+curl -s -X POST localhost:8000/v1/assessments \
   -H 'Content-Type: application/json' \
   -d '{"raw_text": "Bati o carro na traseira de outro veículo ao tentar estacionar."}'
-# -> 202, {"assessment_id": "<id>", "status": "pending"}
+# -> 202 {"assessment_id": "<id>", "status": "pending"}
 
-curl -s localhost:${API_PORT:-8000}/v1/assessments/<id>
-# -> status moves pending -> running -> awaiting_review, with the
-# recommendation and its citations once ready
+curl -s localhost:8000/v1/assessments/<id>
+# status moves pending -> running -> awaiting_review, with the recommendation
+# and its citations once ready
 ```
 
-Endpoint shapes, the human-decision step and the audit trail are in
-[`docs/API.md`](docs/API.md). `docker compose --profile tracing up -d` adds
-the self-hosted Langfuse stack alongside the above — see "Tracing" below.
+## What this system cannot do
 
-## Fast start: inspect the parsed corpus without running the pipeline
+- **It assesses registered products, not contracts.** The corpus holds no
+  contracted coverage, insured amount, deductible, premium or policy period. A
+  `compatible` verdict means the described event does not contradict a product's
+  filed conditions — it does **not** mean a claim would be paid. No amount of
+  retrieval or reasoning recovers a fact that was never in the source documents.
+- **The evaluation is small and single-author.** 140 golden questions and 51
+  synthetic claims, all selected, written and reviewed by the person who built
+  the system; scorable retrieval questions cover 2 of the 5 product lines; the
+  end-to-end run is one non-deterministic sample where a single claim moves
+  overall accuracy by ~2 points. The numbers are measured and reproducible —
+  they are not an independent benchmark ([`docs/EVALUATION.md`](docs/EVALUATION.md),
+  "What this evaluation cannot establish").
+- **It is not a fraud detector.** The consistency node flags internal
+  contradictions in a narrative for a human to look at. Neither the data nor the
+  method supports a fraud claim, and none is made.
+- **It does not decide.** Every run stops at a human checkpoint before anything
+  is recorded. The output is a recommendation with citations, for a person to
+  approve, edit or reject.
 
-The full M1 parsing pipeline (OCR, LLM clause classification, the vision-LLM
-boundary-escalation pass, LLM validation) costs real tokens and real
-wall-clock time. If you just want to inspect the already-published result —
-the finished 4,925-clause corpus and the LLM caches behind it — run this
-instead of `make parse`:
+## Where this sits
 
-```bash
-make fetch-corpus-artifacts
-```
+This is the author's third production-shaped multi-agent orchestration. The
+first was an auto-insurance sales assistant built directly on the OpenAI SDK
+with keyword-map retrieval; the second, a customer-loyalty WhatsApp assistant on
+LangGraph + LangChain. Both shipped in production; neither is public. This one is
+the most demanding of the three: a conditional graph with a self-capping
+clarification loop, parallel assessment branches, an interrupt checkpoint,
+hybrid RAG with reranking and a domain-rule co-retrieval step, and a
+pre-registered evaluation behind every claim it makes. Career context:
+[linkedin.com/in/warley-xavier-a8b8811b7](https://www.linkedin.com/in/warley-xavier-a8b8811b7).
 
-This downloads a small (~10MB) release asset and needs no `.env`/LLM
-credentials. See [`docs/PARSING.md`](docs/PARSING.md) for the published
-accuracy numbers this corpus was measured against. Note: if you later run
-`make parse` locally anyway, `git status`/`git diff` on `build/manifest.json`
-will show a one-line difference on the `built_at_utc` timestamp field only —
-everything else reproduces byte-identical.
+## Documentation
 
-## Development Commands
-
-### System dependencies
-
-Two policy PDFs have no extractable text layer and are OCR'd via
-[Tesseract](https://github.com/tesseract-ocr/tesseract) (see [M1-02]).
-Install it locally before running `make extract-text`:
-
-```bash
-sudo apt update && sudo apt install tesseract-ocr tesseract-ocr-por
-```
-
-Verify with `tesseract --version`, and confirm the Portuguese language pack
-is present with `tesseract --list-langs`.
-
-### Environment variables
-
-Copy the example file and fill in the values for your environment:
-
-```bash
-cp .env.example .env
-```
-
-### Database (Postgres + pgvector) and Redis
-
-This is the bare-metal dev loop -- infra in containers, `make serve` /
-`make worker` on the host for hot reload. (For the fully containerized stack,
-including `api` / `worker` themselves, see the Quickstart above; don't run
-both at once against the same ports.) Postgres is required by the retrieval
-index, the LangGraph checkpointer and the audit trail; Redis backs the
-asynchronous assessment queue ([M5-05]). Bring both up locally, in this
-order, on a clean clone:
-
-```bash
-cp .env.example .env
-docker compose up -d postgres redis   # infra only -- not migrate/api/worker
-make migrate
-make setup-checkpointer
-```
-
-The `.env.example` defaults match the Compose services, so the sequence works
-as written without editing anything first. `make migrate` applies the Alembic
-migrations (the first one enables the `vector` extension); `make migrate-down`
-rolls the latest one back. `make setup-checkpointer` is the second half of the
-schema: the LangGraph checkpointer creates and migrates its own tables outside
-Alembic, so a database with `make migrate` applied is still not ready to run the
-graph. It is idempotent and reads the same `DATABASE_URL`.
-
-Run the database-backed tests with:
-
-```bash
-make test-integration
-```
-
-This applies migrations to the `insurance_claims_test` database — created by
-the Compose service on first boot — before running `pytest -m integration`.
-
-See [`docs/DATABASE.md`](docs/DATABASE.md) for the pinned pgvector version and
-why, how `CREATE EXTENSION vector` is executed and what privilege it needs,
-the sync-vs-async engine decision, and why the checkpointer's schema is a
-separate step. The human checkpoint that uses it is
-[`docs/HUMAN_CHECKPOINT.md`](docs/HUMAN_CHECKPOINT.md).
-
-### Index the corpus
-
-One command rebuilds the whole searchable index from `data/policies/raw/`:
-
-```bash
-make build-index     # parse -> chunk -> Postgres -> embeddings
-```
-
-It needs the same environment as `make parse` (the `LLM_*` keys in `.env`, plus
-Tesseract) and a running Postgres. When `build/parsed_clauses.jsonl` is already
-present — from an earlier `make parse` or `make fetch-corpus-artifacts` — the
-parse stage is skipped and the rest runs from cache. The manual breakdown of the
-last two steps:
-
-```bash
-make load-chunks     # upsert the chunk corpus into Postgres (idempotent)
-make embed-chunks    # embed the chunks; installs the optional `embed` group on first run
-```
-
-The embedding model (`Alibaba-NLP/gte-multilingual-base`) runs locally, so the
-dollar cost is **$0.00** — no API key needed. A cold pass over the ~4,540-chunk
-corpus is ~41 min of CPU time on an AMD Ryzen 5 5600H (a few minutes on a GPU);
-re-runs are served from an on-disk cache and do zero inference. See
-[`docs/EMBEDDINGS.md`](docs/EMBEDDINGS.md).
-
-Score every retrieval configuration on the golden set with
-`make eval-retrieval-matrix` — the committed comparison table and verdict are in
-[`docs/RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md).
-
-Latency and token cost per assessment, measured over the whole graph on the 51
-synthetic claims, are in [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)
-(`make eval-performance`) — with the one-off corpus-indexing cost reported
-separately.
-
-### Run the assessment API and the worker
-
-Once the schema, the checkpointer and the index are in place (bare-metal dev
-loop -- see the note above; skip this if you're already running the
-containerized `api` / `worker` from the Quickstart):
-
-```bash
-make serve           # the API: uvicorn presentation.app:app on :8000
-make worker          # the queue workers (a second shell)
-```
-
-`POST /v1/assessments` submits a claim (202, `status: "pending"`); a worker runs
-the graph in the background. `GET /v1/assessments/{id}` reads its lifecycle state
-(`pending` → `running` → `awaiting_review`, or `failed`) and, once ready, the
-recommendation. `POST /v1/assessments/{id}/decision` submits the human decision
-and resumes the run; `GET /v1/assessments/{id}/audit` returns the audit trail.
-Endpoint shapes and error codes are in [`docs/API.md`](docs/API.md); the queue,
-the retry/back-off policy and the dead-letter path are in
-[`docs/ASYNC_PROCESSING.md`](docs/ASYNC_PROCESSING.md). `api` and `worker` also
-run as Compose services from the same Dockerfile — see the Quickstart above
-and [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) [M5-09].
-
-### Tracing (optional)
-
-A run is a tree of nodes, LLM calls and one retrieval step; when a verdict is
-wrong, the question is which of them was. [M5-07] traces that into a
-self-hosted Langfuse, which rides along in the Compose stack behind a profile:
-
-```bash
-# .env: set the three secrets first -- openssl rand -hex 32 each
-#   LANGFUSE_NEXTAUTH_SECRET, LANGFUSE_SALT, LANGFUSE_ENCRYPTION_KEY
-docker compose --profile tracing up -d    # + langfuse-web, langfuse-worker, clickhouse, minio
-open http://localhost:3000                # sign in with LANGFUSE_INIT_USER_*
-```
-
-This also brings up `migrate` / `api` / `worker` alongside the tracing
-services (they have no profile, so any `up` starts them) — if you're running
-the bare-metal `make serve` / `make worker` instead, stop them first to avoid
-a port clash. The project is seeded on first boot with the
-`LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` already in your `.env`, so
-there is no key-copying step. Tracing is off unless both keys are set and
-`TRACING_ENABLED` is not `false`, and the plain `docker compose up -d` from
-the Quickstart runs identically with none of this. Reading a trace, and a
-worked example of diagnosing a wrong verdict, are in
-[`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
-
-### Prompt-injection classifier (optional)
-
-Every prompt in this system carries text this project does not control: a
-retrieved clause excerpt or a claimant's own narrative
-([`docs/PROMPT_INJECTION.md`](docs/PROMPT_INJECTION.md)). Delimiters, schema
-rejection and metadata-only document trust are the actual guard and are
-always on. The M5-08 issue's Appendix additionally spikes a runtime
-classifier as an optional, advisory-only defense-in-depth layer — off by
-default:
-
-```bash
-uv sync --group embed                          # transformers + torch
-PROMPT_INJECTION_CLASSIFIER_ENABLED=true make serve   # and/or `make worker`
-```
-
-It never blocks a node or changes a verdict — a flagged span only adds one
-entry to the audit trail. **On this project's own Portuguese corpus it is
-not recommended**: the pinned model
-(`protectai/deberta-v3-base-prompt-injection-v2`) is trained only on English
-text and flags 70% of real, non-adversarial policy clauses in the measured
-benchmark. That is a property of this model on this domain, not of the
-approach — the code is kept as a working, tested reference for the pattern
-on a domain closer to the model's training language. Method, the real
-numbers and the reasoning behind the `false` default are in
-[`docs/PROMPT_INJECTION_CLASSIFIER.md`](docs/PROMPT_INJECTION_CLASSIFIER.md).
-
-### Pre-commit hooks
-
-1. Install the dev dependency (skip if already in the lockfile — run `uv sync` instead):
-
-```bash
-uv add --dev pre-commit
-```
-
-2. Enable the hooks in your local clone:
-
-```bash
-uv run pre-commit install
-```
-
-3. Run the hooks against all files once, to check the existing codebase:
-
-```bash
-uv run pre-commit run --all-files
-```
-
-### Jupyter kernel for notebooks
-
-Notebooks under `notebooks/` should run against this project's virtual
-environment rather than a globally installed kernel. Register a
-project-bound kernel with:
-
-```bash
-./scripts/setup_dev_kernel.sh
-```
-
-This adds `ipykernel` as a dev dependency (via `uv`) and registers a Jupyter
-kernel named "Insurance Claims (uv)". Select it in Jupyter/VS Code, or launch
-directly with:
-
-```bash
-uv run jupyter lab
-```
+| Doc | What it covers |
+| --- | --- |
+| [`GETTING_STARTED.md`](docs/GETTING_STARTED.md) | prerequisites, `.env`, running the stack, container management, API usage |
+| [`SCOPE.md`](docs/SCOPE.md) | the canonical statement of what the system may and may not assert |
+| [`ARCHITECTURE.md`](docs/ARCHITECTURE.md) | layer boundaries, graph topology, the deterministic/LLM split, decision log |
+| [`DATA_SOURCES.md`](docs/DATA_SOURCES.md) | corpus selection, composition and known limitations |
+| [`EVALUATION.md`](docs/EVALUATION.md) | the golden set, metric definitions, the second-reviewer pass |
+| [`PARSING.md`](docs/PARSING.md) · [`RETRIEVAL_BENCHMARK.md`](docs/RETRIEVAL_BENCHMARK.md) · [`END_TO_END_EVALUATION.md`](docs/END_TO_END_EVALUATION.md) · [`PERFORMANCE.md`](docs/PERFORMANCE.md) | the measurements behind the results table |
+| [`API.md`](docs/API.md) · [`DEPLOYMENT.md`](docs/DEPLOYMENT.md) | endpoint reference and the Compose stack's design |

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,8 +50,12 @@ Code:
 
 ## Bring-up
 
+The full setup — per-OS prerequisites, `.env`, the Compose stack and container
+management — is [`docs/GETTING_STARTED.md`](GETTING_STARTED.md). The bare-metal
+short version:
+
 ```bash
-cp .env.example .env          # fill LLM_PROVIDER / LLM_API_KEY / DATABASE_URL
+cp .env.example .env          # fill LLM_PROVIDER / LLM_BASE_URL / LLM_API_KEY / LLM_MODEL_*
 make migrate                  # assessment / decision / audit_event tables
 make setup-checkpointer       # the LangGraph checkpointer's own tables
 make build-index              # raw PDFs -> parsed -> chunks -> Postgres -> embeddings

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1224,6 +1224,6 @@ DoD's "image built" clause — `integration` already covered "integration
 tests against Postgres" and "migrations applied", from [M5-05]/[M5-01]-era
 work, before this issue started). `docker compose config` validates every
 YAML anchor resolves. No automated test drives the full containerised stack
-end-to-end (that needs Docker-in-CI plus real LLM credentials); README's
-Quickstart is written to be run and checked by hand against a clean clone,
-which is what this issue's own DoD asks for.
+end-to-end (that needs Docker-in-CI plus real LLM credentials); the Quickstart
+(now `docs/GETTING_STARTED.md`) is written to be run and checked by hand against
+a clean clone, which is what this issue's own DoD asks for.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,9 +1,10 @@
 # Deployment: the Docker Compose stack
 
 How the `api` / `worker` / `migrate` Compose services are built and wired —
-[M5-09]. Step-by-step run instructions live in README's Quickstart; this
-document is the "why", the same split `docs/ASYNC_PROCESSING.md` and
-`docs/OBSERVABILITY.md` use for their own services.
+[M5-09]. Step-by-step run instructions live in
+[`docs/GETTING_STARTED.md`](GETTING_STARTED.md); this document is the "why", the
+same split `docs/ASYNC_PROCESSING.md` and `docs/OBSERVABILITY.md` use for their
+own services.
 
 ## One image, two containers
 
@@ -142,7 +143,7 @@ content-addressed cache `CachingEmbedder` already reads before ever loading
 the model. With that cache in place, `embed-chunks` re-fills every vector
 from disk in ~2.6 seconds instead of running the model at all. `make
 fetch-demo-artifacts` runs both fetches (corpus + embedding cache) in one
-step; README's Quickstart uses it.
+step; [`docs/GETTING_STARTED.md`](GETTING_STARTED.md) uses it.
 
 **What this issue ships, and what it deliberately doesn't (yet).** The
 fetch/package scripts and Makefile targets exist and are ready to use; the

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,401 @@
+# Getting started
+
+Everything needed to clone this repository and reproduce its behaviour on a
+clean machine — Linux, macOS or Windows. It covers prerequisites, `.env`
+configuration, running the stack through Docker Compose (and the bare-metal dev
+loop), managing the containers, and a full worked session against the API.
+
+The design rationale for the Compose stack is separate, in
+[`DEPLOYMENT.md`](DEPLOYMENT.md); the endpoint reference is [`API.md`](API.md).
+This document is the *how*.
+
+---
+
+## 1. What you get
+
+Two application processes — an **API** (`FastAPI`/`uvicorn`) and a **worker** —
+sharing one image, backed by **Postgres + pgvector** (the dense retrieval index,
+the LangGraph checkpointer, the audit trail) and **Redis** (the assessment
+queue). You submit a claim narrative to the API; a worker runs the LangGraph
+pipeline (intake → clarification loop → hybrid retrieval → parallel
+compatibility/consistency assessment → recommendation → a human checkpoint); you
+poll for the result, submit a decision, and read the audit trail.
+
+---
+
+## 2. Prerequisites
+
+**All platforms**
+
+- **Docker Engine 24+ with Compose v2** (`docker compose`, not the legacy
+  `docker-compose`). Docker Desktop includes both.
+- **git** and **GNU `make`**.
+- An **LLM API key** for an OpenAI-compatible endpoint (see §3). Nothing runs
+  without one.
+
+**Linux** — Docker Engine from your distro or Docker's apt/yum repo; `make` from
+the distro package (`build-essential` / `make`).
+
+**macOS** — Docker Desktop (Apple Silicon and Intel both work; the image base is
+multi-arch). `make` ships with the Xcode Command Line Tools (`xcode-select
+--install`). The built image is large (~9 GB, mostly PyTorch CUDA wheels that go
+unused on CPU) — make sure Docker Desktop's disk allocation has room.
+
+**Windows** — Docker Desktop with the **WSL2 backend**, and run every command
+from a **WSL2 shell** (e.g. Ubuntu), where `make` is available
+(`sudo apt install make`). Git Bash on its own is not enough: it has no `make`,
+and bind-mount path translation is unreliable. Clone the repo *inside* the WSL2
+filesystem, not under `/mnt/c`, or the `./build` bind mount will be slow.
+
+**Only for `make parse` or the bare-metal dev loop** (not needed for the Compose
+path): [`uv`](https://docs.astral.sh/uv/), Python 3.12, and — for the two
+policy PDFs with no text layer — `tesseract-ocr` plus `tesseract-ocr-por`.
+
+---
+
+## 3. Configure `.env`
+
+```bash
+cp .env.example .env
+```
+
+`.env.example` is annotated in full. The defaults already match the bundled
+Compose services, so the only values you must supply are the LLM ones.
+
+### Must set
+
+| Key | What it is |
+| --- | --- |
+| `LLM_PROVIDER` | the client family — `openai` for any OpenAI-compatible gateway (OpenRouter, a local proxy, …) |
+| `LLM_BASE_URL` | the gateway base URL, e.g. `https://openrouter.ai/api/v1` |
+| `LLM_API_KEY` | your key for that gateway |
+| `LLM_MODEL_FAST` | the fast model — intake, clarification, consistency, the recommendation prose |
+| `LLM_MODEL_REASONING` | the reasoning model — the compatibility verdict |
+
+If your gateway is **OpenRouter**, also pin the provider route for each model —
+the built-in defaults (`["baidu/fp8"]` for fast, `["streamlake"]` for reasoning)
+can return HTTP 404 for a model that route does not serve:
+
+| Key | Example |
+| --- | --- |
+| `LLM_FAST_PROVIDER_ORDER` | `["streamlake/fp8"]` |
+| `LLM_REASONING_PROVIDER_ORDER` | `["novita/fp8"]` |
+
+A concrete, known-good configuration (the one behind
+[`PERFORMANCE.md`](PERFORMANCE.md)):
+
+```dotenv
+LLM_PROVIDER=openai
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_API_KEY=sk-or-...
+LLM_MODEL_FAST=deepseek/deepseek-v4-flash-0731
+LLM_MODEL_REASONING=deepseek/deepseek-v4-pro-0813
+LLM_FAST_PROVIDER_ORDER=["streamlake/fp8"]
+LLM_REASONING_PROVIDER_ORDER=["novita/fp8"]
+```
+
+`LLM_MODEL_VISION` (e.g. `google/gemini-3.8-flash`) is **optional** — it is only
+used by `make escalate-vision-boundaries` and
+`make validate-parsing-quality-sample`, neither of which is on the assessment
+path.
+
+### Leave as-is
+
+`DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_USER` / `DATABASE_PASSWORD` /
+`DATABASE_NAME`, `REDIS_URL`, `TEST_DATABASE_URL` / `TEST_REDIS_URL`,
+`API_PORT` (`8000`), `LOG_FORMAT` (`json`; set `text` for readable local lines),
+`EMBEDDING_MODEL`, `RERANKER_MODEL`, and the `ASSESSMENT_*` queue knobs all have
+working defaults. Inside the Compose network the app reaches Postgres, Redis and
+Langfuse by service name, so `compose.yaml` overrides `DATABASE_HOST`,
+`REDIS_URL` and `LANGFUSE_HOST` for the containers automatically —
+[`DEPLOYMENT.md`](DEPLOYMENT.md) explains the split.
+
+> **Do not set `DATABASE_URL`.** It is blank by default on purpose. If it is
+> set, `DatabaseSettings` prefers it and the Compose `DATABASE_HOST: postgres`
+> override stops working — the containers then try to reach Postgres at
+> `localhost` and fail. Use the discrete `DATABASE_*` keys.
+
+---
+
+## 4. Run the stack — Docker Compose (recommended)
+
+From a clean clone, with `.env` filled in:
+
+```bash
+# 1. Infrastructure first. api/worker read data files at startup and will
+#    crash-loop if they start before the index exists.
+docker compose up -d postgres redis
+
+# 2. Get the pre-processed corpus (skips the LLM parsing cost — ~10 MB download,
+#    no .env needed).
+make fetch-corpus-artifacts
+
+# 3. Build the searchable index against the running Postgres:
+#    chunk -> load into Postgres -> embed.
+make build-index
+
+# 4. Build the image, run migrations once, start api + worker.
+docker compose up -d --build
+```
+
+**About step 3.** The embedding pass runs a local model (no API cost) but a cold
+run over the full corpus is ~41 minutes of CPU time. To skip it, run
+`make fetch-embedding-cache` (or `make fetch-demo-artifacts`, which does step 2
+and the cache in one) *before* `make build-index` — with the cache in place the
+embed step re-fills every vector from disk in seconds. That download depends on
+a published `m3-embedding-cache-v1` release; until the maintainer publishes it,
+the fetch fails with a clear message and `make build-index` falls through to the
+real cold embed ([`DEPLOYMENT.md`](DEPLOYMENT.md), "Demo mode").
+
+**About step 4.** `docker compose up -d --build` builds
+`insurance-claims-assessment:local`, runs the one-shot `migrate` service
+(`alembic upgrade head` + the LangGraph checkpointer's own schema) to
+completion, then starts `api` and `worker`. Both wait on `migrate` succeeding
+and on Postgres/Redis being healthy.
+
+### Verify
+
+```bash
+docker compose ps                       # migrate = exited (0); api, worker = healthy
+curl -s localhost:8000/health           # {"status":"ok"}
+curl -s localhost:8000/ready            # 200 once the chunk table has embedded rows
+```
+
+`GET /ready` returns **503** with `"vector_index": {"status": "error", ...}`
+while the `chunk` table is empty — that is expected before `make build-index`
+has loaded and embedded the corpus, and it is why the container healthcheck uses
+`/health`, not `/ready`.
+
+---
+
+## 5. Manage the containers
+
+| Task | Command |
+| --- | --- |
+| Status | `docker compose ps` |
+| Follow logs | `docker compose logs -f api` · `docker compose logs -f worker` |
+| Restart one service | `docker compose restart api` |
+| Pick up a re-`make build-index` (new corpus) | `docker compose restart api worker` — `./build` is bind-mounted, no rebuild needed |
+| Rebuild after a code change | `docker compose up -d --build` |
+| Stop everything (keep data) | `docker compose stop` |
+| Tear down (keep volumes) | `docker compose down` |
+| Tear down **and wipe** DB + model cache | `docker compose down -v` — next start re-downloads ~1.2 GB of model weights |
+| Add self-hosted tracing | `docker compose --profile tracing up -d` (see §8) |
+
+**Before `make test-integration`, stop the worker.** The Compose `worker` and
+the integration tests share the Redis queue name `assessments`; a running worker
+races the tests for their fake jobs and they hang. `docker compose stop worker`
+first ([`DEPLOYMENT.md`](DEPLOYMENT.md), "Known limitation").
+
+The ~9 GB image is expected — it is PyTorch's default CUDA wheels, pulled in
+transitively even though retrieval runs on CPU.
+
+---
+
+## 6. Run the stack — bare-metal dev loop
+
+For hot-reload development, run only the infrastructure in containers and the
+app on the host. Do **not** run this and the containerised `api`/`worker` at the
+same time — they bind the same port.
+
+```bash
+docker compose up -d postgres redis
+make migrate                # Alembic: assessment / decision / audit_event tables
+make setup-checkpointer     # the LangGraph checkpointer's own tables (outside Alembic)
+make build-index            # same index build as §4 step 3
+make serve                  # uvicorn presentation.app:app --reload --port 8000
+make worker                 # the queue workers — in a second shell
+```
+
+`make serve` and `make worker` run under the optional `embed` uv group
+(`sentence-transformers` + `torch`); the first run installs it. Both fail fast
+with an actionable message if the checkpointer schema or the embedded chunk
+corpus is missing.
+
+---
+
+## 7. Use the API
+
+Full endpoint reference, the error envelope and the `code` table are in
+[`API.md`](API.md). A complete session:
+
+### Submit a claim
+
+```bash
+curl -s -i -X POST localhost:8000/v1/assessments \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "raw_text": "Ao dar ré na garagem bati a traseira do meu carro no portão. Quero acionar o seguro para o conserto.",
+        "policy_ref": "15414.610650/2024-59",
+        "claim_id": "CLAIM-2026-0007"
+      }'
+```
+
+- `raw_text` — **required**, the claimant's narrative.
+- `policy_ref` — optional SUSEP process number (canonical `NNNNN.NNNNNN/NNNN-NN`
+  or 17 digits). It is stored on the job and prepended to the narrative as
+  `[Apólice registrada: processo SUSEP …]` so intake extracts it and retrieval
+  pre-filters on the right product.
+- `claim_id` — optional external id; one is minted otherwise.
+
+Response — **202 Accepted**, `Location: /v1/assessments/<id>`:
+
+```json
+{ "assessment_id": "a1b2c3d4-...", "status": "pending" }
+```
+
+### Poll for the result
+
+```bash
+curl -s localhost:8000/v1/assessments/a1b2c3d4-...
+```
+
+`status` moves `pending → running → awaiting_review` (or `failed`). While it is
+not ready:
+
+```json
+{ "assessment_id": "a1b2c3d4-...", "claim_id": "CLAIM-2026-0007",
+  "status": "running", "error": null, "verdict": null, "citations": [],
+  "is_grounded": false, "created_at": "2026-09-07T12:00:00Z", "decision": null }
+```
+
+Once `status` is `awaiting_review` it is the full aggregate:
+
+```json
+{ "assessment_id": "a1b2c3d4-...", "claim_id": "CLAIM-2026-0007",
+  "status": "awaiting_review", "error": null,
+  "verdict": "compatible",
+  "reasoning": "O evento descrito — colisão da traseira do veículo do segurado ...",
+  "recommended_action": "Encaminhar para análise de cobertura de danos ao veículo.",
+  "confidence": 0.72, "is_grounded": true,
+  "citations": [
+    { "clause_id": "casco-...-3.1", "document_id": "15414610650202459",
+      "susep_process": "15414.610650/2024-59", "clause_type": "coverage",
+      "excerpt": "Garante ao Segurado ... colisão, abalroamento ...",
+      "relevance_score": 0.83 }
+  ],
+  "consistency_flags": [],
+  "context_sufficient": true, "clarification_exhausted": false,
+  "missing_information": [],
+  "created_at": "2026-09-07T12:00:00Z", "decision": null }
+```
+
+`status` is one of `pending`, `running`, `awaiting_review`, `decided`, `failed`.
+A `failed` job carries the cause in `error`.
+
+### Submit the human decision
+
+```bash
+curl -s -X POST localhost:8000/v1/assessments/a1b2c3d4-.../decision \
+  -H 'Content-Type: application/json' \
+  -d '{ "decision": "approve", "notes": "Conferido contra as condições gerais." }'
+```
+
+`decision` is `approve`, `edit` or `reject`. For `edit`, add an `edited` object
+carrying `verdict` / `reasoning` / `recommended_action` / `confidence` /
+`citations` (every cited clause is validated against the corpus before the graph
+resumes). The system's own verdict, prose and citations are **never
+overwritten** — an edit lives in `decision.edited_assessment`. Returns
+**200 OK** with the settled aggregate; a second decision returns **409**.
+
+### Read the audit trail
+
+```bash
+curl -s localhost:8000/v1/assessments/a1b2c3d4-.../audit
+```
+
+`{"entries": []}` until a decision is submitted — the durable trail is written
+once, at the human checkpoint. After that it is the per-node record ending in
+`human_review` / `human_decision:approve` with the decision in `payload`.
+
+### List completed assessments
+
+```bash
+curl -s 'localhost:8000/v1/assessments?status=awaiting_review&limit=20'
+```
+
+Lists `awaiting_review` / `decided` only (not queued or failed), newest first;
+accepts `claim_id`, `status`, `limit`, `offset`.
+
+### Correlation ids
+
+Send `X-Correlation-ID: <anything>` and it is echoed on the response and tagged
+on every log line the request and its worker run emit — `docker compose logs
+worker | grep <id>` follows one claim end to end. See
+[`OBSERVABILITY.md`](OBSERVABILITY.md).
+
+---
+
+## 8. Optional components
+
+**Tracing (self-hosted Langfuse).** Set the three secrets in `.env`
+(`openssl rand -hex 32` each): `LANGFUSE_NEXTAUTH_SECRET`, `LANGFUSE_SALT`,
+`LANGFUSE_ENCRYPTION_KEY`. Then `docker compose --profile tracing up -d` adds
+`langfuse-web` / `langfuse-worker` / `clickhouse` / `minio` and opens the UI on
+`http://localhost:3000`. The project is seeded with the `LANGFUSE_*_KEY` values
+already in `.env`, so there is no key-copying step. Reading a trace, and a worked
+example of diagnosing a wrong verdict, are in [`OBSERVABILITY.md`](OBSERVABILITY.md).
+
+**Prompt-injection classifier.** An advisory-only runtime classifier, **off by
+default**. On this project's Portuguese corpus it is *not* recommended — the
+pinned model is English-only and flags ~70% of real policy clauses. Kept as a
+working reference for the pattern. Method and numbers:
+[`PROMPT_INJECTION_CLASSIFIER.md`](PROMPT_INJECTION_CLASSIFIER.md).
+
+**Pre-commit hooks.**
+
+```bash
+uv run pre-commit install
+uv run pre-commit run --all-files   # check the current tree once
+```
+
+Runs lint, format and type checks and strips notebook output. See
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+**Jupyter kernel.** `./scripts/setup_dev_kernel.sh` registers a project-bound
+kernel ("Insurance Claims (uv)") for the notebooks under `notebooks/`.
+
+---
+
+## 9. Inspect the parsed corpus without running the pipeline
+
+To read the published parsing result — the 4,925-clause corpus and the LLM
+caches behind it — without spending tokens or time:
+
+```bash
+make fetch-corpus-artifacts
+```
+
+A ~10 MB release asset, no `.env` needed. [`PARSING.md`](PARSING.md) has the
+accuracy numbers this corpus was measured against. A later local `make parse`
+reproduces it byte-identically except for `build/manifest.json`'s `built_at_utc`
+timestamp.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `api` / `worker` restart continuously right after `up` | The index files are missing. Run `make build-index` on the host (it creates `build/chunks.jsonl`), then `docker compose up -d`. |
+| `GET /ready` → 503, `vector_index` error | The `chunk` table has no embedded rows. Finish `make build-index` (the `embed-chunks` stage). |
+| Assessments always return `insufficient_information` | Check `/ready` first. If the index is fine, the retrieval pre-filter may be selecting nothing — see [`RETRIEVAL_NODE.md`](RETRIEVAL_NODE.md). |
+| Many claims `failed` with a provider `429` | The pinned provider is rate-limiting a sustained run. Use a quieter route, or raise `ASSESSMENT_RETRY_BACKOFF_SECONDS` / `ASSESSMENT_MAX_RETRIES` in `.env` ([`END_TO_END_EVALUATION.md`](END_TO_END_EVALUATION.md), arm 3). |
+| ~10% of a batch `failed` at intake | The fast model returned empty structured output on that route — a known robustness gap ([`PERFORMANCE.md`](PERFORMANCE.md), finding 6). A different fast route usually recovers them. |
+| `make test-integration` hangs at `pending` | A Compose `worker` is draining the test queue. `docker compose stop worker` first. |
+| `DATABASE_HOST: postgres` seems ignored | `DATABASE_URL` is set in `.env`. Clear it. |
+
+---
+
+## 11. Verify your setup
+
+```bash
+make check                                    # lint + format-check + typecheck + unit tests
+docker compose stop worker && make test-integration   # DB-backed tests against Postgres + Redis
+```
+
+Retrieval quality is reproducible offline once the index is built:
+
+```bash
+make eval-retrieval-matrix    # regenerates the docs/RETRIEVAL_BENCHMARK.md table
+```

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -42,5 +42,5 @@ All other current dependencies (`pydantic`, `pydantic-settings`, `pypdf`,
 (MIT/Apache-2.0/BSD family) and impose no obligations beyond attribution
 already satisfied by this repository's own `LICENSE`. The same applies to
 Tesseract OCR itself (Apache-2.0), a system-level (not Python-packaged)
-dependency invoked via `pytesseract` -- see the README for install
-instructions.
+dependency invoked via `pytesseract` -- see `docs/GETTING_STARTED.md` for
+install instructions.

--- a/docs/RETRIEVAL_BENCHMARK.md
+++ b/docs/RETRIEVAL_BENCHMARK.md
@@ -284,7 +284,7 @@ metrics. The one source of drift is fp32 rounding in the cross-encoder across
 different GPU / CPU hardware, which could reorder a borderline `(question,
 clause)` pair and move a reranked-configuration metric by **≤ ~1 question
 (≈ 0.9 pt at n = 117)**. The corpus itself reproduces byte-identical via
-`make fetch-corpus-artifacts` (`README.md`); a `make parse` from raw differs
+`make fetch-corpus-artifacts` (`docs/GETTING_STARTED.md`); a `make parse` from raw differs
 only on `build/manifest.json`'s `built_at_utc`. Latency is hardware-specific and
 reported with the machine. Cost is $0.00.
 


### PR DESCRIPTION
## Summary

Rewrites `README.md` so a reviewer's first two minutes land on measured results,
not on setup commands, and moves all setup/API detail into a new dedicated doc.

**`README.md`** — new structure: tagline → pointer to the setup guide →
three-sentence problem + scope constraint → **results table** (parsing accuracy,
Recall@10, MRR, exclusion recall, end-to-end verdict accuracy, latency, cost —
each row with its sample size and a link to the committed report) → architecture
summary with a **Mermaid graph diagram** (the first diagram in the repo; renders
natively on GitHub, no asset file) → compact clean-clone Quickstart → a "What
this system cannot do" section (registered-product limitation + small-sample
caveat, stated plainly) → a "Where this sits" paragraph positioning this as the
author's third and most demanding multi-agent orchestration, with a LinkedIn
pointer (the two prior systems are non-public professional work, so they are
described, not linked).

**`docs/GETTING_STARTED.md`** (new) — the setup/run/API guide the README now
points to: per-OS prerequisites (incl. Windows/WSL2), `.env` configuration
(must-set vs. leave-as-is, with a known-good example config), the Docker Compose
run-through, a container-management reference, the bare-metal dev loop, a full
worked API session (submit → poll → decide → audit, with payloads and response
bodies), optional components (tracing, injection classifier, pre-commit,
Jupyter), a troubleshooting table, and verification steps.

**Cross-references** repointed from "README's Quickstart" to
`docs/GETTING_STARTED.md`: `docs/DEPLOYMENT.md`, `docs/API.md`,
`docs/LICENSING.md`, `docs/ARCHITECTURE.md`, `docs/RETRIEVAL_BENCHMARK.md`,
`Makefile` (two help/comment strings).

Results-table figures are quoted verbatim from the committed reports
(`docs/PARSING.md`, `docs/RETRIEVAL_BENCHMARK.md`, `docs/EXCLUSION_CO_RETRIEVAL.md`,
`docs/HYBRID_RETRIEVAL.md`, `docs/END_TO_END_EVALUATION.md`, `docs/PERFORMANCE.md`);
the graph diagram matches `app/src/infrastructure/graph/build.py`.

## Related issue

[M6-01]

## Checklist

- [x] Tests added/updated for the change (or explained why not needed) — none
      needed: documentation only, no code changed (the two `Makefile` edits are
      help-text/comment strings)
- [x] Docs updated (`README.md`, `docs/`, or other affected doc) — this PR is the
      doc change: `README.md` rewritten, `docs/GETTING_STARTED.md` added, six
      files repointed
- [x] Evaluation impact considered — none. No parsing, retrieval or evaluation
      code or data is touched; every number in the new results table is quoted
      from an existing committed report. Verifying the README numbers against the
      reports on a clean machine is the M6-06 release-checklist step.
- [x] `make check` passes locally — 1427 passed, 99 deselected